### PR TITLE
Optimize Interpreter Loop Compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           mkdir cmake-build
           cd cmake-build
           cmake .. -DGC_TYPE=${{ matrix.gc}} ${{ matrix.integers }}
-          make
+          make -j5
 
       - name: Run Unit Tests
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ build_and_test:
 
     - cd cmake-build
     - cmake .. $INTEGERS -DGC_TYPE=$GC
-    - make
+    - make -j10
     - ./SOM++ -cp ../Smalltalk ../TestSuite/TestHarness.som
     - ./unittests -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
     - mv SOM++ ../$NAME

--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -121,6 +121,8 @@
 		0AB80AD02C392811006B6419 /* IsValidObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AB80ACE2C392811006B6419 /* IsValidObject.cpp */; };
 		0AB80AD32C392B78006B6419 /* Print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AB80AD12C392B78006B6419 /* Print.cpp */; };
 		0AB80AD42C392B78006B6419 /* Print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AB80AD12C392B78006B6419 /* Print.cpp */; };
+		0AB80AD82C394806006B6419 /* Globals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AB80AD72C394806006B6419 /* Globals.cpp */; };
+		0AB80AD92C394806006B6419 /* Globals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AB80AD72C394806006B6419 /* Globals.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -202,6 +204,8 @@
 		0AB80ACE2C392811006B6419 /* IsValidObject.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IsValidObject.cpp; sourceTree = "<group>"; };
 		0AB80AD12C392B78006B6419 /* Print.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Print.cpp; sourceTree = "<group>"; };
 		0AB80AD52C392BAD006B6419 /* Print.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Print.h; sourceTree = "<group>"; };
+		0AB80AD62C3947F7006B6419 /* Globals.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Globals.h; sourceTree = "<group>"; };
+		0AB80AD72C394806006B6419 /* Globals.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Globals.cpp; sourceTree = "<group>"; };
 		3F5202F10FA6624C00E75857 /* BytecodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BytecodeGenerator.cpp; sourceTree = "<group>"; };
 		3F5202F20FA6624C00E75857 /* BytecodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = BytecodeGenerator.h; sourceTree = "<group>"; tabWidth = 4; };
 		3F5202F30FA6624C00E75857 /* ClassGenerationContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ClassGenerationContext.cpp; sourceTree = "<group>"; };
@@ -568,6 +572,8 @@
 				0AB80ACE2C392811006B6419 /* IsValidObject.cpp */,
 				0AB80AD12C392B78006B6419 /* Print.cpp */,
 				0AB80AD52C392BAD006B6419 /* Print.h */,
+				0AB80AD62C3947F7006B6419 /* Globals.h */,
+				0AB80AD72C394806006B6419 /* Globals.cpp */,
 			);
 			path = vm;
 			sourceTree = "<group>";
@@ -819,6 +825,7 @@
 				0A1886DD1832BCC800A2CBCA /* ClassGenerationContext.cpp in Sources */,
 				0A3A3C941A5D546D004CB03B /* Class.cpp in Sources */,
 				0A18870B1832C0E400A2CBCA /* AbstractObject.cpp in Sources */,
+				0AB80AD82C394806006B6419 /* Globals.cpp in Sources */,
 				0A3A3C991A5D546D004CB03B /* Primitive.cpp in Sources */,
 				0A1886FF1832BCF500A2CBCA /* VMFrame.cpp in Sources */,
 				0A1886E41832BCD300A2CBCA /* Interpreter.cpp in Sources */,
@@ -875,6 +882,7 @@
 				0A3A3CAB1A5D546D004CB03B /* System.cpp in Sources */,
 				0A3A3CA31A5D546D004CB03B /* Class.cpp in Sources */,
 				0A67EA9019ACD83200830E3B /* Lexer.cpp in Sources */,
+				0AB80AD92C394806006B6419 /* Globals.cpp in Sources */,
 				0A3A3CA71A5D546D004CB03B /* Object.cpp in Sources */,
 				0A3A3CB21A5D5476004CB03B /* PrimitiveContainer.cpp in Sources */,
 				0A67EA8419ACD74800830E3B /* VMFrame.cpp in Sources */,

--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -117,6 +117,10 @@
 		0A67EAA119ACDB4600830E3B /* TestSuite in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0A1887401832C62100A2CBCA /* TestSuite */; };
 		0A70752A297DF9FE00EB9F59 /* ParseInteger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A707529297DF97700EB9F59 /* ParseInteger.cpp */; };
 		0A70752B297DF9FE00EB9F59 /* ParseInteger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A707529297DF97700EB9F59 /* ParseInteger.cpp */; };
+		0AB80ACF2C392811006B6419 /* IsValidObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AB80ACE2C392811006B6419 /* IsValidObject.cpp */; };
+		0AB80AD02C392811006B6419 /* IsValidObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AB80ACE2C392811006B6419 /* IsValidObject.cpp */; };
+		0AB80AD32C392B78006B6419 /* Print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AB80AD12C392B78006B6419 /* Print.cpp */; };
+		0AB80AD42C392B78006B6419 /* Print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0AB80AD12C392B78006B6419 /* Print.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -194,6 +198,10 @@
 		0A67EAA619ACE09700830E3B /* WriteBarrierTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WriteBarrierTest.h; path = unitTests/WriteBarrierTest.h; sourceTree = "<group>"; };
 		0A707528297DF36F00EB9F59 /* ParseInteger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParseInteger.h; sourceTree = "<group>"; };
 		0A707529297DF97700EB9F59 /* ParseInteger.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ParseInteger.cpp; sourceTree = "<group>"; };
+		0AB80ACD2C3927EC006B6419 /* IsValidObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsValidObject.h; sourceTree = "<group>"; };
+		0AB80ACE2C392811006B6419 /* IsValidObject.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IsValidObject.cpp; sourceTree = "<group>"; };
+		0AB80AD12C392B78006B6419 /* Print.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Print.cpp; sourceTree = "<group>"; };
+		0AB80AD52C392BAD006B6419 /* Print.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Print.h; sourceTree = "<group>"; };
 		3F5202F10FA6624C00E75857 /* BytecodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BytecodeGenerator.cpp; sourceTree = "<group>"; };
 		3F5202F20FA6624C00E75857 /* BytecodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = BytecodeGenerator.h; sourceTree = "<group>"; tabWidth = 4; };
 		3F5202F30FA6624C00E75857 /* ClassGenerationContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ClassGenerationContext.cpp; sourceTree = "<group>"; };
@@ -556,6 +564,10 @@
 				3F5203310FA6624C00E75857 /* Shell.h */,
 				3F5203320FA6624C00E75857 /* Universe.cpp */,
 				3F5203330FA6624C00E75857 /* Universe.h */,
+				0AB80ACD2C3927EC006B6419 /* IsValidObject.h */,
+				0AB80ACE2C392811006B6419 /* IsValidObject.cpp */,
+				0AB80AD12C392B78006B6419 /* Print.cpp */,
+				0AB80AD52C392BAD006B6419 /* Print.h */,
 			);
 			path = vm;
 			sourceTree = "<group>";
@@ -816,6 +828,7 @@
 				0A1886FB1832BCF500A2CBCA /* VMBlock.cpp in Sources */,
 				0A1887391832C12E00A2CBCA /* Timer.cpp in Sources */,
 				0A1887021832BCFA00A2CBCA /* VMMethod.cpp in Sources */,
+				0AB80AD32C392B78006B6419 /* Print.cpp in Sources */,
 				0A3A3CB11A5D5475004CB03B /* PrimitiveLoader.cpp in Sources */,
 				0A1887001832BCFA00A2CBCA /* VMInteger.cpp in Sources */,
 				0A3A3C931A5D546D004CB03B /* Block.cpp in Sources */,
@@ -836,6 +849,7 @@
 				0A3A3C9A1A5D546D004CB03B /* String.cpp in Sources */,
 				0A3A3C951A5D546D004CB03B /* Double.cpp in Sources */,
 				0A1886F61832BCED00A2CBCA /* Universe.cpp in Sources */,
+				0AB80ACF2C392811006B6419 /* IsValidObject.cpp in Sources */,
 				0A1886E21832BCC800A2CBCA /* SourcecodeCompiler.cpp in Sources */,
 				0A1886FC1832BCF500A2CBCA /* VMClass.cpp in Sources */,
 				0A1886DF1832BCC800A2CBCA /* Lexer.cpp in Sources */,
@@ -888,6 +902,7 @@
 				0A3A3CA51A5D546D004CB03B /* Integer.cpp in Sources */,
 				0A67EA8F19ACD83200830E3B /* Disassembler.cpp in Sources */,
 				0A67EA9719ACD84F00830E3B /* GenerationalHeap.cpp in Sources */,
+				0AB80AD02C392811006B6419 /* IsValidObject.cpp in Sources */,
 				0A67EA9519ACD83900830E3B /* Interpreter.cpp in Sources */,
 				0A67EA8A19ACD74800830E3B /* VMSymbol.cpp in Sources */,
 				0A67EA7C19ACD74800830E3B /* AbstractObject.cpp in Sources */,
@@ -904,6 +919,7 @@
 				0A3A3CA21A5D546D004CB03B /* Block.cpp in Sources */,
 				0A3A3CA91A5D546D004CB03B /* String.cpp in Sources */,
 				0A67EA9319ACD83200830E3B /* SourcecodeCompiler.cpp in Sources */,
+				0AB80AD42C392B78006B6419 /* Print.cpp in Sources */,
 				0A3A3CA41A5D546D004CB03B /* Double.cpp in Sources */,
 				0A67EA8519ACD74800830E3B /* VMInteger.cpp in Sources */,
 			);
@@ -1117,6 +1133,7 @@
 				OTHER_CFLAGS = (
 					"-DGC_TYPE=COPYING",
 					"-DUSE_TAGGING=false",
+					"-DNDEBUG",
 				);
 				VALID_ARCHS = arm64;
 			};
@@ -1156,6 +1173,7 @@
 				OTHER_CFLAGS = (
 					"-DGC_TYPE=COPYING",
 					"-DUSE_TAGGING=false",
+					"-DNDEBUG",
 				);
 				VALID_ARCHS = arm64;
 			};

--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		0AB80AD52C392BAD006B6419 /* Print.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Print.h; sourceTree = "<group>"; };
 		0AB80AD62C3947F7006B6419 /* Globals.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Globals.h; sourceTree = "<group>"; };
 		0AB80AD72C394806006B6419 /* Globals.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Globals.cpp; sourceTree = "<group>"; };
+		0AB80ADA2C39AC27006B6419 /* InterpreterLoop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InterpreterLoop.h; sourceTree = "<group>"; };
 		3F5202F10FA6624C00E75857 /* BytecodeGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BytecodeGenerator.cpp; sourceTree = "<group>"; };
 		3F5202F20FA6624C00E75857 /* BytecodeGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = BytecodeGenerator.h; sourceTree = "<group>"; tabWidth = 4; };
 		3F5202F30FA6624C00E75857 /* ClassGenerationContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ClassGenerationContext.cpp; sourceTree = "<group>"; };
@@ -479,6 +480,7 @@
 				3F5203020FA6624C00E75857 /* bytecodes.h */,
 				3F5203030FA6624C00E75857 /* Interpreter.cpp */,
 				3F5203040FA6624C00E75857 /* Interpreter.h */,
+				0AB80ADA2C39AC27006B6419 /* InterpreterLoop.h */,
 			);
 			path = interpreter;
 			sourceTree = "<group>";

--- a/src/compiler/ClassGenerationContext.cpp
+++ b/src/compiler/ClassGenerationContext.cpp
@@ -30,6 +30,8 @@
 #include "../vmobjects/VMObject.h"
 #include "../vmobjects/VMClass.h"
 
+#include <vm/Universe.h>
+
 ClassGenerationContext::ClassGenerationContext() :
         instanceFields(), instanceMethods(), classFields(), classMethods() {
     name = nullptr;

--- a/src/compiler/Disassembler.cpp
+++ b/src/compiler/Disassembler.cpp
@@ -29,7 +29,8 @@
 
 #include "Disassembler.h"
 
-#include "../vm/Universe.h"
+#include <vm/Print.h>
+#include <vm/Universe.h>
 
 #include "../interpreter/bytecodes.h"
 #include "../interpreter/Interpreter.h"
@@ -126,12 +127,12 @@ void Disassembler::DumpMethod(VMMethod* method, const char* indent) {
         max_stack, method->GetNumberOfBytecodes());
     }
 #ifdef _DEBUG
-    Universe::Print("bytecodes: ");
+    Print("bytecodes: ");
     long numBytecodes = method->GetNumberOfBytecodes();
     for (long i = 0; i < numBytecodes; ++i) {
-        Universe::Print(to_string((int)(*method)[i]) + " ");
+        Print(to_string((int)(*method)[i]) + " ");
     }
-    Universe::Print("\n");
+    Print("\n");
 #endif
     // output bytecodes
     long numBytecodes = method->GetNumberOfBytecodes();

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -24,6 +24,9 @@
  THE SOFTWARE.
  */
 
+#include <vm/Print.h>
+#include <vm/Universe.h>
+
 #include "MethodGenerationContext.h"
 
 #include "../interpreter/bytecodes.h"
@@ -181,7 +184,7 @@ uint8_t MethodGenerationContext::ComputeStackDepth() {
             i += 5;
             break;
         default: {
-            Universe::ErrorPrint("Illegal bytecode: " + to_string(bytecode[i]) + "\n");
+            ErrorPrint("Illegal bytecode: " + to_string(bytecode[i]) + "\n");
             GetUniverse()->Quit(1);
           }
         }

--- a/src/compiler/SourcecodeCompiler.cpp
+++ b/src/compiler/SourcecodeCompiler.cpp
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <fstream>
 #include <vm/Print.h>
+#include <vm/Universe.h>
 
 #include "SourcecodeCompiler.h"
 #include "ClassGenerationContext.h"

--- a/src/compiler/SourcecodeCompiler.cpp
+++ b/src/compiler/SourcecodeCompiler.cpp
@@ -26,6 +26,7 @@
 
 #include <sstream>
 #include <fstream>
+#include <vm/Print.h>
 
 #include "SourcecodeCompiler.h"
 #include "ClassGenerationContext.h"
@@ -75,7 +76,7 @@ VMClass* SourcecodeCompiler::CompileClass( const StdString& path,
     parser = nullptr;
     delete(fp);
 #ifdef COMPILER_DEBUG
-    Universe::ErrorPrint("Compilation finished\n");
+    ErrorPrint("Compilation finished\n");
 #endif
     return result;
 }
@@ -98,13 +99,13 @@ VMClass* SourcecodeCompiler::CompileClassString( const StdString& stream,
 
 void SourcecodeCompiler::showCompilationError(const StdString& filename,
         const char* message) {
-    Universe::ErrorPrint("Error when compiling " + filename + ":\n" +
+    ErrorPrint("Error when compiling " + filename + ":\n" +
                          message + "\n");
 }
 
 VMClass* SourcecodeCompiler::compile(VMClass* systemClass) {
     if (parser == nullptr) {
-        Universe::ErrorPrint("Parser not initiated\n");
+        ErrorPrint("Parser not initiated\n");
         GetUniverse()->ErrorExit("Compiler error");
         return nullptr;
     }

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -53,11 +53,6 @@ Interpreter::Interpreter() : frame(nullptr) {}
 
 Interpreter::~Interpreter() {}
 
-template<>
-__attribute__((used)) vm_oop_t Interpreter::Start<true>();
-template<>
-__attribute__((used)) vm_oop_t Interpreter::Start<false>();
-
 VMFrame* Interpreter::PushNewFrame(VMMethod* method) {
     SetFrame(GetUniverse()->NewFrame(GetFrame(), method));
     return GetFrame();

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -53,6 +53,26 @@ Interpreter::Interpreter() : frame(nullptr) {}
 
 Interpreter::~Interpreter() {}
 
+vm_oop_t Interpreter::StartAndPrintBytecodes() {
+#define PROLOGUE(bc_count) {\
+disassembleMethod(); \
+bytecodeIndexGlobal += bc_count;\
+}
+#define HACK_INLINE_START
+#include "InterpreterLoop.h"
+#undef HACK_INLINE_START
+}
+
+vm_oop_t Interpreter::Start() {
+#undef PROLOGUE
+#define PROLOGUE(bc_count) {\
+bytecodeIndexGlobal += bc_count;\
+}
+#define HACK_INLINE_START
+#include "InterpreterLoop.h"
+#undef HACK_INLINE_START
+}
+
 VMFrame* Interpreter::PushNewFrame(VMMethod* method) {
     SetFrame(GetUniverse()->NewFrame(GetFrame(), method));
     return GetFrame();

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -207,19 +207,6 @@ void Interpreter::doPushField(long bytecodeIndex) {
 }
 
 void Interpreter::doPushBlock(long bytecodeIndex) {
-    // Short cut the negative case of #ifTrue: and #ifFalse:
-    if (currentBytecodes[bytecodeIndexGlobal] == BC_SEND) {
-        if (GetFrame()->GetStackElement(0) == load_ptr(falseObject) &&
-            method->GetConstant(bytecodeIndexGlobal) == load_ptr(symbolIfTrue)) {
-            GetFrame()->Push(load_ptr(nilObject));
-            return;
-        } else if (GetFrame()->GetStackElement(0) == load_ptr(trueObject) &&
-                   method->GetConstant(bytecodeIndexGlobal) == load_ptr(symbolIfFalse)) {
-            GetFrame()->Push(load_ptr(nilObject));
-            return;
-        }
-    }
-
     VMMethod* blockMethod = static_cast<VMMethod*>(method->GetConstant(bytecodeIndex));
 
     long numOfArgs = blockMethod->GetNumberOfArguments();

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -227,11 +227,6 @@ void Interpreter::doPushBlock(long bytecodeIndex) {
     GetFrame()->Push(GetUniverse()->NewBlock(blockMethod, GetFrame(), numOfArgs));
 }
 
-void Interpreter::doPushConstant(long bytecodeIndex) {
-    vm_oop_t constant = method->GetConstant(bytecodeIndex);
-    GetFrame()->Push(constant);
-}
-
 void Interpreter::doPushGlobal(long bytecodeIndex) {
     VMSymbol* globalName = static_cast<VMSymbol*>(method->GetConstant(bytecodeIndex));
     vm_oop_t global = GetUniverse()->GetGlobal(globalName);
@@ -415,12 +410,10 @@ void Interpreter::WalkGlobals(walk_heap_fn walk) {
 }
 
 void Interpreter::triggerGC() {
-    if (GetHeap<HEAP_CLS>()->isCollectionTriggered()) {
-        GetFrame()->SetBytecodeIndex(bytecodeIndexGlobal);
-        GetHeap<HEAP_CLS>()->FullGC();
-        method = GetFrame()->GetMethod();
-        currentBytecodes = method->GetBytecodes();
-    }
+    GetFrame()->SetBytecodeIndex(bytecodeIndexGlobal);
+    GetHeap<HEAP_CLS>()->FullGC();
+    method = GetFrame()->GetMethod();
+    currentBytecodes = method->GetBytecodes();
 }
 
 VMMethod* Interpreter::GetMethod() const {

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -28,6 +28,8 @@
 #include "bytecodes.h"
 
 #include <vm/IsValidObject.h>
+#include <vm/Universe.h>
+#include <vm/Globals.h>
 
 #include <vmobjects/VMMethod.h>
 #include <vmobjects/VMFrame.h>
@@ -150,7 +152,7 @@ void Interpreter::send(VMSymbol* signature, VMClass* receiverClass) {
     }
 }
 
-inline void Interpreter::doDup() {
+void Interpreter::doDup() {
     vm_oop_t elem = GetFrame()->GetStackElement(0);
     GetFrame()->Push(elem);
 }
@@ -238,7 +240,7 @@ void Interpreter::doPushGlobal(long bytecodeIndex) {
     }
 }
 
-inline void Interpreter::doPop() {
+void Interpreter::doPop() {
     GetFrame()->Pop();
 }
 
@@ -406,11 +408,11 @@ void Interpreter::triggerGC() {
     }
 }
 
-inline VMMethod* Interpreter::GetMethod() const {
+VMMethod* Interpreter::GetMethod() const {
     return GetFrame()->GetMethod();
 }
 
-inline uint8_t* Interpreter::GetBytecodes() const {
+uint8_t* Interpreter::GetBytecodes() const {
     return method->GetBytecodes();
 }
 

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -54,9 +54,9 @@ Interpreter::Interpreter() : frame(nullptr) {}
 Interpreter::~Interpreter() {}
 
 template<>
-vm_oop_t Interpreter::Start<true>();
+__attribute__((used)) vm_oop_t Interpreter::Start<true>();
 template<>
-vm_oop_t Interpreter::Start<false>();
+__attribute__((used)) vm_oop_t Interpreter::Start<false>();
 
 VMFrame* Interpreter::PushNewFrame(VMMethod* method) {
     SetFrame(GetUniverse()->NewFrame(GetFrame(), method));

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -289,7 +289,7 @@ void Interpreter::send(VMSymbol* signature, VMClass* receiverClass) {
     }
 }
 
-void Interpreter::doDup() {
+inline void Interpreter::doDup() {
     vm_oop_t elem = GetFrame()->GetStackElement(0);
     GetFrame()->Push(elem);
 }
@@ -377,7 +377,7 @@ void Interpreter::doPushGlobal(long bytecodeIndex) {
     }
 }
 
-void Interpreter::doPop() {
+inline void Interpreter::doPop() {
     GetFrame()->Pop();
 }
 

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -30,11 +30,6 @@
 #include <vmobjects/ObjectFormats.h>
 #include <vmobjects/VMFrame.h>
 
-#define PROLOGUE(bc_count) {\
-  if (printBytecodes) disassembleMethod(); \
-    bytecodeIndexGlobal += bc_count;\
-  }
-
 #define DISPATCH_NOGC() {\
   goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]]; \
 }
@@ -50,132 +45,27 @@ public:
     Interpreter();
     ~Interpreter();
     
-    template<bool printBytecodes>
-    vm_oop_t  Start() {
-        // initialization
-        method = GetMethod();
-        currentBytecodes = GetBytecodes();
-
-        void* loopTargets[] = {
-            &&LABEL_BC_HALT,
-            &&LABEL_BC_DUP,
-            &&LABEL_BC_PUSH_LOCAL,
-            &&LABEL_BC_PUSH_ARGUMENT,
-            &&LABEL_BC_PUSH_FIELD,
-            &&LABEL_BC_PUSH_BLOCK,
-            &&LABEL_BC_PUSH_CONSTANT,
-            &&LABEL_BC_PUSH_GLOBAL,
-            &&LABEL_BC_POP,
-            &&LABEL_BC_POP_LOCAL,
-            &&LABEL_BC_POP_ARGUMENT,
-            &&LABEL_BC_POP_FIELD,
-            &&LABEL_BC_SEND,
-            &&LABEL_BC_SUPER_SEND,
-            &&LABEL_BC_RETURN_LOCAL,
-            &&LABEL_BC_RETURN_NON_LOCAL,
-            &&LABEL_BC_JUMP_IF_FALSE,
-            &&LABEL_BC_JUMP_IF_TRUE,
-            &&LABEL_BC_JUMP
-        };
-
-        goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]];
-
-        //
-        // THIS IS THE former interpretation loop
-        LABEL_BC_HALT:
-          PROLOGUE(1);
-          return GetFrame()->GetStackElement(0); // handle the halt bytecode
-
-        LABEL_BC_DUP:
-          PROLOGUE(1);
-          doDup();
-          DISPATCH_NOGC();
-
-        LABEL_BC_PUSH_LOCAL:
-          PROLOGUE(3);
-          doPushLocal(bytecodeIndexGlobal - 3);
-          DISPATCH_NOGC();
-
-        LABEL_BC_PUSH_ARGUMENT:
-          PROLOGUE(3);
-          doPushArgument(bytecodeIndexGlobal - 3);
-          DISPATCH_NOGC();
-
-        LABEL_BC_PUSH_FIELD:
-          PROLOGUE(2);
-          doPushField(bytecodeIndexGlobal - 2);
-          DISPATCH_NOGC();
-
-        LABEL_BC_PUSH_BLOCK:
-          PROLOGUE(2);
-          doPushBlock(bytecodeIndexGlobal - 2);
-          DISPATCH_GC();
-
-        LABEL_BC_PUSH_CONSTANT:
-          PROLOGUE(2);
-          doPushConstant(bytecodeIndexGlobal - 2);
-          DISPATCH_NOGC();
-
-        LABEL_BC_PUSH_GLOBAL:
-          PROLOGUE(2);
-          doPushGlobal(bytecodeIndexGlobal - 2);
-          DISPATCH_GC();
-
-        LABEL_BC_POP:
-          PROLOGUE(1);
-          doPop();
-          DISPATCH_NOGC();
-
-        LABEL_BC_POP_LOCAL:
-          PROLOGUE(3);
-          doPopLocal(bytecodeIndexGlobal - 3);
-          DISPATCH_NOGC();
-
-        LABEL_BC_POP_ARGUMENT:
-          PROLOGUE(3);
-          doPopArgument(bytecodeIndexGlobal - 3);
-          DISPATCH_NOGC();
-
-        LABEL_BC_POP_FIELD:
-          PROLOGUE(2);
-          doPopField(bytecodeIndexGlobal - 2);
-          DISPATCH_NOGC();
-
-        LABEL_BC_SEND:
-          PROLOGUE(2);
-          doSend(bytecodeIndexGlobal - 2);
-          DISPATCH_GC();
-
-        LABEL_BC_SUPER_SEND:
-          PROLOGUE(2);
-          doSuperSend(bytecodeIndexGlobal - 2);
-          DISPATCH_GC();
-
-        LABEL_BC_RETURN_LOCAL:
-          PROLOGUE(1);
-          doReturnLocal();
-          DISPATCH_NOGC();
-
-        LABEL_BC_RETURN_NON_LOCAL:
-          PROLOGUE(1);
-          doReturnNonLocal();
-          DISPATCH_NOGC();
-
-        LABEL_BC_JUMP_IF_FALSE:
-          PROLOGUE(5);
-          doJumpIfFalse(bytecodeIndexGlobal - 5);
-          DISPATCH_NOGC();
-
-        LABEL_BC_JUMP_IF_TRUE:
-          PROLOGUE(5);
-          doJumpIfTrue(bytecodeIndexGlobal - 5);
-          DISPATCH_NOGC();
-
-        LABEL_BC_JUMP:
-          PROLOGUE(5);
-          doJump(bytecodeIndexGlobal - 5);
-          DISPATCH_NOGC();
+    vm_oop_t StartAndPrintBytecodes() {
+#define PROLOGUE(bc_count) {\
+    disassembleMethod(); \
+    bytecodeIndexGlobal += bc_count;\
+}
+#define HACK_INLINE_START
+#include "InterpreterLoop.h"
+#undef HACK_INLINE_START
     }
+    
+    vm_oop_t Start() {
+#undef PROLOGUE
+#define PROLOGUE(bc_count) {\
+    bytecodeIndexGlobal += bc_count;\
+  }
+#define HACK_INLINE_START
+#include "InterpreterLoop.h"
+#undef HACK_INLINE_START
+    }
+    
+    
     
     VMFrame*  PushNewFrame(VMMethod* method);
     void      SetFrame(VMFrame* frame);

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -45,27 +45,8 @@ public:
     Interpreter();
     ~Interpreter();
     
-    vm_oop_t StartAndPrintBytecodes() {
-#define PROLOGUE(bc_count) {\
-    disassembleMethod(); \
-    bytecodeIndexGlobal += bc_count;\
-}
-#define HACK_INLINE_START
-#include "InterpreterLoop.h"
-#undef HACK_INLINE_START
-    }
-    
-    vm_oop_t Start() {
-#undef PROLOGUE
-#define PROLOGUE(bc_count) {\
-    bytecodeIndexGlobal += bc_count;\
-  }
-#define HACK_INLINE_START
-#include "InterpreterLoop.h"
-#undef HACK_INLINE_START
-    }
-    
-    
+    vm_oop_t StartAndPrintBytecodes();
+    vm_oop_t Start();
     
     VMFrame*  PushNewFrame(VMMethod* method);
     void      SetFrame(VMFrame* frame);

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -180,8 +180,8 @@ public:
     VMFrame*  PushNewFrame(VMMethod* method);
     void      SetFrame(VMFrame* frame);
     inline VMFrame* GetFrame() const;
-    inline VMMethod* GetMethod() const;
-    inline uint8_t* GetBytecodes() const;
+    VMMethod* GetMethod() const;
+    uint8_t* GetBytecodes() const;
     void      WalkGlobals(walk_heap_fn);
     
 private:

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -29,13 +29,14 @@
 #include <misc/defs.h>
 #include <vmobjects/ObjectFormats.h>
 #include <vmobjects/VMFrame.h>
+#include <vmobjects/VMMethod.h>
 
 #define DISPATCH_NOGC() {\
   goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]]; \
 }
 
 #define DISPATCH_GC() {\
-  triggerGC(); \
+  if (GetHeap<HEAP_CLS>()->isCollectionTriggered()) { triggerGC(); } \
   goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]];\
 }
 
@@ -83,7 +84,12 @@ private:
     void doPushArgument(long bytecodeIndex);
     void doPushField(long bytecodeIndex);
     void doPushBlock(long bytecodeIndex);
-    void doPushConstant(long bytecodeIndex);
+    
+    inline void doPushConstant(long bytecodeIndex) {
+        vm_oop_t constant = method->GetConstant(bytecodeIndex);
+        GetFrame()->Push(constant);
+    }
+    
     void doPushGlobal(long bytecodeIndex);
     void doPop(void);
     void doPopLocal(long bytecodeIndex);

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -28,16 +28,160 @@
 
 #include <misc/defs.h>
 #include <vmobjects/ObjectFormats.h>
+#include <vmobjects/VMFrame.h>
+
+#define PROLOGUE(bc_count) {\
+  if (printBytecodes) disassembleMethod(); \
+    bytecodeIndexGlobal += bc_count;\
+  }
+
+#define DISPATCH_NOGC() {\
+  goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]]; \
+}
+
+#define DISPATCH_GC() {\
+  triggerGC(); \
+  goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]];\
+}
+
 
 class Interpreter {
 public:
     Interpreter();
     ~Interpreter();
     
-    vm_oop_t  Start();
+    template<bool printBytecodes>
+    vm_oop_t  Start() {
+        // initialization
+        method = GetMethod();
+        currentBytecodes = GetBytecodes();
+
+        void* loopTargets[] = {
+            &&LABEL_BC_HALT,
+            &&LABEL_BC_DUP,
+            &&LABEL_BC_PUSH_LOCAL,
+            &&LABEL_BC_PUSH_ARGUMENT,
+            &&LABEL_BC_PUSH_FIELD,
+            &&LABEL_BC_PUSH_BLOCK,
+            &&LABEL_BC_PUSH_CONSTANT,
+            &&LABEL_BC_PUSH_GLOBAL,
+            &&LABEL_BC_POP,
+            &&LABEL_BC_POP_LOCAL,
+            &&LABEL_BC_POP_ARGUMENT,
+            &&LABEL_BC_POP_FIELD,
+            &&LABEL_BC_SEND,
+            &&LABEL_BC_SUPER_SEND,
+            &&LABEL_BC_RETURN_LOCAL,
+            &&LABEL_BC_RETURN_NON_LOCAL,
+            &&LABEL_BC_JUMP_IF_FALSE,
+            &&LABEL_BC_JUMP_IF_TRUE,
+            &&LABEL_BC_JUMP
+        };
+
+        goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]];
+
+        //
+        // THIS IS THE former interpretation loop
+        LABEL_BC_HALT:
+          PROLOGUE(1);
+          return GetFrame()->GetStackElement(0); // handle the halt bytecode
+
+        LABEL_BC_DUP:
+          PROLOGUE(1);
+          doDup();
+          DISPATCH_NOGC();
+
+        LABEL_BC_PUSH_LOCAL:
+          PROLOGUE(3);
+          doPushLocal(bytecodeIndexGlobal - 3);
+          DISPATCH_NOGC();
+
+        LABEL_BC_PUSH_ARGUMENT:
+          PROLOGUE(3);
+          doPushArgument(bytecodeIndexGlobal - 3);
+          DISPATCH_NOGC();
+
+        LABEL_BC_PUSH_FIELD:
+          PROLOGUE(2);
+          doPushField(bytecodeIndexGlobal - 2);
+          DISPATCH_NOGC();
+
+        LABEL_BC_PUSH_BLOCK:
+          PROLOGUE(2);
+          doPushBlock(bytecodeIndexGlobal - 2);
+          DISPATCH_GC();
+
+        LABEL_BC_PUSH_CONSTANT:
+          PROLOGUE(2);
+          doPushConstant(bytecodeIndexGlobal - 2);
+          DISPATCH_NOGC();
+
+        LABEL_BC_PUSH_GLOBAL:
+          PROLOGUE(2);
+          doPushGlobal(bytecodeIndexGlobal - 2);
+          DISPATCH_GC();
+
+        LABEL_BC_POP:
+          PROLOGUE(1);
+          doPop();
+          DISPATCH_NOGC();
+
+        LABEL_BC_POP_LOCAL:
+          PROLOGUE(3);
+          doPopLocal(bytecodeIndexGlobal - 3);
+          DISPATCH_NOGC();
+
+        LABEL_BC_POP_ARGUMENT:
+          PROLOGUE(3);
+          doPopArgument(bytecodeIndexGlobal - 3);
+          DISPATCH_NOGC();
+
+        LABEL_BC_POP_FIELD:
+          PROLOGUE(2);
+          doPopField(bytecodeIndexGlobal - 2);
+          DISPATCH_NOGC();
+
+        LABEL_BC_SEND:
+          PROLOGUE(2);
+          doSend(bytecodeIndexGlobal - 2);
+          DISPATCH_GC();
+
+        LABEL_BC_SUPER_SEND:
+          PROLOGUE(2);
+          doSuperSend(bytecodeIndexGlobal - 2);
+          DISPATCH_GC();
+
+        LABEL_BC_RETURN_LOCAL:
+          PROLOGUE(1);
+          doReturnLocal();
+          DISPATCH_NOGC();
+
+        LABEL_BC_RETURN_NON_LOCAL:
+          PROLOGUE(1);
+          doReturnNonLocal();
+          DISPATCH_NOGC();
+
+        LABEL_BC_JUMP_IF_FALSE:
+          PROLOGUE(5);
+          doJumpIfFalse(bytecodeIndexGlobal - 5);
+          DISPATCH_NOGC();
+
+        LABEL_BC_JUMP_IF_TRUE:
+          PROLOGUE(5);
+          doJumpIfTrue(bytecodeIndexGlobal - 5);
+          DISPATCH_NOGC();
+
+        LABEL_BC_JUMP:
+          PROLOGUE(5);
+          doJump(bytecodeIndexGlobal - 5);
+          DISPATCH_NOGC();
+    }
+    
     VMFrame*  PushNewFrame(VMMethod* method);
     void      SetFrame(VMFrame* frame);
     inline VMFrame* GetFrame() const;
+    inline VMMethod* GetMethod() const;
+    inline uint8_t* GetBytecodes() const;
     void      WalkGlobals(walk_heap_fn);
     
 private:
@@ -55,6 +199,9 @@ private:
     static const StdString unknownGlobal;
     static const StdString doesNotUnderstand;
     static const StdString escapedBlock;
+    
+    void triggerGC();
+    void disassembleMethod() const;
 
     VMFrame* popFrame();
     void popFrameAndPushResult(vm_oop_t result);
@@ -80,6 +227,6 @@ private:
     void doJump(long bytecodeIndex);
 };
 
-VMFrame* Interpreter::GetFrame() const {
+inline VMFrame* Interpreter::GetFrame() const {
     return frame;
 }

--- a/src/interpreter/InterpreterLoop.h
+++ b/src/interpreter/InterpreterLoop.h
@@ -1,0 +1,130 @@
+#ifndef HACK_INLINE_START
+vm_oop_t Start() {
+#endif
+    // initialization
+    method = GetMethod();
+    currentBytecodes = GetBytecodes();
+    
+    void* loopTargets[] = {
+        &&LABEL_BC_HALT,
+        &&LABEL_BC_DUP,
+        &&LABEL_BC_PUSH_LOCAL,
+        &&LABEL_BC_PUSH_ARGUMENT,
+        &&LABEL_BC_PUSH_FIELD,
+        &&LABEL_BC_PUSH_BLOCK,
+        &&LABEL_BC_PUSH_CONSTANT,
+        &&LABEL_BC_PUSH_GLOBAL,
+        &&LABEL_BC_POP,
+        &&LABEL_BC_POP_LOCAL,
+        &&LABEL_BC_POP_ARGUMENT,
+        &&LABEL_BC_POP_FIELD,
+        &&LABEL_BC_SEND,
+        &&LABEL_BC_SUPER_SEND,
+        &&LABEL_BC_RETURN_LOCAL,
+        &&LABEL_BC_RETURN_NON_LOCAL,
+        &&LABEL_BC_JUMP_IF_FALSE,
+        &&LABEL_BC_JUMP_IF_TRUE,
+        &&LABEL_BC_JUMP
+    };
+    
+    goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]];
+    
+    //
+    // THIS IS THE former interpretation loop
+LABEL_BC_HALT:
+    PROLOGUE(1);
+    return GetFrame()->GetStackElement(0); // handle the halt bytecode
+    
+LABEL_BC_DUP:
+    PROLOGUE(1);
+    doDup();
+    DISPATCH_NOGC();
+    
+LABEL_BC_PUSH_LOCAL:
+    PROLOGUE(3);
+    doPushLocal(bytecodeIndexGlobal - 3);
+    DISPATCH_NOGC();
+    
+LABEL_BC_PUSH_ARGUMENT:
+    PROLOGUE(3);
+    doPushArgument(bytecodeIndexGlobal - 3);
+    DISPATCH_NOGC();
+    
+LABEL_BC_PUSH_FIELD:
+    PROLOGUE(2);
+    doPushField(bytecodeIndexGlobal - 2);
+    DISPATCH_NOGC();
+    
+LABEL_BC_PUSH_BLOCK:
+    PROLOGUE(2);
+    doPushBlock(bytecodeIndexGlobal - 2);
+    DISPATCH_GC();
+    
+LABEL_BC_PUSH_CONSTANT:
+    PROLOGUE(2);
+    doPushConstant(bytecodeIndexGlobal - 2);
+    DISPATCH_NOGC();
+    
+LABEL_BC_PUSH_GLOBAL:
+    PROLOGUE(2);
+    doPushGlobal(bytecodeIndexGlobal - 2);
+    DISPATCH_GC();
+    
+LABEL_BC_POP:
+    PROLOGUE(1);
+    doPop();
+    DISPATCH_NOGC();
+    
+LABEL_BC_POP_LOCAL:
+    PROLOGUE(3);
+    doPopLocal(bytecodeIndexGlobal - 3);
+    DISPATCH_NOGC();
+    
+LABEL_BC_POP_ARGUMENT:
+    PROLOGUE(3);
+    doPopArgument(bytecodeIndexGlobal - 3);
+    DISPATCH_NOGC();
+    
+LABEL_BC_POP_FIELD:
+    PROLOGUE(2);
+    doPopField(bytecodeIndexGlobal - 2);
+    DISPATCH_NOGC();
+    
+LABEL_BC_SEND:
+    PROLOGUE(2);
+    doSend(bytecodeIndexGlobal - 2);
+    DISPATCH_GC();
+    
+LABEL_BC_SUPER_SEND:
+    PROLOGUE(2);
+    doSuperSend(bytecodeIndexGlobal - 2);
+    DISPATCH_GC();
+    
+LABEL_BC_RETURN_LOCAL:
+    PROLOGUE(1);
+    doReturnLocal();
+    DISPATCH_NOGC();
+    
+LABEL_BC_RETURN_NON_LOCAL:
+    PROLOGUE(1);
+    doReturnNonLocal();
+    DISPATCH_NOGC();
+    
+LABEL_BC_JUMP_IF_FALSE:
+    PROLOGUE(5);
+    doJumpIfFalse(bytecodeIndexGlobal - 5);
+    DISPATCH_NOGC();
+    
+LABEL_BC_JUMP_IF_TRUE:
+    PROLOGUE(5);
+    doJumpIfTrue(bytecodeIndexGlobal - 5);
+    DISPATCH_NOGC();
+    
+LABEL_BC_JUMP:
+    PROLOGUE(5);
+    doJump(bytecodeIndexGlobal - 5);
+    DISPATCH_NOGC();
+
+#ifndef HACK_INLINE_START
+}
+#endif

--- a/src/memory/CopyingCollector.cpp
+++ b/src/memory/CopyingCollector.cpp
@@ -7,6 +7,7 @@
 #include <vmobjects/IntegerBox.h>
 
 #include "CopyingCollector.h"
+#include <vm/IsValidObject.h>
 
 static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     // don't process tagged objects
@@ -14,7 +15,7 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
         return oop;
     
     AbstractVMObject* obj = AS_OBJ(oop);
-    assert(Universe::IsValidObject(obj));
+    assert(IsValidObject(obj));
 
 
     long gcField = obj->GetGCField();

--- a/src/memory/CopyingHeap.cpp
+++ b/src/memory/CopyingHeap.cpp
@@ -1,8 +1,12 @@
+#include <vm/Print.h>
+
 #include "CopyingHeap.h"
 #include "CopyingCollector.h"
 
 #include "../vmobjects/AbstractObject.h"
-#include "../vm/Universe.h"
+
+#include <vm/Universe.h>
+#include <vm/Print.h>
 
 CopyingHeap::CopyingHeap(long objectSpaceSize) : Heap<CopyingHeap>(new CopyingCollector(this), objectSpaceSize) {
     size_t bufSize = objectSpaceSize;
@@ -31,7 +35,7 @@ AbstractVMObject* CopyingHeap::AllocateObject(size_t size) {
     AbstractVMObject* newObject = (AbstractVMObject*) nextFreePosition;
     nextFreePosition = (void*)((size_t)nextFreePosition + size);
     if (nextFreePosition > currentBufferEnd) {
-        Universe::ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
+        ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
         GetUniverse()->Quit(-1);
     }
     //let's see if we have to trigger the GC

--- a/src/memory/GenerationalCollector.cpp
+++ b/src/memory/GenerationalCollector.cpp
@@ -13,6 +13,7 @@
 #include "../vmobjects/VMClass.h"
 #include "../vmobjects/VMEvaluationPrimitive.h"
 #include <vmobjects/IntegerBox.h>
+#include <vm/IsValidObject.h>
 
 #define INITIAL_MAJOR_COLLECTION_THRESHOLD (5 * 1024 * 1024) //5 MB
 
@@ -27,7 +28,7 @@ static gc_oop_t mark_object(gc_oop_t oop) {
         return oop;
     
     AbstractVMObject* obj = AS_OBJ(oop);
-    assert(Universe::IsValidObject(obj));
+    assert(IsValidObject(obj));
     
 
     if (obj->GetGCField() & MASK_OBJECT_IS_MARKED)
@@ -45,7 +46,7 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
         return oop;
     
     AbstractVMObject* obj = AS_OBJ(oop);
-    assert(Universe::IsValidObject(obj));
+    assert(IsValidObject(obj));
 
 
     size_t gcField = obj->GetGCField();
@@ -109,7 +110,7 @@ void GenerationalCollector::MajorCollection() {
             heap->allocatedObjects->end(); objIter++) {
         
         AbstractVMObject* obj = *objIter;
-        assert(Universe::IsValidObject(obj));
+        assert(IsValidObject(obj));
         
         if (obj->GetGCField() & MASK_OBJECT_IS_MARKED) {
             survivors->push_back(obj);

--- a/src/memory/GenerationalHeap.cpp
+++ b/src/memory/GenerationalHeap.cpp
@@ -30,7 +30,7 @@ AbstractVMObject* GenerationalHeap::AllocateNurseryObject(size_t size) {
     AbstractVMObject* newObject = (AbstractVMObject*) nextFreePosition;
     nextFreePosition = (void*)((size_t)nextFreePosition + size);
     if ((size_t)nextFreePosition > nursery_end) {
-        Universe::ErrorPrint("Failed to allocate " + to_string(size) + " Bytes in nursery.\n");
+        ErrorPrint("Failed to allocate " + to_string(size) + " Bytes in nursery.\n");
         GetUniverse()->Quit(-1);
     }
     //let's see if we have to trigger the GC
@@ -42,7 +42,7 @@ AbstractVMObject* GenerationalHeap::AllocateNurseryObject(size_t size) {
 AbstractVMObject* GenerationalHeap::AllocateMatureObject(size_t size) {
     AbstractVMObject* newObject = (AbstractVMObject*) malloc(size);
     if (newObject == nullptr) {
-        Universe::ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
+        ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
         GetUniverse()->Quit(-1);
     }
     allocatedObjects->push_back(newObject);

--- a/src/memory/GenerationalHeap.h
+++ b/src/memory/GenerationalHeap.h
@@ -7,7 +7,7 @@
 #include "Heap.h"
 #include "../vmobjects/VMObjectBase.h"
 
-#include <vm/Universe.h>
+#include <vm/IsValidObject.h>
 
 #ifdef UNITTESTS
 struct VMObjectCompare {
@@ -46,7 +46,7 @@ private:
 };
 
 inline bool GenerationalHeap::isObjectInNursery(vm_oop_t obj) {
-    assert(Universe::IsValidObject(obj));
+    assert(IsValidObject(obj));
     
     return (size_t) obj >= (size_t)nursery && (size_t) obj < nursery_end;
 }
@@ -60,8 +60,8 @@ inline void GenerationalHeap::writeBarrier(VMObjectBase* holder, vm_oop_t refere
     writeBarrierCalledOn.insert(make_pair(holder, referencedObject));
 #endif
     
-    assert(Universe::IsValidObject(referencedObject));
-    assert(Universe::IsValidObject(holder));
+    assert(IsValidObject(referencedObject));
+    assert(IsValidObject(holder));
 
     size_t gcfield = *(((size_t*)holder)+1);
     if ((gcfield & 6 /* MASK_OBJECT_IS_OLD + MASK_SEEN_BY_WRITE_BARRIER */) == 2 /* MASK_OBJECT_IS_OLD */)

--- a/src/memory/Heap.cpp
+++ b/src/memory/Heap.cpp
@@ -26,6 +26,7 @@
 
 #include <iostream>
 #include <string.h>
+#include <vm/Print.h>
 
 #include "Heap.h"
 #include "../vmobjects/VMObject.h"
@@ -34,7 +35,7 @@
 template<class HEAP_T>
 void Heap<HEAP_T>::InitializeHeap(long objectSpaceSize) {
     if (theHeap) {
-        Universe::ErrorPrint("Warning, reinitializing already initialized Heap, "
+        ErrorPrint("Warning, reinitializing already initialized Heap, "
                              "all data will be lost!\n");
         delete theHeap;
     }

--- a/src/memory/MarkSweepHeap.cpp
+++ b/src/memory/MarkSweepHeap.cpp
@@ -1,6 +1,7 @@
 #include "MarkSweepHeap.h"
 
 #include <string.h>
+#include <vm/Print.h>
 
 #include "MarkSweepCollector.h"
 #include "../vmobjects/AbstractObject.h"
@@ -17,7 +18,7 @@ AbstractVMObject* MarkSweepHeap::AllocateObject(size_t size) {
     //TODO: PADDING wird eigentlich auch durch malloc erledigt
     AbstractVMObject* newObject = (AbstractVMObject*) malloc(size);
     if (newObject == nullptr) {
-        Universe::ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
+        ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
         GetUniverse()->Quit(-1);
     }
     spcAlloc += size;

--- a/src/primitives/Double.cpp
+++ b/src/primitives/Double.cpp
@@ -36,6 +36,7 @@
 #include <vmobjects/VMInteger.h>
 
 #include <vm/Universe.h>
+#include <vm/Globals.h>
 
 #include "Double.h"
 #include "../primitivesCore/Routine.h"

--- a/src/primitives/Integer.cpp
+++ b/src/primitives/Integer.cpp
@@ -39,6 +39,7 @@
 #include <vmobjects/VMInteger.h>
 #include <vmobjects/VMString.h>
 #include <vm/Universe.h>
+#include <vm/Globals.h>
 
 #include "Integer.h"
 #include "../primitivesCore/Routine.h"

--- a/src/primitives/System.cpp
+++ b/src/primitives/System.cpp
@@ -36,6 +36,7 @@
 #include <vmobjects/VMClass.h>
 #include <vmobjects/VMInteger.h>
 
+#include <vm/Print.h>
 #include <vm/Universe.h>
 
 #include "System.h"
@@ -101,29 +102,29 @@ void _System::Exit_(Interpreter*, VMFrame* frame) {
 void _System::PrintString_(Interpreter*, VMFrame* frame) {
     VMString* arg = static_cast<VMString*>(frame->Pop());
     std::string str = arg->GetStdString();
-    Universe::Print(str);
+    Print(str);
 }
 
 void _System::PrintNewline(Interpreter*, VMFrame*) {
-    Universe::Print("\n");
+    Print("\n");
 }
 
 void _System::PrintNewline_(Interpreter*, VMFrame* frame) {
     VMString* arg = static_cast<VMString*>(frame->Pop());
     std::string str = arg->GetStdString();
-    Universe::Print(str + "\n");
+    Print(str + "\n");
 }
 
 void _System::ErrorPrint_(Interpreter*, VMFrame* frame) {
     VMString* arg = static_cast<VMString*>(frame->Pop());
     std::string str = arg->GetStdString();
-    Universe::ErrorPrint(str);
+    ErrorPrint(str);
 }
 
 void _System::ErrorPrintNewline_(Interpreter*, VMFrame* frame) {
     VMString* arg = static_cast<VMString*>(frame->Pop());
     std::string str = arg->GetStdString();
-    Universe::ErrorPrint(str + "\n");
+    ErrorPrint(str + "\n");
 }
 
 

--- a/src/primitivesCore/PrimitiveLoader.cpp
+++ b/src/primitivesCore/PrimitiveLoader.cpp
@@ -39,6 +39,7 @@
 #include "PrimitiveLoader.h"
 #include "PrimitiveContainer.h"
 
+#include <vm/Print.h>
 #include <vmobjects/PrimitiveRoutine.h>
 
 PrimitiveLoader PrimitiveLoader::loader;
@@ -89,13 +90,13 @@ PrimitiveRoutine* PrimitiveLoader::getPrimitiveRoutine(const std::string& cname,
     PrimitiveRoutine* result;
     PrimitiveContainer* primitive = primitiveObjects[cname];
     if (!primitive) {
-        Universe::ErrorPrint("Primitive object not found for name: " + cname + "\n");
+        ErrorPrint("Primitive object not found for name: " + cname + "\n");
         return nullptr;
     }
     result = primitive->GetPrimitive(mname);
     if (!result) {
         if (isPrimitive) {
-            Universe::ErrorPrint("method " + mname + " not found in class " + cname + "\n");
+            ErrorPrint("method " + mname + " not found in class " + cname + "\n");
         }
         return nullptr;
     }

--- a/src/unitTests/CloneObjectsTest.cpp
+++ b/src/unitTests/CloneObjectsTest.cpp
@@ -5,6 +5,8 @@
  *      Author: christian
  */
 
+#include <vm/Universe.h>
+
 #include "CloneObjectsTest.h"
 
 #include "vmobjects/ObjectFormats.h"

--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -6,6 +6,7 @@
  */
 #include <vector>
 #include <algorithm>
+#include <vm/Universe.h>
 
 #include "WalkObjectsTest.h"
 #include "vmobjects/VMSymbol.h"

--- a/src/unitTests/WriteBarrierTest.cpp
+++ b/src/unitTests/WriteBarrierTest.cpp
@@ -1,3 +1,5 @@
+#include <vm/Universe.h>
+
 #include "WriteBarrierTest.h"
 #include "../src/vmobjects/VMSymbol.h"
 #include "../src/vmobjects/VMDouble.h"

--- a/src/unitTests/main.cpp
+++ b/src/unitTests/main.cpp
@@ -13,7 +13,7 @@
 #include <cppunit/BriefTestProgressListener.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 
-#include "vm/Universe.h"
+#include <vm/Universe.h>
 
 #include "WalkObjectsTest.h"
 #include "CloneObjectsTest.h"

--- a/src/vm/Globals.cpp
+++ b/src/vm/Globals.cpp
@@ -1,0 +1,26 @@
+#include <vm/Globals.h>
+
+GCObject* nilObject;
+GCObject* trueObject;
+GCObject* falseObject;
+
+GCClass* objectClass;
+GCClass* classClass;
+GCClass* metaClassClass;
+
+GCClass* nilClass;
+GCClass* integerClass;
+GCClass* arrayClass;
+GCClass* methodClass;
+GCClass* symbolClass;
+GCClass* primitiveClass;
+GCClass* stringClass;
+GCClass* systemClass;
+GCClass* blockClass;
+GCClass* doubleClass;
+
+GCClass* trueClass;
+GCClass* falseClass;
+
+GCSymbol* symbolIfTrue;
+GCSymbol* symbolIfFalse;

--- a/src/vm/Globals.h
+++ b/src/vm/Globals.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vmobjects/ObjectFormats.h>
+
+extern GCObject* nilObject;
+extern GCObject* trueObject;
+extern GCObject* falseObject;
+
+extern GCClass* objectClass;
+extern GCClass* classClass;
+extern GCClass* metaClassClass;
+
+extern GCClass* nilClass;
+extern GCClass* integerClass;
+extern GCClass* arrayClass;
+extern GCClass* methodClass;
+extern GCClass* symbolClass;
+extern GCClass* primitiveClass;
+extern GCClass* stringClass;
+extern GCClass* systemClass;
+extern GCClass* blockClass;
+extern GCClass* doubleClass;
+
+extern GCClass* trueClass;
+extern GCClass* falseClass;
+
+extern GCSymbol* symbolIfTrue;
+extern GCSymbol* symbolIfFalse;

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -1,0 +1,114 @@
+#include <vm/IsValidObject.h>
+#include <assert.h>
+#include <vmobjects/ObjectFormats.h>
+
+#include <vmobjects/VMSymbol.h>
+#include <vmobjects/VMObject.h>
+#include <vmobjects/VMMethod.h>
+#include <vmobjects/VMClass.h>
+#include <vmobjects/VMFrame.h>
+#include <vmobjects/VMArray.h>
+#include <vmobjects/VMBlock.h>
+#include <vmobjects/VMDouble.h>
+#include <vmobjects/VMInteger.h>
+#include <vmobjects/VMString.h>
+#include <vmobjects/VMEvaluationPrimitive.h>
+
+
+#if DEBUG
+    void* vt_array;
+    void* vt_block;
+    void* vt_class;
+    void* vt_double;
+    void* vt_eval_primitive;
+    void* vt_frame;
+    void* vt_integer;
+    void* vt_method;
+    void* vt_object;
+    void* vt_primitive;
+    void* vt_string;
+    void* vt_symbol;
+
+    bool IsValidObject(vm_oop_t obj) {
+        if (IS_TAGGED(obj))
+            return true;
+
+        if (obj == INVALID_VM_POINTER
+            // || obj == nullptr
+            ) {
+            assert(false);
+            return false;
+        }
+        
+        if (obj == nullptr)
+            return true;
+        
+        
+        if (vt_symbol == nullptr) // initialization not yet completed
+            return true;
+        
+        void* vt = *(void**) obj;
+        bool b = vt == vt_array    ||
+               vt == vt_block      ||
+               vt == vt_class      ||
+               vt == vt_double     ||
+               vt == vt_eval_primitive ||
+               vt == vt_frame      ||
+               vt == vt_integer    ||
+               vt == vt_method     ||
+               vt == vt_object     ||
+               vt == vt_primitive  ||
+               vt == vt_string     ||
+               vt == vt_symbol;
+        assert(b);
+        return b;
+    }
+
+    void set_vt_to_null() {
+        vt_array      = nullptr;
+        vt_block      = nullptr;
+        vt_class      = nullptr;
+        vt_double     = nullptr;
+        vt_eval_primitive = nullptr;
+        vt_frame      = nullptr;
+        vt_integer    = nullptr;
+        vt_method     = nullptr;
+        vt_object     = nullptr;
+        vt_primitive  = nullptr;
+        vt_string     = nullptr;
+        vt_symbol     = nullptr;
+    }
+
+    void obtain_vtables_of_known_classes(VMSymbol* className) {
+        VMArray* arr  = new (GetHeap<HEAP_CLS>()) VMArray(0, 0);
+        vt_array      = *(void**) arr;
+        
+        VMBlock* blck = new (GetHeap<HEAP_CLS>()) VMBlock();
+        vt_block      = *(void**) blck;
+        
+        vt_class      = *(void**) symbolClass;
+        
+        VMDouble* dbl = new (GetHeap<HEAP_CLS>()) VMDouble(0.0);
+        vt_double     = *(void**) dbl;
+        
+        VMEvaluationPrimitive* ev = new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(1);
+        vt_eval_primitive = *(void**) ev;
+        
+        VMFrame* frm  = new (GetHeap<HEAP_CLS>()) VMFrame(0, 0);
+        vt_frame      = *(void**) frm;
+        
+        VMInteger* i  = new (GetHeap<HEAP_CLS>()) VMInteger(0);
+        vt_integer    = *(void**) i;
+        
+        VMMethod* mth = new (GetHeap<HEAP_CLS>()) VMMethod(0, 0, 0);
+        vt_method     = *(void**) mth;
+        vt_object     = *(void**) nilObject;
+        
+        VMPrimitive* prm = new (GetHeap<HEAP_CLS>()) VMPrimitive(className);
+        vt_primitive  = *(void**) prm;
+        
+        VMString* str = new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);
+        vt_string     = *(void**) str;
+        vt_symbol     = *(void**) className;
+    }
+#endif

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -1,6 +1,8 @@
 #include <vm/IsValidObject.h>
+#include <misc/defs.h>
 #include <assert.h>
 #include <vmobjects/ObjectFormats.h>
+#include <vm/Globals.h>
 
 #include <vmobjects/VMSymbol.h>
 #include <vmobjects/VMObject.h>

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -16,101 +16,102 @@
 #include <vmobjects/VMString.h>
 #include <vmobjects/VMEvaluationPrimitive.h>
 
+void* vt_array;
+void* vt_block;
+void* vt_class;
+void* vt_double;
+void* vt_eval_primitive;
+void* vt_frame;
+void* vt_integer;
+void* vt_method;
+void* vt_object;
+void* vt_primitive;
+void* vt_string;
+void* vt_symbol;
 
-#if DEBUG
-    void* vt_array;
-    void* vt_block;
-    void* vt_class;
-    void* vt_double;
-    void* vt_eval_primitive;
-    void* vt_frame;
-    void* vt_integer;
-    void* vt_method;
-    void* vt_object;
-    void* vt_primitive;
-    void* vt_string;
-    void* vt_symbol;
-
-    bool IsValidObject(vm_oop_t obj) {
-        if (IS_TAGGED(obj))
-            return true;
-
-        if (obj == INVALID_VM_POINTER
-            // || obj == nullptr
-            ) {
-            assert(false);
-            return false;
-        }
-        
-        if (obj == nullptr)
-            return true;
-        
-        
-        if (vt_symbol == nullptr) // initialization not yet completed
-            return true;
-        
-        void* vt = *(void**) obj;
-        bool b = vt == vt_array    ||
-               vt == vt_block      ||
-               vt == vt_class      ||
-               vt == vt_double     ||
-               vt == vt_eval_primitive ||
-               vt == vt_frame      ||
-               vt == vt_integer    ||
-               vt == vt_method     ||
-               vt == vt_object     ||
-               vt == vt_primitive  ||
-               vt == vt_string     ||
-               vt == vt_symbol;
-        assert(b);
-        return b;
+bool IsValidObject(vm_oop_t obj) {
+    if (DEBUG) {
+        return true;
     }
+    
+    if (IS_TAGGED(obj))
+        return true;
 
-    void set_vt_to_null() {
-        vt_array      = nullptr;
-        vt_block      = nullptr;
-        vt_class      = nullptr;
-        vt_double     = nullptr;
-        vt_eval_primitive = nullptr;
-        vt_frame      = nullptr;
-        vt_integer    = nullptr;
-        vt_method     = nullptr;
-        vt_object     = nullptr;
-        vt_primitive  = nullptr;
-        vt_string     = nullptr;
-        vt_symbol     = nullptr;
+    if (obj == INVALID_VM_POINTER
+        // || obj == nullptr
+        ) {
+        assert(false);
+        return false;
     }
+    
+    if (obj == nullptr)
+        return true;
+    
+    
+    if (vt_symbol == nullptr) // initialization not yet completed
+        return true;
+    
+    void* vt = *(void**) obj;
+    bool b = vt == vt_array    ||
+           vt == vt_block      ||
+           vt == vt_class      ||
+           vt == vt_double     ||
+           vt == vt_eval_primitive ||
+           vt == vt_frame      ||
+           vt == vt_integer    ||
+           vt == vt_method     ||
+           vt == vt_object     ||
+           vt == vt_primitive  ||
+           vt == vt_string     ||
+           vt == vt_symbol;
+    assert(b);
+    return b;
+}
 
-    void obtain_vtables_of_known_classes(VMSymbol* className) {
-        VMArray* arr  = new (GetHeap<HEAP_CLS>()) VMArray(0, 0);
-        vt_array      = *(void**) arr;
-        
-        VMBlock* blck = new (GetHeap<HEAP_CLS>()) VMBlock();
-        vt_block      = *(void**) blck;
-        
-        vt_class      = *(void**) symbolClass;
-        
-        VMDouble* dbl = new (GetHeap<HEAP_CLS>()) VMDouble(0.0);
-        vt_double     = *(void**) dbl;
-        
-        VMEvaluationPrimitive* ev = new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(1);
-        vt_eval_primitive = *(void**) ev;
-        
-        VMFrame* frm  = new (GetHeap<HEAP_CLS>()) VMFrame(0, 0);
-        vt_frame      = *(void**) frm;
-        
-        VMInteger* i  = new (GetHeap<HEAP_CLS>()) VMInteger(0);
-        vt_integer    = *(void**) i;
-        
-        VMMethod* mth = new (GetHeap<HEAP_CLS>()) VMMethod(0, 0, 0);
-        vt_method     = *(void**) mth;
-        vt_object     = *(void**) nilObject;
-        
-        VMPrimitive* prm = new (GetHeap<HEAP_CLS>()) VMPrimitive(className);
-        vt_primitive  = *(void**) prm;
-        
-        VMString* str = new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);
-        vt_string     = *(void**) str;
-        vt_symbol     = *(void**) className;
-    }
-#endif
+void set_vt_to_null() {
+    vt_array      = nullptr;
+    vt_block      = nullptr;
+    vt_class      = nullptr;
+    vt_double     = nullptr;
+    vt_eval_primitive = nullptr;
+    vt_frame      = nullptr;
+    vt_integer    = nullptr;
+    vt_method     = nullptr;
+    vt_object     = nullptr;
+    vt_primitive  = nullptr;
+    vt_string     = nullptr;
+    vt_symbol     = nullptr;
+}
+
+void obtain_vtables_of_known_classes(VMSymbol* className) {
+    VMArray* arr  = new (GetHeap<HEAP_CLS>()) VMArray(0, 0);
+    vt_array      = *(void**) arr;
+    
+    VMBlock* blck = new (GetHeap<HEAP_CLS>()) VMBlock();
+    vt_block      = *(void**) blck;
+    
+    vt_class      = *(void**) symbolClass;
+    
+    VMDouble* dbl = new (GetHeap<HEAP_CLS>()) VMDouble(0.0);
+    vt_double     = *(void**) dbl;
+    
+    VMEvaluationPrimitive* ev = new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(1);
+    vt_eval_primitive = *(void**) ev;
+    
+    VMFrame* frm  = new (GetHeap<HEAP_CLS>()) VMFrame(0, 0);
+    vt_frame      = *(void**) frm;
+    
+    VMInteger* i  = new (GetHeap<HEAP_CLS>()) VMInteger(0);
+    vt_integer    = *(void**) i;
+    
+    VMMethod* mth = new (GetHeap<HEAP_CLS>()) VMMethod(0, 0, 0);
+    vt_method     = *(void**) mth;
+    vt_object     = *(void**) nilObject;
+    
+    VMPrimitive* prm = new (GetHeap<HEAP_CLS>()) VMPrimitive(className);
+    vt_primitive  = *(void**) prm;
+    
+    VMString* str = new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);
+    vt_string     = *(void**) str;
+    vt_symbol     = *(void**) className;
+}

--- a/src/vm/IsValidObject.h
+++ b/src/vm/IsValidObject.h
@@ -1,15 +1,23 @@
+#pragma once
+
+#include <misc/defs.h>
 #include <vmobjects/ObjectFormats.h>
 
-#if !DEBUG
-void set_vt_to_null() {}
+#if DEBUG
 
-void obtain_vtables_of_known_classes(VMSymbol* className) {}
+    bool IsValidObject(vm_oop_t obj);
 
-inline bool IsValidObject(vm_oop_t obj) {
-    return true;
-}
+    void set_vt_to_null();
+
+    void obtain_vtables_of_known_classes(VMSymbol* className);
 #else
-bool IsValidObject(vm_oop_t obj);
-void set_vt_to_null();
-void obtain_vtables_of_known_classes(VMSymbol* className);
+
+    void set_vt_to_null() {}
+
+    void obtain_vtables_of_known_classes(VMSymbol* className) {}
+
+    inline bool IsValidObject(vm_oop_t obj) {
+        return true;
+    }
+
 #endif

--- a/src/vm/IsValidObject.h
+++ b/src/vm/IsValidObject.h
@@ -3,21 +3,9 @@
 #include <misc/defs.h>
 #include <vmobjects/ObjectFormats.h>
 
-#if DEBUG
+bool IsValidObject(vm_oop_t obj);
 
-    bool IsValidObject(vm_oop_t obj);
+void set_vt_to_null();
 
-    void set_vt_to_null();
+void obtain_vtables_of_known_classes(VMSymbol* className);
 
-    void obtain_vtables_of_known_classes(VMSymbol* className);
-#else
-
-    void set_vt_to_null() {}
-
-    void obtain_vtables_of_known_classes(VMSymbol* className) {}
-
-    inline bool IsValidObject(vm_oop_t obj) {
-        return true;
-    }
-
-#endif

--- a/src/vm/IsValidObject.h
+++ b/src/vm/IsValidObject.h
@@ -1,0 +1,15 @@
+#include <vmobjects/ObjectFormats.h>
+
+#if !DEBUG
+void set_vt_to_null() {}
+
+void obtain_vtables_of_known_classes(VMSymbol* className) {}
+
+inline bool IsValidObject(vm_oop_t obj) {
+    return true;
+}
+#else
+bool IsValidObject(vm_oop_t obj);
+void set_vt_to_null();
+void obtain_vtables_of_known_classes(VMSymbol* className);
+#endif

--- a/src/vm/Print.cpp
+++ b/src/vm/Print.cpp
@@ -1,0 +1,19 @@
+#include <vm/Print.h>
+
+#include <mutex>
+#include <misc/defs.h>
+#include <iostream>
+
+using namespace std;
+
+static mutex output_mutex;
+
+void Print(StdString str) {
+    lock_guard<mutex> lock(output_mutex);
+    cout << str << flush;
+}
+
+void ErrorPrint(StdString str) {
+    lock_guard<mutex> lock(output_mutex);
+    cerr << str << flush;
+}

--- a/src/vm/Print.h
+++ b/src/vm/Print.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <misc/defs.h>
+
+void Print(StdString str);
+void ErrorPrint(StdString str);
+

--- a/src/vm/Shell.cpp
+++ b/src/vm/Shell.cpp
@@ -129,9 +129,9 @@ void Shell::Start(Interpreter* interp) {
         // Start the Interpreter
 
         if (dumpBytecodes > 1) {
-            interp->Start<true>();
+            interp->StartAndPrintBytecodes();
         } else {
-            interp->Start<false>();
+            interp->Start();
         }
 
         // Save the result of the run method

--- a/src/vm/Shell.cpp
+++ b/src/vm/Shell.cpp
@@ -128,7 +128,11 @@ void Shell::Start(Interpreter* interp) {
 
         // Start the Interpreter
 
-        interp->Start();
+        if (dumpBytecodes > 1) {
+            interp->Start<true>();
+        } else {
+            interp->Start<false>();
+        }
 
         // Save the result of the run method
         it = currentFrame->Pop();

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -34,6 +34,7 @@
 #include "Shell.h"
 #include <vm/IsValidObject.h>
 #include <vm/Print.h>
+#include <vm/Globals.h>
 
 #include <vmobjects/VMSymbol.h>
 #include <vmobjects/VMObject.h>
@@ -66,31 +67,6 @@ short dumpBytecodes;
 short gcVerbosity;
 
 Universe* Universe::theUniverse = nullptr;
-
-GCObject* nilObject;
-GCObject* trueObject;
-GCObject* falseObject;
-
-GCClass* objectClass;
-GCClass* classClass;
-GCClass* metaClassClass;
-
-GCClass* nilClass;
-GCClass* integerClass;
-GCClass* arrayClass;
-GCClass* methodClass;
-GCClass* symbolClass;
-GCClass* primitiveClass;
-GCClass* stringClass;
-GCClass* systemClass;
-GCClass* blockClass;
-GCClass* doubleClass;
-
-GCClass* trueClass;
-GCClass* falseClass;
-
-GCSymbol* symbolIfTrue;
-GCSymbol* symbolIfFalse;
 
 std::string bm_name;
 

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -319,9 +319,9 @@ vm_oop_t Universe::interpretMethod(VMObject* receiver, VMInvokable* initialize, 
   }
 
   if (dumpBytecodes > 1) {
-    return interpreter->Start<true>();
+    return interpreter->StartAndPrintBytecodes();
   }
-  return interpreter->Start<false>();
+  return interpreter->Start();
 }
 
 void Universe::initialize(long _argc, char** _argv) {

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -28,7 +28,6 @@
 
 //#define __DEBUG
 #include <map>
-#include <mutex>
 #include <vector>
 
 #include "../misc/defs.h"
@@ -142,11 +141,6 @@ public:
     map<StdString, stat_data> callStats;
 #endif
     //
-    
-    static bool IsValidObject(vm_oop_t obj);
-    
-    static void Print(StdString str);
-    static void ErrorPrint(StdString str);
 
 private:
     vm_oop_t interpretMethod(VMObject* receiver, VMInvokable* initialize, VMArray* argumentsArray);
@@ -171,8 +165,6 @@ private:
     vector<StdString> classPath;
 
     Interpreter* interpreter;
-    
-    static mutex output_mutex;
 };
 
 //Singleton accessor

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -46,32 +46,6 @@ class SourcecodeCompiler;
 extern short dumpBytecodes;
 extern short gcVerbosity;
 
-//global VMObjects
-extern GCObject* nilObject;
-extern GCObject* trueObject;
-extern GCObject* falseObject;
-
-extern GCClass* objectClass;
-extern GCClass* classClass;
-extern GCClass* metaClassClass;
-
-extern GCClass* nilClass;
-extern GCClass* integerClass;
-extern GCClass* arrayClass;
-extern GCClass* methodClass;
-extern GCClass* symbolClass;
-extern GCClass* primitiveClass;
-extern GCClass* stringClass;
-extern GCClass* systemClass;
-extern GCClass* blockClass;
-extern GCClass* doubleClass;
-
-extern GCClass* trueClass;
-extern GCClass* falseClass;
-
-extern GCSymbol* symbolIfTrue;
-extern GCSymbol* symbolIfFalse;
-
 using namespace std;
 class Universe {
 public:

--- a/src/vmobjects/AbstractObject.h
+++ b/src/vmobjects/AbstractObject.h
@@ -12,6 +12,7 @@
 
 
 #include <misc/defs.h>
+#include <vm/Print.h>
 #include <memory/GenerationalHeap.h>
 #include <memory/CopyingHeap.h>
 #include <memory/MarkSweepHeap.h>
@@ -25,6 +26,8 @@
 #define PADDED_SIZE(N) ((((uint32_t)N)+(sizeof(void*)-1) & ~(sizeof(void*)-1)))
 
 using namespace std;
+
+class Interpreter;
 
 //this is the base class for all VMObjects
 class AbstractVMObject: public VMObjectBase {
@@ -46,21 +49,21 @@ public:
     }
 
     inline virtual void SetObjectSize(size_t size) {
-        Universe::ErrorPrint("this object doesn't support SetObjectSize\n");
+        ErrorPrint("this object doesn't support SetObjectSize\n");
         throw "this object doesn't support SetObjectSize";
     }
 
     inline virtual long GetNumberOfFields() const {
-        Universe::ErrorPrint("this object doesn't support GetNumberOfFields\n");
+        ErrorPrint("this object doesn't support GetNumberOfFields\n");
         throw "this object doesn't support GetNumberOfFields";
     }
 
     virtual void SetNumberOfFields(long nof) {
-        Universe::ErrorPrint("this object doesn't support SetNumberOfFields\n");
+        ErrorPrint("this object doesn't support SetNumberOfFields\n");
         throw "this object doesn't support SetNumberOfFields";
     }
     inline virtual void SetClass(VMClass* cl) {
-        Universe::ErrorPrint("this object doesn't support SetClass\n");
+        ErrorPrint("this object doesn't support SetClass\n");
         throw "this object doesn't support SetClass";
     }
 
@@ -71,7 +74,7 @@ public:
     }
 
     inline virtual VMSymbol* GetFieldName(long index) const {
-        Universe::ErrorPrint("this object doesn't support GetFieldName\n");
+        ErrorPrint("this object doesn't support GetFieldName\n");
         throw "this object doesn't support GetFieldName";
     }
 

--- a/src/vmobjects/VMArray.h
+++ b/src/vmobjects/VMArray.h
@@ -26,8 +26,8 @@
  THE SOFTWARE.
  */
 
-#include "VMObject.h"
-#include "VMInteger.h"
+#include <vmobjects/VMObject.h>
+#include <vmobjects/VMInteger.h>
 
 class VMArray: public VMObject {
 public:

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -33,6 +33,7 @@
 
 #include <vm/Print.h>
 #include <vm/IsValidObject.h>
+#include <vm/Universe.h>
 #include <primitivesCore/PrimitiveLoader.h>
 
 

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -31,6 +31,8 @@
 #include "VMPrimitive.h"
 #include "PrimitiveRoutine.h"
 
+#include <vm/Print.h>
+#include <vm/IsValidObject.h>
 #include <primitivesCore/PrimitiveLoader.h>
 
 
@@ -149,7 +151,7 @@ void VMClass::SetInstanceInvokable(long index, VMInvokable* invokable) {
 }
 
 VMInvokable* VMClass::LookupInvokable(VMSymbol* name) const {
-    assert(Universe::IsValidObject(const_cast<VMClass*>(this)));
+    assert(IsValidObject(const_cast<VMClass*>(this)));
     
     VMInvokable* invokable = name->GetCachedInvokable(this);
     if (invokable != nullptr)
@@ -232,7 +234,7 @@ void VMClass::setPrimitives(const StdString& cname, bool classSide) {
         for (long i = 0; i < numInvokables; i++) {
             VMInvokable* anInvokable = current->GetInstanceInvokable(i);
 #ifdef __DEBUG
-            Universe::ErrorPrint("cname: >" + cname + "<\n" +
+            ErrorPrint("cname: >" + cname + "<\n" +
                                  anInvokable->GetSignature()->GetStdString() + "\n");
 #endif
 
@@ -257,7 +259,7 @@ void VMClass::setPrimitives(const StdString& cname, bool classSide) {
             } else {
                 if (anInvokable->IsPrimitive() && current == this) {
                     if (!routine || routine->isClassSide() == classSide) {
-                        Universe::ErrorPrint("could not load primitive '" +
+                        ErrorPrint("could not load primitive '" +
                                              selector + "' for class " +
                                              cname + "\n");
                         GetUniverse()->Quit(ERR_FAIL);

--- a/src/vmobjects/VMClass.h
+++ b/src/vmobjects/VMClass.h
@@ -32,6 +32,7 @@
 
 #include <misc/defs.h>
 #include <vm/IsValidObject.h>
+#include <vm/Globals.h>
 
 #if defined(_MSC_VER)   //Visual Studio
 #include <windows.h> 

--- a/src/vmobjects/VMClass.h
+++ b/src/vmobjects/VMClass.h
@@ -31,6 +31,7 @@
 #include "VMObject.h"
 
 #include <misc/defs.h>
+#include <vm/IsValidObject.h>
 
 #if defined(_MSC_VER)   //Visual Studio
 #include <windows.h> 
@@ -107,7 +108,7 @@ void VMClass::SetName(VMSymbol* nam) {
 }
 
 bool VMClass::HasSuperClass() const {
-    assert(Universe::IsValidObject(load_ptr(superClass)));
+    assert(IsValidObject(load_ptr(superClass)));
     return load_ptr(superClass) != load_ptr(nilObject);
 }
 

--- a/src/vmobjects/VMDouble.cpp
+++ b/src/vmobjects/VMDouble.cpp
@@ -26,7 +26,7 @@
 
 #include "VMDouble.h"
 
-#include <vm/Universe.h>
+#include <vm/Globals.h>
 
 VMDouble* VMDouble::Clone() const {
     return new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMDouble(*this);

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -167,18 +167,6 @@ long VMFrame::RemainingStackSize() const {
     return size - 1;
 }
 
-vm_oop_t VMFrame::Pop() {
-    vm_oop_t result = load_ptr(*stack_ptr);
-    stack_ptr--;
-    return result;
-}
-
-void VMFrame::Push(vm_oop_t obj) {
-    assert(RemainingStackSize() > 0);
-    ++stack_ptr;
-    store_ptr(*stack_ptr, obj);
-}
-
 void VMFrame::PrintBytecode() const {
     Disassembler::DumpMethod(GetMethod(), "  ");
 }
@@ -243,10 +231,6 @@ void VMFrame::ResetStackPointer() {
     locals = arguments + meth->GetNumberOfArguments();
     // Set the stack pointer to its initial value thereby clearing the stack
     stack_ptr = locals + meth->GetNumberOfLocals() - 1;
-}
-
-vm_oop_t VMFrame::GetStackElement(long index) const {
-    return load_ptr(stack_ptr[-index]);
 }
 
 vm_oop_t VMFrame::GetLocal(long index, long contextLevel) {

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -24,6 +24,8 @@
  THE SOFTWARE.
  */
 
+#include <vm/Globals.h>
+
 #include "VMFrame.h"
 #include "VMMethod.h"
 #include "VMObject.h"

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -33,7 +33,7 @@
 
 #include <compiler/Disassembler.h>
 
-#include <vm/Universe.h>
+#include <vm/Print.h>
 
 // when doesNotUnderstand or UnknownGlobal is sent, additional stack slots might
 // be necessary, as these cases are not taken into account when the stack
@@ -173,17 +173,17 @@ void VMFrame::PrintBytecode() const {
 
 static void print_oop(gc_oop_t vmo) {
     if (vmo == nullptr)
-        Universe::Print("nullptr\n");
+        Print("nullptr\n");
     else if (vmo == nilObject)
-        Universe::Print("NIL_OBJECT\n");
+        Print("NIL_OBJECT\n");
     else {
         AbstractVMObject* o = AS_OBJ(vmo);
-        Universe::Print(o->AsDebugString() + "\n");
+        Print(o->AsDebugString() + "\n");
     }
 }
 
 void VMFrame::PrintStack() const {
-    Universe::Print(GetMethod()->AsDebugString() + ", bc: " +
+    Print(GetMethod()->AsDebugString() + ", bc: " +
                     to_string(GetBytecodeIndex()) + "\n" + "Args: " +
                     to_string(GetMethod()->GetNumberOfArguments()) +
                     " Locals: " + to_string(GetMethod()->GetNumberOfLocals()) +
@@ -191,13 +191,13 @@ void VMFrame::PrintStack() const {
                     "\n");
 
     for (size_t i = 0; i < GetMethod()->GetNumberOfArguments(); i++) {
-        Universe::Print("   arg " + to_string(i) + ": ");
+        Print("   arg " + to_string(i) + ": ");
         print_oop(arguments[i]);
     }
     
     size_t local_offset = 0;
     for (size_t i = 0; i < GetMethod()->GetNumberOfLocals(); i++) {
-        Universe::Print("   loc " + to_string(i) + ": ");
+        Print("   loc " + to_string(i) + ": ");
         print_oop(locals[i]);
         local_offset++;
     }
@@ -205,9 +205,9 @@ void VMFrame::PrintStack() const {
     size_t max = GetMethod()->GetMaximumNumberOfStackElements();
     for (size_t i = 0; i < max; i++) {
         if (stack_ptr == &locals[local_offset + i]) {
-            Universe::Print("-> stk " + to_string(i) + ": ");
+            Print("-> stk " + to_string(i) + ": ");
         } else {
-            Universe::Print("   stk " + to_string(i) + ": ");
+            Print("   stk " + to_string(i) + ": ");
         }
         print_oop(locals[local_offset + i]);
     }
@@ -216,9 +216,9 @@ void VMFrame::PrintStack() const {
     size_t i = 0;
     while (&locals[local_offset + max + i] < end) {
         if (stack_ptr == &locals[local_offset + max + i]) {
-            Universe::Print("->estk " + to_string(i) + ": ");
+            Print("->estk " + to_string(i) + ": ");
         } else {
-            Universe::Print("  estk " + to_string(i) + ": ");
+            Print("  estk " + to_string(i) + ": ");
         }
         print_oop(locals[local_offset + max + i]);
         i++;
@@ -258,11 +258,11 @@ void VMFrame::PrintStackTrace() const {
     VMMethod* meth = GetMethod();
     
     if (meth->GetHolder() == load_ptr(nilObject)) {
-        Universe::Print("nil");
+        Print("nil");
     } else {
-        Universe::Print(meth->GetHolder()->GetName()->GetStdString());
+        Print(meth->GetHolder()->GetName()->GetStdString());
     }
-    Universe::Print(">>#" + meth->GetSignature()->GetStdString() + "\n");
+    Print(">>#" + meth->GetSignature()->GetStdString() + "\n");
     if (previousFrame) {
         load_ptr(previousFrame)->PrintStackTrace();
     }

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -235,20 +235,9 @@ void VMFrame::ResetStackPointer() {
     stack_ptr = locals + meth->GetNumberOfLocals() - 1;
 }
 
-vm_oop_t VMFrame::GetLocal(long index, long contextLevel) {
-    VMFrame* context = GetContextLevel(contextLevel);
-    return load_ptr(context->locals[index]);
-}
-
 void VMFrame::SetLocal(long index, long contextLevel, vm_oop_t value) {
     VMFrame* context = GetContextLevel(contextLevel);
     context->SetLocal(index, value);
-}
-
-vm_oop_t VMFrame::GetArgument(long index, long contextLevel) {
-    // get the context
-    VMFrame* context = GetContextLevel(contextLevel);
-    return load_ptr(context->arguments[index]);
 }
 
 void VMFrame::SetArgument(long index, long contextLevel, vm_oop_t value) {

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -26,7 +26,7 @@
  THE SOFTWARE.
  */
 
-#include "VMArray.h"
+#include <vmobjects/VMArray.h>
 
 class Universe;
 

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -72,9 +72,19 @@ public:
         return load_ptr(stack_ptr[-index]);
     }
     
-    vm_oop_t GetLocal(long, long);
+    inline vm_oop_t GetLocal(long index, long contextLevel) {
+        VMFrame* context = GetContextLevel(contextLevel);
+        return load_ptr(context->locals[index]);
+    }
+    
     void SetLocal(long index, long context_level, vm_oop_t);
-    vm_oop_t GetArgument(long, long);
+    
+    inline vm_oop_t GetArgument(long index, long contextLevel) {
+        // get the context
+        VMFrame* context = GetContextLevel(contextLevel);
+        return load_ptr(context->arguments[index]);
+    }
+    
     void SetArgument(long, long, vm_oop_t);
     void PrintStackTrace() const;
     long ArgumentStackIndex(long index) const;

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -51,12 +51,27 @@ public:
     VMFrame* GetOuterContext();
     inline VMMethod* GetMethod() const;
     void SetMethod(VMMethod*);
-    vm_oop_t Pop();
-    void Push(vm_oop_t);
+    
+    inline vm_oop_t Pop() {
+        vm_oop_t result = load_ptr(*stack_ptr);
+        stack_ptr--;
+        return result;
+    }
+    
+    inline void Push(vm_oop_t obj) {
+        assert(RemainingStackSize() > 0);
+        ++stack_ptr;
+        store_ptr(*stack_ptr, obj);
+    }
+
     void ResetStackPointer();
     inline long GetBytecodeIndex() const;
     inline void SetBytecodeIndex(long);
-    vm_oop_t GetStackElement(long) const;
+    
+    inline vm_oop_t GetStackElement(long index) const {
+        return load_ptr(stack_ptr[-index]);
+    }
+    
     vm_oop_t GetLocal(long, long);
     void SetLocal(long index, long context_level, vm_oop_t);
     vm_oop_t GetArgument(long, long);

--- a/src/vmobjects/VMInteger.cpp
+++ b/src/vmobjects/VMInteger.cpp
@@ -25,7 +25,7 @@
  */
 
 #include "VMInteger.h"
-#include "../vm/Universe.h"
+#include <vm/Globals.h>
 
 VMInteger* VMInteger::Clone() const {
     return new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMInteger(*this);

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -34,6 +34,7 @@
 #include "Signature.h"
 
 #include <vm/Universe.h>
+#include <vm/Print.h>
 
 #include <compiler/MethodGenerationContext.h>
 #include <vmobjects/IntegerBox.h>
@@ -163,7 +164,7 @@ void VMMethod::SetHolderAll(VMClass* hld) {
 vm_oop_t VMMethod::GetConstant(long indx) const {
     uint8_t bc = bytecodes[indx + 1];
     if (bc >= GetNumberOfIndexableFields()) {
-        Universe::ErrorPrint("Error: Constant index out of range\n");
+        ErrorPrint("Error: Constant index out of range\n");
         return nullptr;
     }
     return GetIndexableField(bc);

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -161,15 +161,6 @@ void VMMethod::SetHolderAll(VMClass* hld) {
     }
 }
 
-vm_oop_t VMMethod::GetConstant(long indx) const {
-    uint8_t bc = bytecodes[indx + 1];
-    if (bc >= GetNumberOfIndexableFields()) {
-        ErrorPrint("Error: Constant index out of range\n");
-        return nullptr;
-    }
-    return GetIndexableField(bc);
-}
-
 StdString VMMethod::AsDebugString() const {
     VMClass* holder = GetHolder();
     StdString holder_str;

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -27,6 +27,7 @@
  */
 
 #include <iostream>
+#include <vm/Print.h>
 
 #include "VMInvokable.h"
 #include "VMInteger.h"
@@ -51,7 +52,16 @@ public:
             long      GetNumberOfBytecodes() const;
     virtual void      SetHolder(VMClass* hld);
             void      SetHolderAll(VMClass* hld);
-            vm_oop_t GetConstant(long indx) const;
+    
+            inline vm_oop_t GetConstant(long indx) const {
+                uint8_t bc = bytecodes[indx + 1];
+                if (bc >= GetNumberOfIndexableFields()) {
+                    ErrorPrint("Error: Constant index out of range\n");
+                    return nullptr;
+                }
+                return GetIndexableField(bc);
+            }
+    
     inline  uint8_t   GetBytecode(long indx) const;
     inline  void      SetBytecode(long indx, uint8_t);
 #ifdef UNSAFE_FRAME_OPTIMIZATION
@@ -59,10 +69,16 @@ public:
     VMFrame* GetCachedFrame() const;
 #endif
     virtual void WalkObjects(walk_heap_fn);
-    inline  long      GetNumberOfIndexableFields() const;
+    
+    inline  long GetNumberOfIndexableFields() const {
+        //cannot be done using GetAdditionalSpaceConsumption,
+        //as bytecodes need space, too, and there might be padding
+        return INT_VAL(load_ptr(numberOfConstants));
+    }
+    
     virtual VMMethod* Clone() const;
 
-    inline  void      SetIndexableField(long idx, vm_oop_t item);
+    inline  void SetIndexableField(long idx, vm_oop_t item);
 
     virtual void Invoke(Interpreter* interp, VMFrame* frame);
 
@@ -75,7 +91,9 @@ private:
         return bytecodes;
     }
     
-    inline vm_oop_t GetIndexableField(long idx) const;
+    inline vm_oop_t GetIndexableField(long idx) const {
+        return load_ptr(indexableFields[idx]);
+    }
 
 private_testable:
     gc_oop_t numberOfLocals;
@@ -97,19 +115,8 @@ inline long VMMethod::GetNumberOfLocals() const {
     return INT_VAL(load_ptr(numberOfLocals));
 }
 
-long VMMethod::GetNumberOfIndexableFields() const {
-    //cannot be done using GetAdditionalSpaceConsumption,
-    //as bytecodes need space, too, and there might be padding
-    return INT_VAL(load_ptr(numberOfConstants));
-}
-
-
 inline long VMMethod::GetNumberOfArguments() const {
     return INT_VAL(load_ptr(numberOfArguments));
-}
-
-vm_oop_t VMMethod::GetIndexableField(long idx) const {
-    return load_ptr(indexableFields[idx]);
 }
 
 void VMMethod::SetIndexableField(long idx, vm_oop_t item) {

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -71,7 +71,10 @@ public:
     virtual StdString AsDebugString() const;
 
 private:
-    inline uint8_t* GetBytecodes() const;
+    inline uint8_t* GetBytecodes() const {
+        return bytecodes;
+    }
+    
     inline vm_oop_t GetIndexableField(long idx) const;
 
 private_testable:
@@ -100,9 +103,6 @@ long VMMethod::GetNumberOfIndexableFields() const {
     return INT_VAL(load_ptr(numberOfConstants));
 }
 
-uint8_t* VMMethod::GetBytecodes() const {
-    return bytecodes;
-}
 
 inline long VMMethod::GetNumberOfArguments() const {
     return INT_VAL(load_ptr(numberOfArguments));

--- a/src/vmobjects/VMObject.cpp
+++ b/src/vmobjects/VMObject.cpp
@@ -24,6 +24,8 @@
  THE SOFTWARE.
  */
 
+#include <vm/Universe.h>
+
 #include "VMObject.h"
 #include "VMClass.h"
 #include "VMSymbol.h"

--- a/src/vmobjects/VMObject.h
+++ b/src/vmobjects/VMObject.h
@@ -33,9 +33,9 @@
 #include "AbstractObject.h"
 
 #include <misc/defs.h>
-#include <vm/Universe.h>
 
 #include "ObjectFormats.h"
+#include <vm/IsValidObject.h>
 
 // this macro returns a shifted ptr by offset bytes
 #define SHIFTED_PTR(ptr, offset) ((void*)((size_t)(ptr)+(size_t)(offset)))
@@ -129,7 +129,7 @@ void VMObject::SetObjectSize(size_t size) {
 }
 
 VMClass* VMObject::GetClass() const {
-    assert(Universe::IsValidObject((VMObject*) load_ptr(clazz)));
+    assert(IsValidObject((VMObject*) load_ptr(clazz)));
     return load_ptr(clazz);
 }
 
@@ -149,11 +149,11 @@ long VMObject::GetAdditionalSpaceConsumption() const {
 
 vm_oop_t VMObject::GetField(long index) const {
     vm_oop_t result = load_ptr(FIELDS[index]);
-    assert(Universe::IsValidObject(result));
+    assert(IsValidObject(result));
     return result;
 }
 
 void VMObject::SetField(long index, vm_oop_t value) {
-    assert(Universe::IsValidObject(value));
+    assert(IsValidObject(value));
     store_ptr(FIELDS[index], value);
 }

--- a/src/vmobjects/VMPrimitive.cpp
+++ b/src/vmobjects/VMPrimitive.cpp
@@ -28,7 +28,7 @@
 #include "VMSymbol.h"
 #include "VMClass.h"
 
-#include "../vm/Universe.h"
+#include <vm/Print.h>
 
 //needed to instanciate the Routine object for the  empty routine
 #include "../primitivesCore/Routine.h"
@@ -63,7 +63,7 @@ void VMPrimitive::WalkObjects(walk_heap_fn walk) {
 
 void VMPrimitive::EmptyRoutine(Interpreter*, VMFrame*) {
     VMSymbol* sig = GetSignature();
-    Universe::ErrorPrint("undefined primitive called: " + sig->GetStdString() + "\n");
+    ErrorPrint("undefined primitive called: " + sig->GetStdString() + "\n");
 }
 
 StdString VMPrimitive::AsDebugString() const {


### PR DESCRIPTION
The most important bit of this PR is the refactoring to be able to have two separate compilations of the interpreter loop. One that prints bytecodes during execution, and the other optimized for performance, without the run-time checks for printing.

There are a few more changes that allow the compiler to inline more methods into the loop.

This also removes a remaining bit of the optimization for inlining `#ifTrue:`/`#ifFalse:`, which was mostly removed in #16 since it was broken.