### PR TITLE
Fix various minor issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c++
+dist: xenial
 
 # attempt to install GCC 4.8 when necessary, otherwise we wont have C++11 support
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: c++
 dist: xenial
 
-# attempt to install GCC 4.8 when necessary, otherwise we wont have C++11 support
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -qq
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; export CXX=g++-4.8; fi
-  - sudo apt-get install -qq libcppunit-dev
+addons:
+  apt:
+    packages:
+      - libcppunit-dev
 
 compiler:
   - clang

--- a/src/memory/GenerationalHeap.cpp
+++ b/src/memory/GenerationalHeap.cpp
@@ -50,7 +50,7 @@ AbstractVMObject* GenerationalHeap::AllocateMatureObject(size_t size) {
     return newObject;
 }
 
-void GenerationalHeap::writeBarrier_OldHolder(AbstractVMObject* holder,
+void GenerationalHeap::writeBarrier_OldHolder(VMObjectBase* holder,
                                               const vm_oop_t referencedObject) {
     if (isObjectInNursery(referencedObject)) {
         oldObjsWithRefToYoungObjs->push_back((size_t)holder);

--- a/src/memory/GenerationalHeap.h
+++ b/src/memory/GenerationalHeap.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../misc/defs.h"
-#include <assert.h>
+#include <cassert>
 
 
 #include "Heap.h"
@@ -26,10 +26,10 @@ public:
     AbstractVMObject* AllocateNurseryObject(size_t size);
     AbstractVMObject* AllocateMatureObject(size_t size);
     size_t GetMaxNurseryObjectSize();
-    void writeBarrier(AbstractVMObject* holder, vm_oop_t referencedObject);
+    void writeBarrier(VMObjectBase* holder, vm_oop_t referencedObject);
     inline bool isObjectInNursery(vm_oop_t obj);
 #ifdef UNITTESTS
-    std::set< pair<AbstractVMObject*, vm_oop_t>, VMObjectCompare > writeBarrierCalledOn;
+    std::set< pair<vm_oop_t, vm_oop_t>, VMObjectCompare > writeBarrierCalledOn;
 #endif
 private:
     void* nursery;
@@ -38,7 +38,7 @@ private:
     size_t maxNurseryObjSize;
     size_t matureObjectsSize;
     void* nextFreePosition;
-    void writeBarrier_OldHolder(AbstractVMObject* holder, const vm_oop_t
+    void writeBarrier_OldHolder(VMObjectBase* holder, const vm_oop_t
             referencedObject);
     void* collectionLimit;
     vector<size_t>* oldObjsWithRefToYoungObjs;
@@ -55,13 +55,13 @@ inline size_t GenerationalHeap::GetMaxNurseryObjectSize() {
     return maxNurseryObjSize;
 }
 
-inline void GenerationalHeap::writeBarrier(AbstractVMObject* holder, vm_oop_t referencedObject) {
+inline void GenerationalHeap::writeBarrier(VMObjectBase* holder, vm_oop_t referencedObject) {
 #ifdef UNITTESTS
     writeBarrierCalledOn.insert(make_pair(holder, referencedObject));
 #endif
     
     assert(Universe::IsValidObject(referencedObject));
-    assert(Universe::IsValidObject((vm_oop_t) holder));
+    assert(Universe::IsValidObject(holder));
 
     size_t gcfield = *(((size_t*)holder)+1);
     if ((gcfield & 6 /* MASK_OBJECT_IS_OLD + MASK_SEEN_BY_WRITE_BARRIER */) == 2 /* MASK_OBJECT_IS_OLD */)

--- a/src/memory/Heap.cpp
+++ b/src/memory/Heap.cpp
@@ -32,9 +32,6 @@
 #include "../vm/Universe.h"
 
 template<class HEAP_T>
-HEAP_T* Heap<HEAP_T>::theHeap = nullptr;
-
-template<class HEAP_T>
 void Heap<HEAP_T>::InitializeHeap(long objectSpaceSize) {
     if (theHeap) {
         Universe::ErrorPrint("Warning, reinitializing already initialized Heap, "

--- a/src/memory/Heap.h
+++ b/src/memory/Heap.h
@@ -59,6 +59,8 @@ private:
     bool gcTriggered;
 };
 
+template<class HEAP_T> HEAP_T* Heap<HEAP_T>::theHeap;
+
 template<class HEAP_T>
 inline HEAP_T* GetHeap() __attribute__ ((always_inline));
 template<class HEAP_T>

--- a/src/misc/defs.h
+++ b/src/misc/defs.h
@@ -141,6 +141,18 @@
 #endif
 
 //
+// Testing
+//
+#ifndef UNITTESTS
+  #define private_testable   private
+  #define protected_testable protected
+#else
+  #define private_testable   public
+  #define protected_testable public
+#endif
+
+
+//
 // Performance Optimization
 //
 #define likely(x)       __builtin_expect((x),1)

--- a/src/unitTests/CloneObjectsTest.cpp
+++ b/src/unitTests/CloneObjectsTest.cpp
@@ -7,9 +7,6 @@
 
 #include "CloneObjectsTest.h"
 
-#define private public
-#define protected public
-
 #include "vmobjects/ObjectFormats.h"
 #include "vmobjects/VMObjectBase.h"
 #include "vmobjects/VMObject.h"

--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -7,7 +7,6 @@
 #include <vector>
 #include <algorithm>
 
-#define private public
 #include "WalkObjectsTest.h"
 #include "vmobjects/VMSymbol.h"
 #include "vmobjects/VMClass.h"

--- a/src/unitTests/WriteBarrierTest.cpp
+++ b/src/unitTests/WriteBarrierTest.cpp
@@ -3,7 +3,6 @@
 #include "../src/vmobjects/VMDouble.h"
 #include "../src/vmobjects/VMClass.h"
 #include "../src/vmobjects/VMBlock.h"
-#define private public
 #include "../src/vmobjects/VMMethod.h"
 #include "../src/vmobjects/VMFrame.h"
 #include "../src/vmobjects/VMEvaluationPrimitive.h"

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -452,7 +452,7 @@ Universe::~Universe() {
         VMPrimitive* prm = new (GetHeap<HEAP_CLS>()) VMPrimitive(className);
         vt_primitive  = *(void**) prm;
         
-        VMString* str = new (GetHeap<HEAP_CLS>()) VMString("");
+        VMString* str = new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString("");
         vt_string     = *(void**) str;
         vt_symbol     = *(void**) className;
     }

--- a/src/vmobjects/VMBlock.h
+++ b/src/vmobjects/VMBlock.h
@@ -43,10 +43,12 @@ public:
     virtual StdString AsDebugString() const;
 
     static VMEvaluationPrimitive* GetEvaluationPrimitive(int);
-private:
+
+private_testable:
     GCMethod* blockMethod;
     GCFrame* context;
 
+private:
     static const int VMBlockNumberOfFields;
 };
 

--- a/src/vmobjects/VMClass.h
+++ b/src/vmobjects/VMClass.h
@@ -78,12 +78,13 @@ private:
     void setPrimitives(const StdString& cname, bool classSide);
     long numberOfSuperInstanceFields() const;
 
-    GCClass* superClass;
+    static const long VMClassNumberOfFields;
+
+private_testable:
     GCSymbol* name;
     GCArray* instanceFields;
     GCArray* instanceInvokables;
-
-    static const long VMClassNumberOfFields;
+    GCClass* superClass;
 };
 
 #include "VMSymbol.h"

--- a/src/vmobjects/VMDouble.h
+++ b/src/vmobjects/VMDouble.h
@@ -43,7 +43,7 @@ public:
     
     virtual StdString AsDebugString() const;
     
-private:
+private_testable:
     const double embeddedDouble;
 };
 

--- a/src/vmobjects/VMEvaluationPrimitive.h
+++ b/src/vmobjects/VMEvaluationPrimitive.h
@@ -43,6 +43,7 @@ public:
 private:
     static VMSymbol* computeSignatureString(long argc);
     void evaluationRoutine(Interpreter*, VMFrame*);
+private_testable:
     gc_oop_t numberOfArguments;
 
 };

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -267,7 +267,7 @@ vm_oop_t VMFrame::GetArgument(long index, long contextLevel) {
 
 void VMFrame::SetArgument(long index, long contextLevel, vm_oop_t value) {
     VMFrame* context = GetContextLevel(contextLevel);
-    SetArgument(index, value);
+    context->SetArgument(index, value);
 }
 
 void VMFrame::PrintStackTrace() const {

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -73,12 +73,14 @@ public:
     long RemainingStackSize() const;
     
     virtual StdString AsDebugString() const;
-    
+
+private_testable:
+    long bytecodeIndex;
+
 private:
     GCFrame* previousFrame;
     GCFrame* context;
     GCMethod* method;
-    long bytecodeIndex;
     gc_oop_t* arguments;
     gc_oop_t* locals;
     gc_oop_t* stack_ptr;

--- a/src/vmobjects/VMInteger.h
+++ b/src/vmobjects/VMInteger.h
@@ -46,7 +46,7 @@ public:
     
     virtual StdString AsDebugString() const;
 
-private:
+private_testable:
     const int64_t embeddedInteger;
 };
 

--- a/src/vmobjects/VMInvokable.h
+++ b/src/vmobjects/VMInvokable.h
@@ -45,7 +45,7 @@ public:
 
     void WalkObjects(walk_heap_fn);
 
-protected:
+protected_testable:
     GCSymbol* signature;
     GCClass*  holder;
 };

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -74,11 +74,14 @@ private:
     inline uint8_t* GetBytecodes() const;
     inline vm_oop_t GetIndexableField(long idx) const;
 
+private_testable:
     gc_oop_t numberOfLocals;
     gc_oop_t maximumNumberOfStackElements;
     gc_oop_t bcLength;
     gc_oop_t numberOfArguments;
     gc_oop_t numberOfConstants;
+
+private:
 #ifdef UNSAFE_FRAME_OPTIMIZATION
     GCFrame* cachedFrame;
 #endif

--- a/src/vmobjects/VMObject.h
+++ b/src/vmobjects/VMObject.h
@@ -106,9 +106,11 @@ protected:
 
     // VMObject essentials
     int64_t hash;
+
+protected_testable:
     size_t objectSize;     // set by the heap at allocation time
     long   numberOfFields;
-
+  
     GCClass* clazz;
 
     // Start of fields. All members beyond after clazz are indexable.

--- a/src/vmobjects/VMPrimitive.h
+++ b/src/vmobjects/VMPrimitive.h
@@ -54,14 +54,17 @@ public:
 
 private:
     void EmptyRoutine(Interpreter*, VMFrame*);
-protected:
+
+protected_testable:
     // protected to be able to access the field in subclass,
     // for instance VMEvaluationPrimitive needs to GC the primitive object
     // hold in the special routine subclass
     PrimitiveRoutine* routine;
-private:
+
+private_testable:
     bool empty;
 
+private:
     static const int VMPrimitiveNumberOfFields;
 
 };

--- a/src/vmobjects/VMString.h
+++ b/src/vmobjects/VMString.h
@@ -60,10 +60,11 @@ public:
     
     virtual StdString AsDebugString() const;
 
-protected:
+protected_testable:
     //this could be replaced by the CHARS macro in VMString.cpp
     //in order to decrease the object size
     char* chars;
+protected:
     VMString() {}; //constructor to use by VMSymbol
 };
 

--- a/src/vmobjects/VMSymbol.h
+++ b/src/vmobjects/VMSymbol.h
@@ -52,11 +52,13 @@ private:
     GCInvokable* cachedInvokable[3];
     inline VMInvokable* GetCachedInvokable(const VMClass*) const;
     inline void UpdateCachedInvokable(const VMClass* cls, VMInvokable* invo);
-    
-    virtual void WalkObjects(walk_heap_fn);
-    
+
     friend class Signature;
     friend class VMClass;
+
+private_testable:
+    virtual void WalkObjects(walk_heap_fn);
+
 };
 
 


### PR DESCRIPTION
- use context in VMFrame::SetArgument
- update Travis to use Ubuntu 16.04 reliably
- fix warnings and compilation issues on more modern C++
- use `private_testable:` and `protected_testable:` macros for making class member accessible in cppunit tests
- use VMObjectBase as type in write barrier to avoid cyclic import
- fix memory issue for a preallocated empty string