### PR TITLE
Fix semantics of empty blocks and implement basic interpreter tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: xenial
+dist: focal
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ script:
     - make
     - ./SOM++ -cp ./Smalltalk ./TestSuite/TestHarness.som
     - ./SOM++ -cp ./Smalltalk:./Examples/Benchmarks/LanguageFeatures ./Examples/Benchmarks/All.som
-    - ./unittests -cp ./Smalltalk ./Examples/Hello.som
+    - ./unittests -cp ./Smalltalk:./TestSuite/BasicInterpreterTests ./Examples/Hello.som

--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		0A335F6C1832D64100D7CFC8 /* Method.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Method.h; sourceTree = "<group>"; };
 		0A335F6F1832D65100D7CFC8 /* Primitive.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Primitive.cpp; sourceTree = "<group>"; };
 		0A335F701832D65100D7CFC8 /* Primitive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Primitive.h; sourceTree = "<group>"; };
+		0A3FABE724F4670D002D4D69 /* BasicInterpreterTests.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; name = BasicInterpreterTests.h; path = unitTests/BasicInterpreterTests.h; sourceTree = "<group>"; };
 		0A67EA6719ACD37200830E3B /* unittests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = unittests; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A67EA7019ACD43A00830E3B /* CloneObjectsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CloneObjectsTest.cpp; path = unitTests/CloneObjectsTest.cpp; sourceTree = "<group>"; };
 		0A67EA7119ACD43A00830E3B /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = unitTests/main.cpp; sourceTree = "<group>"; };
@@ -397,6 +398,7 @@
 		0A67EA7A19ACD44000830E3B /* unittests */ = {
 			isa = PBXGroup;
 			children = (
+				0A3FABE724F4670D002D4D69 /* BasicInterpreterTests.h */,
 				0A67EA7019ACD43A00830E3B /* CloneObjectsTest.cpp */,
 				0A67EA7119ACD43A00830E3B /* main.cpp */,
 				0A67EAA319ACE09700830E3B /* CloneObjectsTest.h */,

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -272,6 +272,10 @@ bool MethodGenerationContext::IsFinished() {
     return finished;
 }
 
+bool MethodGenerationContext::HasBytecodes() {
+    return !bytecode.empty();
+}
+
 size_t MethodGenerationContext::AddBytecode(uint8_t bc) {
     bytecode.push_back(bc);
     return bytecode.size();

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -77,6 +77,8 @@ public:
     size_t AddBytecode(uint8_t bc);
     void PatchJumpTarget(size_t jump_position);
 
+    bool HasBytecodes();
+
 private:
     ClassGenerationContext* holderGenc;
     MethodGenerationContext* outerGenc;

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -420,6 +420,12 @@ void Parser::blockBody(MethodGenerationContext* mgenc, bool seen_period, bool is
             mgenc->RemoveLastBytecode();
         }
         if (!is_inlined) {
+            // if the block is empty, we need to return nil
+            if (mgenc->IsBlockMethod() && !mgenc->HasBytecodes()) {
+                VMSymbol* nilSym = GetUniverse()->SymbolFor("nil");
+                mgenc->AddLiteralIfAbsent(nilSym);
+                bcGen->EmitPUSHGLOBAL(mgenc, nilSym);
+            }
             bcGen->EmitRETURNLOCAL(mgenc);
             mgenc->SetFinished();
         }
@@ -886,6 +892,12 @@ void Parser::nestedBlock(MethodGenerationContext* mgenc) {
     // if no return has been generated, we can be sure that the last expression
     // in the block was not terminated by ., and can generate a return
     if (!mgenc->IsFinished()) {
+        if (!mgenc->HasBytecodes()) {
+          // if the block is empty, we need to return nil
+          VMSymbol* nilSym = GetUniverse()->SymbolFor("nil");
+          mgenc->AddLiteralIfAbsent(nilSym);
+          bcGen->EmitPUSHGLOBAL(mgenc, nilSym);
+        }
         bcGen->EmitRETURNLOCAL(mgenc);
         mgenc->SetFinished(true);
     }

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -69,7 +69,7 @@ Interpreter::~Interpreter() {}
   goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]];\
 }
 
-void Interpreter::Start() {
+vm_oop_t Interpreter::Start() {
     // initialization
     method = GetFrame()->GetMethod();
     currentBytecodes = method->GetBytecodes();
@@ -102,7 +102,7 @@ void Interpreter::Start() {
     // THIS IS THE former interpretation loop
     LABEL_BC_HALT:
       PROLOGUE(1);
-      return; // handle the halt bytecode
+      return GetFrame()->GetStackElement(0); // handle the halt bytecode
 
     LABEL_BC_DUP:
       PROLOGUE(1);

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -34,7 +34,7 @@ public:
     Interpreter();
     ~Interpreter();
     
-    void      Start();
+    vm_oop_t  Start();
     VMFrame*  PushNewFrame(VMMethod* method);
     void      SetFrame(VMFrame* frame);
     inline VMFrame* GetFrame() const;

--- a/src/unitTests/BasicInterpreterTests.h
+++ b/src/unitTests/BasicInterpreterTests.h
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <cppunit/extensions/HelperMacros.h>
+
+using namespace std;
+
+enum ResultType {
+    INTEGER, CLASS, SYMBOL, DOUBLE
+};
+
+
+class TestData {
+public:
+  std::string className;
+  std::string methodName;
+  void* expectedResult;
+  ResultType type;
+
+  TestData(
+    std::string className,
+    std::string methodName,
+    intptr_t expectedResult,
+    ResultType type) :
+      className(className),
+      methodName(methodName),
+      expectedResult((void*) expectedResult),
+      type(type) {}
+
+  TestData(
+    std::string className,
+    std::string methodName,
+    double const* expectedResult,
+    ResultType type) :
+      className(className),
+      methodName(methodName),
+      expectedResult((void*) expectedResult),
+      type(type) {}
+
+  TestData(
+    std::string className,
+    std::string methodName,
+    char const* expectedResult,
+    ResultType type) :
+      className(className),
+      methodName(methodName),
+      expectedResult((void*) expectedResult),
+      type(type) {}
+};
+
+static const double dbl375 = 3.75;
+
+std::ostream& operator<<(std::ostream& strm, const TestData& data)
+{
+  strm << data.className << "." << data.methodName;
+  return strm;
+}
+
+class BasicInterpreterTests: public CPPUNIT_NS::TestFixture {
+  CPPUNIT_TEST_SUITE (BasicInterpreterTests);
+  CPPUNIT_TEST_PARAMETERIZED (testBasic, {
+    TestData("MethodCall", "test", 42, INTEGER),
+    TestData("MethodCall", "test2", 42, INTEGER),
+
+    TestData("NonLocalReturn", "test1", 42, INTEGER),
+    TestData("NonLocalReturn", "test2", 43, INTEGER),
+    TestData("NonLocalReturn", "test3",  3, INTEGER),
+    TestData("NonLocalReturn", "test4", 42, INTEGER),
+    TestData("NonLocalReturn", "test5", 22, INTEGER),
+
+    TestData("Blocks", "testArg1", 42, INTEGER),
+    TestData("Blocks", "testArg2", 77, INTEGER),
+    TestData("Blocks", "testArgAndLocal",   8, INTEGER),
+    TestData("Blocks", "testArgAndContext", 8, INTEGER),
+    TestData("Blocks", "testEmptyZeroArg", 1, INTEGER),
+    TestData("Blocks", "testEmptyOneArg", 1, INTEGER),
+    TestData("Blocks", "testEmptyTwoArg", 1, INTEGER),
+
+    TestData("Return", "testReturnSelf", "Return", CLASS),
+    TestData("Return", "testReturnSelfImplicitly", "Return", CLASS),
+    TestData("Return", "testNoReturnReturnsSelf", "Return", CLASS),
+    TestData("Return", "testBlockReturnsImplicitlyLastValue", 4, INTEGER),
+
+    TestData("IfTrueIfFalse", "test",  42, INTEGER),
+    TestData("IfTrueIfFalse", "test2", 33, INTEGER),
+    TestData("IfTrueIfFalse", "test3",  4, INTEGER),
+
+    TestData("CompilerSimplification", "testReturnConstantSymbol", "constant", SYMBOL),
+    TestData("CompilerSimplification", "testReturnConstantInt", 42, INTEGER),
+    TestData("CompilerSimplification", "testReturnSelf", "CompilerSimplification", CLASS),
+    TestData("CompilerSimplification", "testReturnSelfImplicitly", "CompilerSimplification",
+        CLASS),
+    TestData("CompilerSimplification", "testReturnArgumentN", 55, INTEGER),
+    TestData("CompilerSimplification", "testReturnArgumentA", 44, INTEGER),
+    TestData("CompilerSimplification", "testSetField", "foo", SYMBOL),
+    TestData("CompilerSimplification", "testGetField", 40, INTEGER),
+
+    TestData("Hash", "testHash", 444, INTEGER),
+
+    TestData("Arrays", "testEmptyToInts", 3, INTEGER),
+    TestData("Arrays", "testPutAllInt", 5, INTEGER),
+    TestData("Arrays", "testPutAllNil", "Nil", CLASS),
+    TestData("Arrays", "testPutAllBlock", 3, INTEGER),
+    TestData("Arrays", "testNewWithAll", 1, INTEGER),
+
+    TestData("BlockInlining", "testNoInlining", 1, INTEGER),
+    TestData("BlockInlining", "testOneLevelInlining", 1, INTEGER),
+    TestData("BlockInlining", "testOneLevelInliningWithLocalShadowTrue", 2, INTEGER),
+    TestData("BlockInlining", "testOneLevelInliningWithLocalShadowFalse", 1, INTEGER),
+
+    TestData("BlockInlining", "testBlockNestedInIfTrue", 2, INTEGER),
+    TestData("BlockInlining", "testBlockNestedInIfFalse", 42, INTEGER),
+
+    TestData("BlockInlining", "testDeepNestedInlinedIfTrue", 3, INTEGER),
+    TestData("BlockInlining", "testDeepNestedInlinedIfFalse", 42, INTEGER),
+
+    TestData("BlockInlining", "testDeepNestedBlocksInInlinedIfTrue", 5, INTEGER),
+    TestData("BlockInlining", "testDeepNestedBlocksInInlinedIfFalse", 43, INTEGER),
+
+    TestData("BlockInlining", "testDeepDeepNestedTrue", 9, INTEGER),
+    TestData("BlockInlining", "testDeepDeepNestedFalse", 43, INTEGER),
+
+    TestData("BlockInlining", "testToDoNestDoNestIfTrue", 2, INTEGER),
+
+    TestData("NonLocalVars", "testWriteDifferentTypes", &dbl375, DOUBLE),
+
+    TestData("ObjectCreation", "test", 1000000, INTEGER),
+
+    TestData("Regressions", "testSymbolEquality", 1, INTEGER),
+    TestData("Regressions", "testSymbolReferenceEquality", 1, INTEGER),
+    TestData("Regressions", "testUninitializedLocal", 1, INTEGER),
+    TestData("Regressions", "testUninitializedLocalInBlock", 1, INTEGER),
+
+    TestData("BinaryOperation", "test", 11, INTEGER),
+
+    TestData("NumberOfTests", "numberOfTests", 57, INTEGER),
+  });
+
+  CPPUNIT_TEST_SUITE_END();
+private:
+  void assertEqualsSOMValue(vm_oop_t actualResult, TestData& data) {
+    if (data.type == INTEGER) {
+      int64_t expected = (intptr_t) data.expectedResult;
+      int64_t actual = INT_VAL(actualResult);
+      CPPUNIT_ASSERT_EQUAL(expected, actual);
+      return;
+    }
+
+    if (data.type == DOUBLE) {
+      double* expected = (double*) data.expectedResult;
+      double actual = ((VMDouble*) actualResult)->GetEmbeddedDouble();
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(*expected, actual, 1e-15);
+      return;
+    }
+
+    if (data.type == CLASS) {
+      char const* expected = (char const*) data.expectedResult;
+      std::string expectedStr = std::string(expected);
+      std::string actual = ((VMClass*) actualResult)->GetName()->GetStdString();
+      if (expected != actual) {
+        CPPUNIT_NS::Asserter::failNotEqual(expected, actual, CPPUNIT_SOURCELINE());
+      }
+      return;
+    }
+
+    if (data.type == SYMBOL) {
+      char const* expected = (char const*) data.expectedResult;
+      std::string expectedStr = std::string(expected);
+      std::string actual = ((VMSymbol*) actualResult)->GetStdString();
+      if (expected != actual) {
+        CPPUNIT_NS::Asserter::failNotEqual(expected, actual, CPPUNIT_SOURCELINE());
+      }
+      return;
+    }
+
+    CPPUNIT_FAIL("SOM Value handler missing");
+  }
+
+  void testBasic(TestData data) {
+    // The Unit Test harness will initialize Universe for a standard run.
+    // This is different from other SOMs.
+    vm_oop_t result = GetUniverse()->interpret(data.className, data.methodName);
+    assertEqualsSOMValue(result, data);
+  }
+};

--- a/src/unitTests/main.cpp
+++ b/src/unitTests/main.cpp
@@ -20,12 +20,12 @@
 #include "WriteBarrierTest.h"
 #include "BasicInterpreterTests.h"
 
-CPPUNIT_TEST_SUITE_REGISTRATION (BasicInterpreterTests);
 CPPUNIT_TEST_SUITE_REGISTRATION (WalkObjectsTest);
 CPPUNIT_TEST_SUITE_REGISTRATION (CloneObjectsTest);
 #if GC_TYPE==GENERATIONAL
 CPPUNIT_TEST_SUITE_REGISTRATION(WriteBarrierTest);
 #endif
+CPPUNIT_TEST_SUITE_REGISTRATION (BasicInterpreterTests);
 
 int main(int ac, char **av) {
     Universe::Start(ac, av);

--- a/src/unitTests/main.cpp
+++ b/src/unitTests/main.cpp
@@ -18,7 +18,9 @@
 #include "WalkObjectsTest.h"
 #include "CloneObjectsTest.h"
 #include "WriteBarrierTest.h"
+#include "BasicInterpreterTests.h"
 
+CPPUNIT_TEST_SUITE_REGISTRATION (BasicInterpreterTests);
 CPPUNIT_TEST_SUITE_REGISTRATION (WalkObjectsTest);
 CPPUNIT_TEST_SUITE_REGISTRATION (CloneObjectsTest);
 #if GC_TYPE==GENERATIONAL

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -80,8 +80,13 @@ public:
 
     //static methods
     static void Start(long argc, char** argv);
+    static void BasicInit();
     static void Quit(long);
     static void ErrorExit(const char*);
+
+    vm_oop_t interpret(StdString className, StdString methodName);
+
+    long setupClassPath(const StdString& cp);
 
     Interpreter* GetInterpreter() {
         return interpreter;
@@ -144,6 +149,8 @@ public:
     static void ErrorPrint(StdString str);
 
 private:
+    vm_oop_t interpretMethod(VMObject* receiver, VMInvokable* initialize, VMArray* argumentsArray);
+
     vector<StdString> handleArguments(long argc, char** argv);
     long getClassPathExt(vector<StdString>& tokens, const StdString& arg) const;
 
@@ -152,7 +159,6 @@ private:
     friend Universe* GetUniverse();
     static Universe* theUniverse;
 
-    long setupClassPath(const StdString& cp);
     long addClassPath(const StdString& cp);
     void printUsageAndExit(char* executable) const;
 


### PR DESCRIPTION
This PR makes sure that empty blocks return `nil`, see: https://github.com/SOM-st/SOM/pull/54.

In order to test this, I also needed to implement the basic interpreter tests, which apparently hasn't been done before.

To avoid issues with CPPUNIT, I'll switch Travis CI to Ubuntu 20.04, which has cppunit in a version that supports parameterized unit tests.