### PR TITLE
Add column tracking for better errors and modernize parser/lexer

### DIFF
--- a/src/compiler/Lexer.h
+++ b/src/compiler/Lexer.h
@@ -74,20 +74,51 @@ static const char* symnames[] = { "NONE", "Integer", "Not", "And", "Or", "Star",
         "NewTerm", "EndTerm", "Pound", "Primitive", "Separator", "STString",
         "Identifier", "Keyword", "KeywordSequence", "OperatorSequence" };
 
+class LexerState {
+public:
+    LexerState() : bufp(0), lineNumber(0), text(""), sym(Symbol::NONE), symc(0), startBufp(0) {}
+    
+    inline size_t incPtr() {
+        return incPtr(1);
+    }
+    
+    inline size_t incPtr(size_t val) {
+        size_t cur = bufp;
+        bufp += val;
+        startBufp = bufp;
+        return cur;
+    }
+
+    size_t lineNumber;
+    size_t bufp;
+    
+    Symbol sym;
+    char symc;
+    StdString text;
+    
+    size_t startBufp;
+};
+
+
 class Lexer {
 
 public:
     Lexer(istream& file);
     Lexer(const StdString& stream);
-    ~Lexer();
+
     Symbol GetSym(void);
     Symbol Peek(void);
     StdString GetText(void);
     StdString GetNextText(void);
     StdString GetRawBuffer(void);
+    StdString GetCurrentLine();
     
-    int GetCurrentLineNumber() {
-        return lineNumber;
+    size_t getCurrentColumn() {
+        return state.startBufp + 1 - state.text.length();
+    }
+    
+    size_t GetCurrentLineNumber() {
+        return state.lineNumber;
     }
     
     bool GetPeekDone() const {
@@ -111,20 +142,10 @@ private:
 
     istream& infile;
 
-    StdString stringInput;
-
-    Symbol sym;
-    char symc;
-
-    StdString text;
-    
-    int lineNumber;
     bool peekDone;
-    Symbol nextSym;
-    char nextSymc;
-    //^^
-    StdString nextText;
-
+    
+    LexerState state;
+    LexerState stateAfterPeek;
+    
     StdString buf;
-    unsigned int bufp;
 };

--- a/src/compiler/Parser.h
+++ b/src/compiler/Parser.h
@@ -47,6 +47,10 @@ public:
     void nestedBlock(MethodGenerationContext* mgenc);
     
 private:
+    __attribute__((noreturn)) void parseError(const char* msg, Symbol expected);
+    __attribute__((noreturn)) void parseError(const char* msg, Symbol* expected);
+    __attribute__((noreturn)) void parseError(const char* msg, StdString expected);
+    
     void GetSym();
     void Peek();
     void PeekForNextSymbolFromLexerIfNecessary();

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -53,8 +53,8 @@ public:
     //static methods
     static void Start(long argc, char** argv);
     static void BasicInit();
-    static void Quit(long);
-    static void ErrorExit(const char*);
+    __attribute__((noreturn)) static void Quit(long);
+    __attribute__((noreturn)) static void ErrorExit(const char*);
 
     vm_oop_t interpret(StdString className, StdString methodName);
 


### PR DESCRIPTION
This brings the parser a little more in line with PySOM and TruffleSOM.

Adding support for reporting columns in errors is the most relevant change.
Though, the code structure is now also more similar, and the errors are exiting SOM++ to avoid continuing parsing after an error.