### PR TITLE
Setup other benchmarks regularly run on other SOMs

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -21,7 +21,7 @@ benchmark_suites:
         command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
         iterations: 10
         benchmarks:
-            - Richards:     {extra_args:   1, machines: [yuria ]}
+            - Richards:     {iterations: 5, extra_args:   1, machines: [yuria3]}
             - DeltaBlue:    {extra_args:  50, machines: [yuria2]}
             - NBody:        {extra_args: 500, machines: [yuria3]}
             - JsonSmall:    {extra_args:   1, machines: [yuria ]}
@@ -30,7 +30,7 @@ benchmark_suites:
 
     micro:
         gauge_adapter: RebenchLog
-        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures:Examples/Benchmarks/TestSuite Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
         iterations: 10
         benchmarks:
             - Fannkuch:     {extra_args:  6, machines: [yuria ]}
@@ -53,6 +53,61 @@ benchmark_suites:
             - FieldLoop:    {extra_args:  1, machines: [yuria3]}
             - WhileLoop:    {extra_args: 10, machines: [yuria ]}
             - Mandelbrot:   {extra_args: 30, machines: [yuria2]}
+
+            - Test:     {invocations: 5, iterations: 1, machines: [yuria2]}
+            - TestGC:   {invocations: 5, iterations: 1, extra_args: 10, machines: [yuria2]}
+
+    awfy:
+        gauge_adapter: RebenchLog
+        command: "-cp Examples/AreWeFastYet/CD:Examples/AreWeFastYet/Havlak:Examples/AreWeFastYet/Core:Smalltalk Examples/AreWeFastYet/Harness.som --gc %(benchmark)s %(iterations)s "
+        iterations: 1
+        invocations: 5
+        benchmarks:
+            - CD:     {extra_args: 10, machines: [yuria2]}
+            - Havlak: {extra_args:  1, machines: [yuria3]}
+
+    micro-somsom:
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
+        iterations: 1
+        benchmarks:
+            - Loop:         {extra_args: 1, machines: [yuria3]}
+            - Queens:       {extra_args: 1, machines: [yuria2]}
+            - List:         {extra_args: 1, machines: [yuria2]}
+            - Recurse:      {extra_args: 1, machines: [yuria3]}
+            - Mandelbrot:   {extra_args: 3, machines: [yuria3]}
+
+    som-parse:
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/GraphSearch:Examples/Benchmarks/Json:Examples/Benchmarks/NBody:TestSuite:core-lib/SomSom/tests:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/primitives:core-lib/SomSom/src/compiler  Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
+        iterations: 1!
+        invocations: 5
+        benchmarks:
+            - SomParse: {extra_args: 1, machines: [yuria2]}
+            - SomInit:  {extra_args: 10000, machines: [yuria2]}
+
+    interpreter:
+        description: Basic interpreter benchmarks for comparing performance of most basic concepts.
+        gauge_adapter: RebenchLog
+        invocations: 5
+        command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 1"
+        benchmarks:
+            - ArgRead:                           {machines: [yuria2]}
+            - ArrayReadConst:                    {machines: [yuria2]}
+            - ArrayWriteConstConst:              {machines: [yuria2]}
+            - BlockSend0ConstReturn:             {machines: [yuria2]}
+            - Const:                             {machines: [yuria2]}
+            - FieldConstWrite:                   {machines: [yuria2]}
+            - FieldRead:                         {machines: [yuria2]}
+            - FieldReadIncWrite:                 {machines: [yuria2]}
+            - FieldReadWrite:                    {machines: [yuria3]}
+            - GlobalRead:                        {machines: [yuria3]}
+            - LocalConstWrite:                   {machines: [yuria3]}
+            - LocalRead:                         {machines: [yuria3]}
+            - LocalReadIncWrite:                 {machines: [yuria3]}
+            - LocalReadWrite:                    {machines: [yuria3]}
+            - SelfSend0:                         {machines: [yuria3]}
+            - SelfSend0BlockConstNonLocalReturn: {machines: [yuria3]}
 
 executors:
     som-gcc-generational-inttag:            {path: ., executable: som-gcc-generational-inttag           }
@@ -82,6 +137,10 @@ experiments:
         suites:
             - micro
             - macro
+            - awfy
+            - micro-somsom
+            - som-parse
+            - interpreter
         executions:
             - som-gcc-generational-inttag
             - som-gcc-generational-intbox

--- a/rebench.conf
+++ b/rebench.conf
@@ -64,7 +64,7 @@ benchmark_suites:
         invocations: 5
         benchmarks:
             - CD:     {extra_args: 10, machines: [yuria2]}
-            - Havlak: {extra_args:  1, machines: [yuria3]}
+            # - Havlak: {extra_args:  1, machines: [yuria3]}
 
     micro-somsom:
         gauge_adapter: RebenchLog

--- a/rebench.conf
+++ b/rebench.conf
@@ -54,7 +54,7 @@ benchmark_suites:
             - WhileLoop:    {extra_args: 10, machines: [yuria ]}
             - Mandelbrot:   {extra_args: 30, machines: [yuria2]}
 
-            - Test:     {invocations: 5, iterations: 1, machines: [yuria2]}
+            # - Test:     {invocations: 5, iterations: 1, machines: [yuria2]}
             - TestGC:   {invocations: 5, iterations: 1, extra_args: 10, machines: [yuria2]}
 
     awfy:


### PR DESCRIPTION
This adds the rebench.conf bits to run the other benchmarks we regularly run for other SOMs.

The two exceptions are Havlak, which is currently too slow, and Test, which does not pass with the standardized set of expectations, because it doesn't support all the optional features.