### PR TITLE
Update core-lib to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,6 @@ jobs:
           cd cmake-build
           ./SOM++ -cp ../Smalltalk ../TestSuite/TestHarness.som
 
-      # TODO: enable after updating the core-lib
-      # - name: Test SomSom
-      #   run: |
-      #     cd cmake-build
-      #     ./SOM++ -cp ../Smalltalk:../TestSuite:../core-lib/SomSom/src/compiler:../core-lib/SomSom/src/interpreter:../core-lib/SomSom/src/primitives:../core-lib/SomSom/src/vm:../core-lib/SomSom/src/vmobjects ../core-lib/SomSom/tests/SomSomTests.som
+      - name: Test SomSom
+        run: |
+          cmake-build/SOM++ -cp Smalltalk:TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects core-lib/SomSom/tests/SomSomTests.som

--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		0A67EA9E19ACDB4600830E3B /* README.md in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0A18873D1832C62100A2CBCA /* README.md */; };
 		0A67EA9F19ACDB4600830E3B /* Smalltalk in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0A18873E1832C62100A2CBCA /* Smalltalk */; };
 		0A67EAA119ACDB4600830E3B /* TestSuite in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0A1887401832C62100A2CBCA /* TestSuite */; };
+		0A70752A297DF9FE00EB9F59 /* ParseInteger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A707529297DF97700EB9F59 /* ParseInteger.cpp */; };
+		0A70752B297DF9FE00EB9F59 /* ParseInteger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A707529297DF97700EB9F59 /* ParseInteger.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -190,6 +192,8 @@
 		0A67EAA319ACE09700830E3B /* CloneObjectsTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CloneObjectsTest.h; path = unitTests/CloneObjectsTest.h; sourceTree = "<group>"; };
 		0A67EAA519ACE09700830E3B /* WalkObjectsTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WalkObjectsTest.h; path = unitTests/WalkObjectsTest.h; sourceTree = "<group>"; };
 		0A67EAA619ACE09700830E3B /* WriteBarrierTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WriteBarrierTest.h; path = unitTests/WriteBarrierTest.h; sourceTree = "<group>"; };
+		0A707528297DF36F00EB9F59 /* ParseInteger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParseInteger.h; sourceTree = "<group>"; };
+		0A707529297DF97700EB9F59 /* ParseInteger.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ParseInteger.cpp; sourceTree = "<group>"; };
 		3F5202F10FA6624C00E75857 /* BytecodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BytecodeGenerator.cpp; sourceTree = "<group>"; };
 		3F5202F20FA6624C00E75857 /* BytecodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = BytecodeGenerator.h; sourceTree = "<group>"; tabWidth = 4; };
 		3F5202F30FA6624C00E75857 /* ClassGenerationContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ClassGenerationContext.cpp; sourceTree = "<group>"; };
@@ -322,8 +326,6 @@
 		E18AE2B30FB1C45E00EE6540 /* TowersDisk.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TowersDisk.som; sourceTree = "<group>"; };
 		E18AE2B40FB1C45E00EE6540 /* TreeNode.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TreeNode.som; sourceTree = "<group>"; };
 		E18AE2B50FB1C45E00EE6540 /* TreeSort.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TreeSort.som; sourceTree = "<group>"; };
-		E18AE2B70FB1C45E00EE6540 /* Echo.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Echo.som; sourceTree = "<group>"; };
-		E18AE2B90FB1C45E00EE6540 /* Hello.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Hello.som; sourceTree = "<group>"; };
 		E18AE2BB0FB1C45E00EE6540 /* Apple.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Apple.som; sourceTree = "<group>"; };
 		E18AE2BC0FB1C45E00EE6540 /* Board.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Board.som; sourceTree = "<group>"; };
 		E18AE2BD0FB1C45E00EE6540 /* BoardView.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = BoardView.som; sourceTree = "<group>"; };
@@ -336,7 +338,6 @@
 		E18AE2C40FB1C45E00EE6540 /* Terminal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Terminal.cpp; sourceTree = "<group>"; };
 		E18AE2C50FB1C45E00EE6540 /* Terminal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Terminal.h; sourceTree = "<group>"; };
 		E18AE2C60FB1C45E00EE6540 /* Terminal.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Terminal.som; sourceTree = "<group>"; };
-		E18AE2C80FB1C45E00EE6540 /* StringTest.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = StringTest.som; sourceTree = "<group>"; };
 		E18AE2CA0FB1C46B00EE6540 /* ArrayTest.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ArrayTest.som; sourceTree = "<group>"; };
 		E18AE2CC0FB1C46B00EE6540 /* ClosureTest.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ClosureTest.som; sourceTree = "<group>"; };
 		E18AE2CD0FB1C46B00EE6540 /* CoercionTest.som */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoercionTest.som; sourceTree = "<group>"; };
@@ -501,6 +502,8 @@
 				3F52030F0FA6624C00E75857 /* gettimeofday.h */,
 				0A1887371832C12E00A2CBCA /* Timer.cpp */,
 				0A1887381832C12E00A2CBCA /* Timer.h */,
+				0A707528297DF36F00EB9F59 /* ParseInteger.h */,
+				0A707529297DF97700EB9F59 /* ParseInteger.cpp */,
 			);
 			path = misc;
 			sourceTree = "<group>";
@@ -816,6 +819,7 @@
 				0A3A3CB11A5D5475004CB03B /* PrimitiveLoader.cpp in Sources */,
 				0A1887001832BCFA00A2CBCA /* VMInteger.cpp in Sources */,
 				0A3A3C931A5D546D004CB03B /* Block.cpp in Sources */,
+				0A70752A297DF9FE00EB9F59 /* ParseInteger.cpp in Sources */,
 				0A3A3CB01A5D5475004CB03B /* PrimitiveContainer.cpp in Sources */,
 				0A3A3C981A5D546D004CB03B /* Object.cpp in Sources */,
 				0A1886E01832BCC800A2CBCA /* MethodGenerationContext.cpp in Sources */,
@@ -864,6 +868,7 @@
 				0A67EA7E19ACD74800830E3B /* VMArray.cpp in Sources */,
 				0A67EA8719ACD74800830E3B /* VMObject.cpp in Sources */,
 				0A3A3CA11A5D546D004CB03B /* Array.cpp in Sources */,
+				0A70752B297DF9FE00EB9F59 /* ParseInteger.cpp in Sources */,
 				0A3A3CAA1A5D546D004CB03B /* Symbol.cpp in Sources */,
 				0A67EA8619ACD74800830E3B /* VMMethod.cpp in Sources */,
 				0A67EA7519ACD43A00830E3B /* CloneObjectsTest.cpp in Sources */,

--- a/rebench.conf
+++ b/rebench.conf
@@ -18,7 +18,7 @@ runs:
 benchmark_suites:
     macro:
         gauge_adapter: RebenchLog
-        command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
+        command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
         iterations: 10
         benchmarks:
             - Richards:     {extra_args:   1, machines: [yuria ]}
@@ -30,7 +30,7 @@ benchmark_suites:
 
     micro:
         gauge_adapter: RebenchLog
-        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
         iterations: 10
         benchmarks:
             - Fannkuch:     {extra_args:  6, machines: [yuria ]}

--- a/src/compiler/BytecodeGenerator.cpp
+++ b/src/compiler/BytecodeGenerator.cpp
@@ -73,6 +73,11 @@ void BytecodeGenerator::EmitPUSHCONSTANT(MethodGenerationContext* mgenc,
     EMIT2(BC_PUSH_CONSTANT, mgenc->FindLiteralIndex(cst));
 }
 
+void BytecodeGenerator::EmitPUSHCONSTANT(MethodGenerationContext* mgenc,
+        uint8_t literalIndex) {
+    EMIT2(BC_PUSH_CONSTANT, literalIndex);
+}
+
 void BytecodeGenerator::EmitPUSHCONSTANTString(MethodGenerationContext* mgenc,
         VMString* str) {
     EMIT2(BC_PUSH_CONSTANT, mgenc->FindLiteralIndex(str));

--- a/src/compiler/BytecodeGenerator.h
+++ b/src/compiler/BytecodeGenerator.h
@@ -43,6 +43,7 @@ public:
     void EmitPUSHFIELD(MethodGenerationContext* mgenc, VMSymbol* field);
     void EmitPUSHBLOCK(MethodGenerationContext* mgenc, VMMethod* block);
     void EmitPUSHCONSTANT(MethodGenerationContext* mgenc, vm_oop_t cst);
+    void EmitPUSHCONSTANT(MethodGenerationContext* mgenc, uint8_t literalIndex);
     void EmitPUSHCONSTANTString(MethodGenerationContext* mgenc, VMString* str);
     void EmitPUSHGLOBAL(MethodGenerationContext* mgenc, VMSymbol* global);
     void EmitPOP(MethodGenerationContext* mgenc);

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -221,8 +221,15 @@ void MethodGenerationContext::AddLocal(const StdString& local) {
     locals.PushBack(local);
 }
 
-void MethodGenerationContext::AddLiteral(vm_oop_t lit) {
+uint8_t MethodGenerationContext::AddLiteral(vm_oop_t lit) {
+    uint8_t idx = literals.Size();
     literals.PushBack(lit);
+    return idx;
+}
+
+void MethodGenerationContext::UpdateLiteral(vm_oop_t oldValue, uint8_t index, vm_oop_t newValue) {
+    assert(literals.Get(index) == oldValue);
+    literals.Set(index, newValue);
 }
 
 bool MethodGenerationContext::AddArgumentIfAbsent(const StdString& arg) {

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -59,7 +59,8 @@ public:
     void AddArgument(const StdString& arg);
     void SetPrimitive(bool prim = true);
     void AddLocal(const StdString& local);
-    void AddLiteral(vm_oop_t lit);
+    uint8_t AddLiteral(vm_oop_t lit);
+    void UpdateLiteral(vm_oop_t oldValue, uint8_t index, vm_oop_t newValue);
     bool AddArgumentIfAbsent(const StdString& arg);
     bool AddLocalIfAbsent(const StdString& local);
     bool AddLiteralIfAbsent(vm_oop_t lit);

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -59,7 +59,7 @@ void Parser::PeekForNextSymbolFromLexerIfNecessary() {
     }
 }
 
-Parser::Parser(istream& file) {
+Parser::Parser(istream& file, StdString& fname): fname(fname) {
     sym = NONE;
     lexer = new Lexer(file);
     bcGen = new BytecodeGenerator();
@@ -110,8 +110,10 @@ bool Parser::expect(Symbol s) {
     if (accept(s))
         return true;
     fprintf(stderr,
-            "Error: unexpected symbol in line %d. Expected %s, but found %s",
-            lexer->GetCurrentLineNumber(), symnames[s], symnames[sym]);
+            "Error: %s:%d: unexpected symbol. Expected %s, but found %s",
+            fname.c_str(),
+            lexer->GetCurrentLineNumber(),
+            symnames[s], symnames[sym]);
     if (_PRINTABLE_SYM)
         fprintf(stderr, " (%s)", text.c_str());
     fprintf(stderr, ": %s\n", lexer->GetRawBuffer().c_str());

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -186,7 +186,7 @@ void Parser::genPopVariable(MethodGenerationContext* mgenc,
 //
 
 Symbol singleOpSyms[] = { Not, And, Or, Star, Div, Mod, Plus, Equal, More, Less,
-        Comma, At, Per, NONE };
+        Comma, At, Per, Minus, NONE };
 
 Symbol binaryOpSyms[] = { Or, Comma, Minus, Equal, Not, And, Or, Star, Div, Mod,
         Plus, Equal, More, Less, Comma, At, Per, NONE };
@@ -358,15 +358,7 @@ VMSymbol* Parser::unarySelector(void) {
 VMSymbol* Parser::binarySelector(void) {
     StdString s(text);
 
-    if(accept(Or))
-    ;
-    else if(accept(Comma))
-    ;
-    else if(accept(Minus))
-    ;
-    else if(accept(Equal))
-    ;
-    else if(acceptOneOf(singleOpSyms))
+    if(acceptOneOf(singleOpSyms))
     ;
     else if(accept(OperatorSequence))
     ;

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -27,6 +27,8 @@
 #include "Parser.h"
 #include "BytecodeGenerator.h"
 
+#include <misc/ParseInteger.h>
+
 #include <vmobjects/VMMethod.h>
 #include <vmobjects/VMPrimitive.h>
 #include <vmobjects/VMObject.h>
@@ -775,7 +777,6 @@ vm_oop_t Parser::literalDecimal(bool negateValue) {
     if (sym == Integer) {
         return literalInteger(negateValue);
     } else {
-        assert(sym == Double);
         return literalDouble(negateValue);
     }
 }
@@ -786,13 +787,9 @@ vm_oop_t Parser::negativeDecimal(void) {
 }
 
 vm_oop_t Parser::literalInteger(bool negateValue) {
-    int64_t i = std::strtoll(text.c_str(), nullptr, 10);
+    vm_oop_t i = ParseInteger(text.c_str(), 10, negateValue);
     expect(Integer);
-    if (negateValue) {
-        i = 0 - i;
-    }
-    
-    return NEW_INT(i);
+    return i;
 }
 
 vm_oop_t Parser::literalDouble(bool negateValue) {

--- a/src/compiler/Parser.h
+++ b/src/compiler/Parser.h
@@ -88,9 +88,6 @@ private:
     bool binaryOperand(MethodGenerationContext* mgenc);
     void keywordMessage(MethodGenerationContext* mgenc, bool super);
     
-    void ifTrueMessage(MethodGenerationContext* mgenc);
-    void ifFalseMessage(MethodGenerationContext* mgenc);
-    
     void formula(MethodGenerationContext* mgenc);
     void nestedTerm(MethodGenerationContext* mgenc);
     void literal(MethodGenerationContext* mgenc);
@@ -107,7 +104,6 @@ private:
     VMSymbol* keywordSelector(void);
     StdString _string(void);
     void nestedBlock(MethodGenerationContext* mgenc);
-    void inlinedBlock(MethodGenerationContext* mgenc);
     void blockPattern(MethodGenerationContext* mgenc);
     void blockArguments(MethodGenerationContext* mgenc);
     void genPushVariable(MethodGenerationContext*, const StdString&);

--- a/src/compiler/Parser.h
+++ b/src/compiler/Parser.h
@@ -38,7 +38,7 @@
 
 class Parser {
 public:
-    Parser(istream& file);
+    Parser(istream& file, StdString& fname);
     ~Parser();
 
     void Classdef(ClassGenerationContext* cgenc);
@@ -114,6 +114,7 @@ private:
     void genPopVariable(MethodGenerationContext*, const StdString&);
 
     Lexer* lexer;
+    StdString& fname;
 
     Symbol sym;
 

--- a/src/compiler/SourcecodeCompiler.cpp
+++ b/src/compiler/SourcecodeCompiler.cpp
@@ -57,7 +57,7 @@ VMClass* SourcecodeCompiler::CompileClass( const StdString& path,
     }
 
     if (parser != nullptr) delete(parser);
-    parser = new Parser(*fp);
+    parser = new Parser(*fp, fname);
     result = compile(systemClass);
 
     VMSymbol* cname = result->GetName();
@@ -84,7 +84,9 @@ VMClass* SourcecodeCompiler::CompileClassString( const StdString& stream,
         VMClass* systemClass ) {
     istringstream* ss = new istringstream(stream);
     if (parser != nullptr) delete(parser);
-    parser = new Parser(*ss);
+
+    StdString fileName = "repl";
+    parser = new Parser(*ss, fileName);
 
     VMClass* result = compile(systemClass);
     delete(parser);

--- a/src/misc/ExtendedList.h
+++ b/src/misc/ExtendedList.h
@@ -43,6 +43,7 @@ public:
     void Clear();
     size_t Size() const;
     T Get(long index);
+    void Set(long index, const T& ptr);
     int32_t IndexOf(const T& needle);
 
     typedef typename std::list<T>::iterator iterator_t;
@@ -94,6 +95,17 @@ T ExtendedList<T>::Get(long index) {
         --index;
     }
     return nullptr;
+}
+
+template<class T>
+void ExtendedList<T>::Set(long index, const T& ptr) {
+    for (iterator_t it = theList.begin(); it != theList.end(); ++it) {
+        if (index == 0) {
+            *it = ptr;
+            return;
+        }
+        --index;
+    }
 }
 
 template<class T>

--- a/src/misc/ParseInteger.cpp
+++ b/src/misc/ParseInteger.cpp
@@ -1,0 +1,37 @@
+#include <misc/ParseInteger.h>
+
+#include <cerrno>
+#include <string>
+
+#include <vmobjects/VMInteger.h>
+#include <vm/Universe.h>
+
+
+vm_oop_t ParseInteger(const char* str, int base, bool negateValue) {
+  errno = 0;
+
+  char* pEnd {};
+
+  const int64_t i = std::strtoll(str, &pEnd, base);
+
+  if (str == pEnd) {
+    // did not parse anything
+    return NEW_INT(0);
+  }
+
+  const bool rangeError = errno == ERANGE;
+  if (rangeError) {
+    // TODO: try a big int library
+    return NEW_INT(0);
+  }
+
+  // the normal case
+  if (negateValue) {
+    return NEW_INT(-i);
+  }
+  return NEW_INT(i);
+}
+
+vm_oop_t ParseInteger(StdString& str, int base, bool negateValue) {
+  return ParseInteger(str.c_str(), base, negateValue);
+}

--- a/src/misc/ParseInteger.h
+++ b/src/misc/ParseInteger.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <misc/defs.h>
+#include <vmobjects/ObjectFormats.h>
+
+vm_oop_t ParseInteger(const char* str, int base, bool negateValue);
+vm_oop_t ParseInteger(StdString& str, int base, bool negateValue);

--- a/src/primitives/Double.cpp
+++ b/src/primitives/Double.cpp
@@ -47,7 +47,7 @@
 double _Double::coerceDouble(vm_oop_t x) {
     if (IS_TAGGED(x))
         return (double) INT_VAL(x);
-    
+
     VMClass* cl = ((AbstractVMObject*)x)->GetClass();
     if (cl == load_ptr(doubleClass))
         return static_cast<VMDouble*>(x)->GetEmbeddedDouble();
@@ -166,13 +166,21 @@ void _Double::Round(Interpreter*, VMFrame* frame) {
 void _Double::AsInteger(Interpreter*, VMFrame* frame) {
     VMDouble* self = (VMDouble*)frame->Pop();
     int64_t rounded = (int64_t) self->GetEmbeddedDouble();
-    
+
     frame->Push(NEW_INT(rounded));
 }
 
 void _Double::PositiveInfinity(Interpreter*, VMFrame* frame) {
     frame->Pop();
     frame->Push(GetUniverse()->NewDouble(INFINITY));
+}
+
+void _Double::FromString(Interpreter*, VMFrame* frame) {
+    VMString* self = (VMString*) frame->Pop();
+    frame->Pop();
+
+    double value = stod(StdString(self->GetRawChars(), self->GetStringLength()));
+    frame->Push(GetUniverse()->NewDouble(value));
 }
 
 _Double::_Double() : PrimitiveContainer() {
@@ -192,4 +200,5 @@ _Double::_Double() : PrimitiveContainer() {
     SetPrimitive("round",      new Routine<_Double>(this, &_Double::Round,      false));
     SetPrimitive("asInteger",  new Routine<_Double>(this, &_Double::AsInteger,  false));
     SetPrimitive("PositiveInfinity", new Routine<_Double>(this, &_Double::PositiveInfinity, true));
+    SetPrimitive("fromString_", new Routine<_Double>(this, &_Double::FromString, true));
 }

--- a/src/primitives/Double.h
+++ b/src/primitives/Double.h
@@ -47,8 +47,9 @@ public:
     void BitwiseXor(Interpreter*, VMFrame*);
     void Round(Interpreter*, VMFrame*);
     void AsInteger(Interpreter*, VMFrame*);
-    
+
     void PositiveInfinity(Interpreter*, VMFrame*);
+    void FromString(Interpreter*, VMFrame*);
 
 private:
     double coerceDouble(vm_oop_t x);

--- a/src/primitives/Integer.cpp
+++ b/src/primitives/Integer.cpp
@@ -31,6 +31,8 @@
 #include <limits.h>
 #include <sstream>
 
+#include <misc/ParseInteger.h>
+
 #include <vmobjects/VMObject.h>
 #include <vmobjects/VMFrame.h>
 #include <vmobjects/VMDouble.h>
@@ -314,7 +316,8 @@ void _Integer::FromString(Interpreter*, VMFrame* frame) {
     VMString* self = (VMString*) frame->Pop();
     frame->Pop();
 
-    int64_t integer = stol(StdString(self->GetRawChars(), self->GetStringLength()));
-    vm_oop_t new_int = NEW_INT(integer);
+    StdString str = self->GetStdString();
+
+    vm_oop_t new_int = ParseInteger(str, 10, false);
     frame->Push(new_int);
 }

--- a/src/primitives/Integer.cpp
+++ b/src/primitives/Integer.cpp
@@ -73,6 +73,7 @@ _Integer::_Integer() : PrimitiveContainer() {
     SetPrimitive("equalequal",         new Routine<_Integer>(this, &_Integer::EqualEqual, false));
     SetPrimitive("lowerthan",          new Routine<_Integer>(this, &_Integer::Lowerthan,  false));
     SetPrimitive("asString",           new Routine<_Integer>(this, &_Integer::AsString,   false));
+    SetPrimitive("asDouble",           new Routine<_Integer>(this, &_Integer::AsDouble,   false));
     SetPrimitive("as32BitSignedValue", new Routine<_Integer>(this, &_Integer::As32BitSigned, false));
     SetPrimitive("as32BitUnsignedValue", new Routine<_Integer>(this, &_Integer::As32BitUnsigned, false));
     SetPrimitive("sqrt",               new Routine<_Integer>(this, &_Integer::Sqrt,       false));
@@ -116,7 +117,7 @@ void _Integer::BitwiseAnd(Interpreter* interp, VMFrame* frame) {
 void _Integer::BitwiseXor(Interpreter* interp, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
-    
+
     int64_t result = (int64_t)INT_VAL(leftObj) ^ (int64_t)INT_VAL(rightObj);
     frame->Push(NEW_INT(result));
 }
@@ -125,7 +126,7 @@ void _Integer::BitwiseXor(Interpreter* interp, VMFrame* frame) {
 void _Integer::LeftShift(Interpreter* interp, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
-    
+
     int64_t result = (int64_t)INT_VAL(leftObj) << (int64_t)INT_VAL(rightObj);
     frame->Push(NEW_INT(result));
 }
@@ -133,7 +134,7 @@ void _Integer::LeftShift(Interpreter* interp, VMFrame* frame) {
 void _Integer::UnsignedRightShift(Interpreter* interp, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
-    
+
     int64_t result = (int64_t)INT_VAL(leftObj) >> (int64_t)INT_VAL(rightObj);
     frame->Push(NEW_INT(result));
 }
@@ -142,7 +143,7 @@ void _Integer::UnsignedRightShift(Interpreter* interp, VMFrame* frame) {
 void _Integer::Minus(Interpreter* interp, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
-    
+
     CHECK_COERCION(rightObj, leftObj, "-");
 
     int64_t result = (int64_t)INT_VAL(leftObj) - (int64_t)INT_VAL(rightObj);
@@ -152,7 +153,7 @@ void _Integer::Minus(Interpreter* interp, VMFrame* frame) {
 void _Integer::Star(Interpreter* interp, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
-    
+
     CHECK_COERCION(rightObj, leftObj, "*");
 
     int64_t result = (int64_t)INT_VAL(leftObj) * (int64_t)INT_VAL(rightObj);
@@ -162,7 +163,7 @@ void _Integer::Star(Interpreter* interp, VMFrame* frame) {
 void _Integer::Slashslash(Interpreter* interp, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
-    
+
     CHECK_COERCION(rightObj, leftObj, "//");
 
     double result = (double)INT_VAL(leftObj) / (double)INT_VAL(rightObj);
@@ -172,7 +173,7 @@ void _Integer::Slashslash(Interpreter* interp, VMFrame* frame) {
 void _Integer::Slash(Interpreter* interp, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
-    
+
     CHECK_COERCION(rightObj, leftObj, "/");
 
     int64_t result = (int64_t)INT_VAL(leftObj) / (int64_t)INT_VAL(rightObj);
@@ -189,7 +190,7 @@ void _Integer::Percent(Interpreter* interp, VMFrame* frame) {
     int64_t r = (int64_t)INT_VAL(rightObj);
 
     int64_t result = l % r;
-    
+
     if ((result != 0) && ((result < 0) != (r < 0))) {
         result += r;
     }
@@ -200,14 +201,14 @@ void _Integer::Percent(Interpreter* interp, VMFrame* frame) {
 void _Integer::Rem(Interpreter* interp, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
-    
+
     CHECK_COERCION(rightObj, leftObj, "%");
-    
+
     int64_t l = (int64_t)INT_VAL(leftObj);
     int64_t r = (int64_t)INT_VAL(rightObj);
-    
+
     int64_t result = l - (l / r) * r;
-    
+
     frame->Push(NEW_INT(result));
 }
 
@@ -242,7 +243,7 @@ void _Integer::Equal(Interpreter* interp, VMFrame* frame) {
 void _Integer::EqualEqual(Interpreter* interp, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
-    
+
     if (IS_TAGGED(rightObj) || CLASS_OF(rightObj) == load_ptr(integerClass)) {
         if (INT_VAL(leftObj) == INT_VAL(rightObj))
             frame->Push(load_ptr(trueObject));
@@ -273,17 +274,23 @@ void _Integer::AsString(Interpreter*, VMFrame* frame) {
     frame->Push(GetUniverse()->NewString( Str.str()));
 }
 
+void _Integer::AsDouble(Interpreter*, VMFrame* frame) {
+    vm_oop_t self = frame->Pop();
+    long integer = INT_VAL(self);
+    frame->Push(GetUniverse()->NewDouble((double) integer));
+}
+
 void _Integer::As32BitSigned(Interpreter*, VMFrame* frame) {
     vm_oop_t self = frame->Pop();
     int64_t integer = INT_VAL(self);
-    
+
     frame->Push(NEW_INT((int64_t)(int32_t) integer));
 }
 
 void _Integer::As32BitUnsigned(Interpreter*, VMFrame* frame) {
     vm_oop_t self = frame->Pop();
     int64_t integer = INT_VAL(self);
-    
+
     frame->Push(NEW_INT((int64_t)(uint32_t) integer));
 }
 
@@ -311,4 +318,3 @@ void _Integer::FromString(Interpreter*, VMFrame* frame) {
     vm_oop_t new_int = NEW_INT(integer);
     frame->Push(new_int);
 }
-

--- a/src/primitives/Integer.h
+++ b/src/primitives/Integer.h
@@ -49,6 +49,7 @@ public:
     void EqualEqual(Interpreter*, VMFrame*);
     void Lowerthan(Interpreter*, VMFrame*);
     void AsString(Interpreter*, VMFrame*);
+    void AsDouble(Interpreter*, VMFrame*);
     void As32BitSigned(Interpreter*, VMFrame*);
     void As32BitUnsigned(Interpreter*, VMFrame*);
     void Sqrt(Interpreter*, VMFrame*);

--- a/src/primitives/String.cpp
+++ b/src/primitives/String.cpp
@@ -92,7 +92,7 @@ void _String::Equal(Interpreter*, VMFrame* frame) {
     }
 
     VMClass* otherClass = CLASS_OF(op1);
-    if(otherClass == load_ptr(stringClass)) {
+    if(otherClass == load_ptr(stringClass) || otherClass == load_ptr(symbolClass)) {
         StdString s1 = static_cast<VMString*>(op1)->GetStdString();
         StdString s2 = op2->GetStdString();
 

--- a/src/primitives/Symbol.cpp
+++ b/src/primitives/Symbol.cpp
@@ -41,18 +41,7 @@ void _Symbol::AsString(Interpreter*, VMFrame* frame) {
     frame->Push(GetUniverse()->NewString(str));
 }
 
-void _Symbol::Equal(Interpreter*, VMFrame* frame) {
-    vm_oop_t op1 = frame->Pop();
-    vm_oop_t op2 = frame->Pop();
-    
-    if (op1 == op2) {
-        frame->Push(load_ptr(trueObject));
-    } else {
-        frame->Push(load_ptr(falseObject));
-    }
-}
 
 _Symbol::_Symbol() : PrimitiveContainer() {
     SetPrimitive("asString", new Routine<_Symbol>(this, &_Symbol::AsString, false));
-    SetPrimitive("equal",    new Routine<_Symbol>(this, &_Symbol::Equal,    false));
 }

--- a/src/primitives/Symbol.h
+++ b/src/primitives/Symbol.h
@@ -33,5 +33,4 @@ class _Symbol: public PrimitiveContainer {
 public:
     _Symbol();
     void AsString(Interpreter*, VMFrame*);
-    void Equal(Interpreter*, VMFrame*);
 };

--- a/src/primitives/System.cpp
+++ b/src/primitives/System.cpp
@@ -112,6 +112,18 @@ void _System::PrintNewline_(Interpreter*, VMFrame* frame) {
     Universe::Print(str + "\n");
 }
 
+void _System::ErrorPrint_(Interpreter*, VMFrame* frame) {
+    VMString* arg = static_cast<VMString*>(frame->Pop());
+    std::string str = arg->GetStdString();
+    Universe::ErrorPrint(str);
+}
+
+void _System::ErrorPrintNewline_(Interpreter*, VMFrame* frame) {
+    VMString* arg = static_cast<VMString*>(frame->Pop());
+    std::string str = arg->GetStdString();
+    Universe::ErrorPrint(str + "\n");
+}
+
 
 void _System::Time(Interpreter*, VMFrame* frame) {
     /*VMObject* self = */
@@ -158,6 +170,8 @@ _System::_System(void) : PrimitiveContainer() {
     SetPrimitive("printString_", new Routine<_System>(this, &_System::PrintString_, false));
     SetPrimitive("printNewline", new Routine<_System>(this, &_System::PrintNewline, false));
     SetPrimitive("printNewline_",new Routine<_System>(this, &_System::PrintNewline_, false));
+    SetPrimitive("errorPrint_",  new Routine<_System>(this, &_System::ErrorPrint_, false));
+    SetPrimitive("errorPrintln_",new Routine<_System>(this, &_System::ErrorPrintNewline_, false));
     SetPrimitive("time",         new Routine<_System>(this, &_System::Time,   false));
     SetPrimitive("ticks",        new Routine<_System>(this, &_System::Ticks,  false));
     SetPrimitive("fullGC",       new Routine<_System>(this, &_System::FullGC, false));

--- a/src/primitives/System.cpp
+++ b/src/primitives/System.cpp
@@ -25,6 +25,8 @@
  */
 
 #include <stdio.h>
+#include <sstream>
+#include <fstream>
 
 #include <time.h>
 
@@ -159,6 +161,26 @@ void _System::FullGC(Interpreter*, VMFrame* frame) {
     frame->Push(load_ptr(trueObject));
 }
 
+void _System::LoadFile_(Interpreter*, VMFrame* frame) {
+    VMString* fileName = static_cast<VMString*>(frame->Pop());
+    frame->Pop();
+
+    std::ifstream file(fileName->GetStdString(), std::ifstream::in);
+    if (file.is_open()) {
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        
+        VMString* result = GetUniverse()->NewString(buffer.str());
+        frame->Push(result);
+    } else {
+        frame->Push(load_ptr(nilObject));
+    }
+}
+
+void _System::PrintStackTrace(Interpreter*, VMFrame* frame) {
+    frame->PrintStackTrace();
+}
+
 _System::_System(void) : PrimitiveContainer() {
     gettimeofday(&start_time, nullptr);
 
@@ -175,6 +197,9 @@ _System::_System(void) : PrimitiveContainer() {
     SetPrimitive("time",         new Routine<_System>(this, &_System::Time,   false));
     SetPrimitive("ticks",        new Routine<_System>(this, &_System::Ticks,  false));
     SetPrimitive("fullGC",       new Routine<_System>(this, &_System::FullGC, false));
+
+    SetPrimitive("loadFile_",    new Routine<_System>(this, &_System::LoadFile_, false));
+    SetPrimitive("printStackTrace", new Routine<_System>(this, &_System::PrintStackTrace, false));
 }
 
 _System::~_System() {}

--- a/src/primitives/System.h
+++ b/src/primitives/System.h
@@ -44,6 +44,8 @@ public:
     void PrintString_(Interpreter*, VMFrame*);
     void PrintNewline(Interpreter*, VMFrame*);
     void PrintNewline_(Interpreter*, VMFrame*);
+    void ErrorPrint_(Interpreter*, VMFrame*);
+    void ErrorPrintNewline_(Interpreter*, VMFrame*);
     void Time(Interpreter*, VMFrame*);
     void Ticks(Interpreter*, VMFrame*);
     void FullGC(Interpreter*, VMFrame*);

--- a/src/primitives/System.h
+++ b/src/primitives/System.h
@@ -50,6 +50,9 @@ public:
     void Ticks(Interpreter*, VMFrame*);
     void FullGC(Interpreter*, VMFrame*);
 
+    void LoadFile_(Interpreter*, VMFrame*);
+    void PrintStackTrace(Interpreter*, VMFrame*);
+
 private:
     struct timeval start_time;
 };

--- a/src/unitTests/BasicInterpreterTests.h
+++ b/src/unitTests/BasicInterpreterTests.h
@@ -84,6 +84,11 @@ class BasicInterpreterTests: public CPPUNIT_NS::TestFixture {
     TestData("IfTrueIfFalse", "test2", 33, INTEGER),
     TestData("IfTrueIfFalse", "test3",  4, INTEGER),
 
+    TestData("IfTrueIfFalse", "testIfTrueTrueResult", "Integer", CLASS),
+    TestData("IfTrueIfFalse", "testIfTrueFalseResult", "Nil", CLASS),
+    TestData("IfTrueIfFalse", "testIfFalseTrueResult", "Nil", CLASS),
+    TestData("IfTrueIfFalse", "testIfFalseFalseResult", "Integer", CLASS),
+
     TestData("CompilerSimplification", "testReturnConstantSymbol", "constant", SYMBOL),
     TestData("CompilerSimplification", "testReturnConstantInt", 42, INTEGER),
     TestData("CompilerSimplification", "testReturnSelf", "CompilerSimplification", CLASS),
@@ -107,8 +112,14 @@ class BasicInterpreterTests: public CPPUNIT_NS::TestFixture {
     TestData("BlockInlining", "testOneLevelInliningWithLocalShadowTrue", 2, INTEGER),
     TestData("BlockInlining", "testOneLevelInliningWithLocalShadowFalse", 1, INTEGER),
 
+    TestData("BlockInlining", "testShadowDoesntStoreWrongLocal", 33, INTEGER),
+    TestData("BlockInlining", "testShadowDoesntReadUnrelated", "Nil", CLASS),
+
     TestData("BlockInlining", "testBlockNestedInIfTrue", 2, INTEGER),
     TestData("BlockInlining", "testBlockNestedInIfFalse", 42, INTEGER),
+
+    TestData("BlockInlining", "testStackDisciplineTrue", 1, INTEGER),
+    TestData("BlockInlining", "testStackDisciplineFalse", 2, INTEGER),
 
     TestData("BlockInlining", "testDeepNestedInlinedIfTrue", 3, INTEGER),
     TestData("BlockInlining", "testDeepNestedInlinedIfFalse", 42, INTEGER),
@@ -132,7 +143,7 @@ class BasicInterpreterTests: public CPPUNIT_NS::TestFixture {
 
     TestData("BinaryOperation", "test", 11, INTEGER),
 
-    TestData("NumberOfTests", "numberOfTests", 57, INTEGER),
+    TestData("NumberOfTests", "numberOfTests", 65, INTEGER),
   });
 
   CPPUNIT_TEST_SUITE_END();


### PR DESCRIPTION
This PR updates the core-lib to the very latest version and brings SOM++ to the point where it successfully runs SomSom.

This adds:
 - missing primitives in Double, Integer, System, incl. `#loadFile:`
 - expands support for literal arrays

It also removes the broken inlining of `#ifTrue:`/`#ifFalse:`.
The inlining was not correctly handling shadowing.
So, instead of the broken approach, we should really use the one used in PySOM and TruffleSOM.