### PR TITLE
Remove BytecodeGenerator class and start fixing clang-tidy issues

### DIFF
--- a/src/compiler/BytecodeGenerator.h
+++ b/src/compiler/BytecodeGenerator.h
@@ -34,24 +34,26 @@
 
 #include "MethodGenerationContext.h"
 
-class BytecodeGenerator {
-public:
-    void EmitHALT(MethodGenerationContext* mgenc);
-    void EmitDUP(MethodGenerationContext* mgenc);
-    void EmitPUSHLOCAL(MethodGenerationContext* mgenc,    long idx, int ctx);
-    void EmitPUSHARGUMENT(MethodGenerationContext* mgenc, long idx, int ctx);
-    void EmitPUSHFIELD(MethodGenerationContext* mgenc, VMSymbol* field);
-    void EmitPUSHBLOCK(MethodGenerationContext* mgenc, VMMethod* block);
-    void EmitPUSHCONSTANT(MethodGenerationContext* mgenc, vm_oop_t cst);
-    void EmitPUSHCONSTANT(MethodGenerationContext* mgenc, uint8_t literalIndex);
-    void EmitPUSHCONSTANTString(MethodGenerationContext* mgenc, VMString* str);
-    void EmitPUSHGLOBAL(MethodGenerationContext* mgenc, VMSymbol* global);
-    void EmitPOP(MethodGenerationContext* mgenc);
-    void EmitPOPLOCAL(MethodGenerationContext* mgenc,    long idx, int ctx);
-    void EmitPOPARGUMENT(MethodGenerationContext* mgenc, long idx, int ctx);
-    void EmitPOPFIELD(MethodGenerationContext* mgenc, VMSymbol* field);
-    void EmitSEND(MethodGenerationContext* mgenc, VMSymbol* msg);
-    void EmitSUPERSEND(MethodGenerationContext* mgenc, VMSymbol* msg);
-    void EmitRETURNLOCAL(MethodGenerationContext* mgenc);
-    void EmitRETURNNONLOCAL(MethodGenerationContext* mgenc);
-};
+void Emit1(MethodGenerationContext* mgenc, uint8_t bytecode, size_t stackEffect);
+void Emit2(MethodGenerationContext* mgenc, uint8_t bytecode, size_t idx, size_t stackEffect);
+void Emit3(MethodGenerationContext* mgenc, uint8_t bytecode, size_t idx, size_t ctx, size_t stackEffect);
+
+
+void EmitHALT(MethodGenerationContext* mgenc);
+void EmitDUP(MethodGenerationContext* mgenc);
+void EmitPUSHLOCAL(MethodGenerationContext* mgenc,    long idx, int ctx);
+void EmitPUSHARGUMENT(MethodGenerationContext* mgenc, long idx, int ctx);
+void EmitPUSHFIELD(MethodGenerationContext* mgenc, VMSymbol* field);
+void EmitPUSHBLOCK(MethodGenerationContext* mgenc, VMMethod* block);
+void EmitPUSHCONSTANT(MethodGenerationContext* mgenc, vm_oop_t cst);
+void EmitPUSHCONSTANT(MethodGenerationContext* mgenc, uint8_t literalIndex);
+void EmitPUSHCONSTANTString(MethodGenerationContext* mgenc, VMString* str);
+void EmitPUSHGLOBAL(MethodGenerationContext* mgenc, VMSymbol* global);
+void EmitPOP(MethodGenerationContext* mgenc);
+void EmitPOPLOCAL(MethodGenerationContext* mgenc,    long idx, int ctx);
+void EmitPOPARGUMENT(MethodGenerationContext* mgenc, long idx, int ctx);
+void EmitPOPFIELD(MethodGenerationContext* mgenc, VMSymbol* field);
+void EmitSEND(MethodGenerationContext* mgenc, VMSymbol* msg);
+void EmitSUPERSEND(MethodGenerationContext* mgenc, VMSymbol* msg);
+void EmitRETURNLOCAL(MethodGenerationContext* mgenc);
+void EmitRETURNNONLOCAL(MethodGenerationContext* mgenc);

--- a/src/compiler/Disassembler.cpp
+++ b/src/compiler/Disassembler.cpp
@@ -24,8 +24,8 @@
  THE SOFTWARE.
  */
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "Disassembler.h"
 

--- a/src/compiler/Lexer.h
+++ b/src/compiler/Lexer.h
@@ -106,11 +106,22 @@ public:
     Lexer(istream& file);
     Lexer(const StdString& stream);
 
-    Symbol GetSym(void);
-    Symbol Peek(void);
-    StdString GetText(void);
-    StdString GetNextText(void);
-    StdString GetRawBuffer(void);
+    Symbol GetSym();
+    Symbol Peek();
+    
+    StdString GetText() const {
+        return state.text;
+    }
+    
+    StdString GetNextText() const {
+        return stateAfterPeek.text;
+    }
+    
+    StdString GetRawBuffer() const {
+        //for debug
+        return StdString(buf);
+    }
+    
     StdString GetCurrentLine();
     
     size_t getCurrentColumn() {
@@ -126,9 +137,9 @@ public:
     }
 
 private:
-    size_t fillBuffer(void);
-    void skipWhiteSpace(void);
-    void skipComment(void);
+    size_t fillBuffer();
+    void skipWhiteSpace();
+    void skipComment();
     
     bool hasMoreInput();
     
@@ -138,7 +149,7 @@ private:
     void lexStringChar();
     void lexString();
     
-    bool nextWordInBufferIs(StdString word);
+    bool nextWordInBufferIsPrimitive();
 
     istream& infile;
 

--- a/src/compiler/Parser.h
+++ b/src/compiler/Parser.h
@@ -125,6 +125,4 @@ private:
     Symbol nextSym;
 
     StdString nextText;
-
-    BytecodeGenerator* bcGen;
 };

--- a/src/misc/defs.h
+++ b/src/misc/defs.h
@@ -26,8 +26,8 @@
  THE SOFTWARE.
  */
 
-#include <stdint.h>
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
 #include <string>
 
 // Macro Debugging

--- a/src/unitTests/BasicInterpreterTests.h
+++ b/src/unitTests/BasicInterpreterTests.h
@@ -190,6 +190,7 @@ private:
     // The Unit Test harness will initialize Universe for a standard run.
     // This is different from other SOMs.
     vm_oop_t result = GetUniverse()->interpret(data.className, data.methodName);
+    CPPUNIT_ASSERT(result != nullptr);
     assertEqualsSOMValue(result, data);
   }
 };

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -25,6 +25,8 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  */
+#include <misc/defs.h>
+
 //some MACROS for integer tagging
 /**
  * max value for tagged integers

--- a/src/vmobjects/VMArray.cpp
+++ b/src/vmobjects/VMArray.cpp
@@ -23,46 +23,54 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  */
+#include <cstddef>
+#include <cstring>
+#include <string>
 
-#include "VMArray.h"
-#include "VMClass.h"
+#include <memory/Heap.h>
+#include <misc/defs.h>
 
+#include <vm/Globals.h>
 #include <vm/Universe.h>
 
-const long VMArray::VMArrayNumberOfFields = 0;
+#include <vmobjects/ObjectFormats.h>
+#include <vmobjects/VMArray.h>
+#include <vmobjects/VMObject.h>
 
-VMArray::VMArray(long size, long nof) :
+const size_t VMArray::VMArrayNumberOfFields = 0;
+
+VMArray::VMArray(size_t size, size_t nof) :
         VMObject(nof + VMArrayNumberOfFields) {
     // initialize fields with nilObject
     // SetIndexableField is not used to prevent the write barrier to be called
     // too often.
     // Fields start after clazz and other fields (GetNumberOfFields)
     gc_oop_t* arrFields = FIELDS + GetNumberOfFields();
-    for (long i = 0; i < size; ++i) {
+    for (size_t i = 0; i < size; ++i) {
         arrFields[i] = nilObject;
     }
 }
 
-vm_oop_t VMArray::GetIndexableField(long idx) const {
+vm_oop_t VMArray::GetIndexableField(size_t idx) const {
     if (unlikely(idx > GetNumberOfIndexableFields())) {
-        GetUniverse()->ErrorExit(("Array index out of bounds: Accessing " +
-                                 to_string(idx) + ", but array size is only " +
-                                 to_string(GetNumberOfIndexableFields()) + "\n").c_str());
+        Universe::ErrorExit(("Array index out of bounds: Accessing " +
+                             to_string(idx) + ", but array size is only " +
+                             to_string(GetNumberOfIndexableFields()) + "\n").c_str());
     }
     return GetField(GetNumberOfFields() + idx);
 }
 
-void VMArray::SetIndexableField(long idx, vm_oop_t value) {
+void VMArray::SetIndexableField(size_t idx, vm_oop_t value) {
     if (unlikely(idx > GetNumberOfIndexableFields())) {
-        GetUniverse()->ErrorExit(("Array index out of bounds: Accessing " +
-                                  to_string(idx) + ", but array size is only " +
-                                  to_string(GetNumberOfIndexableFields()) + "\n").c_str());
+        Universe::ErrorExit(("Array index out of bounds: Accessing " +
+                             to_string(idx) + ", but array size is only " +
+                             to_string(GetNumberOfIndexableFields()) + "\n").c_str());
     }
     SetField(GetNumberOfFields() + idx, value);
 }
 
 VMArray* VMArray::CopyAndExtendWith(vm_oop_t item) const {
-    size_t fields = GetNumberOfIndexableFields();
+    const size_t fields = GetNumberOfIndexableFields();
     VMArray* result = GetUniverse()->NewArray(fields + 1);
     CopyIndexableFieldsTo(result);
     result->SetIndexableField(fields, item);
@@ -70,36 +78,36 @@ VMArray* VMArray::CopyAndExtendWith(vm_oop_t item) const {
 }
 
 VMArray* VMArray::Clone() const {
-    long addSpace = objectSize - sizeof(VMArray);
-    VMArray* clone = new (GetHeap<HEAP_CLS>(), addSpace ALLOC_MATURE) VMArray(*this);
+    const size_t addSpace = objectSize - sizeof(VMArray);
+    auto* clone = new (GetHeap<HEAP_CLS>(), addSpace ALLOC_MATURE) VMArray(*this);
     void* destination  = SHIFTED_PTR(clone, sizeof(VMArray));
     const void* source = SHIFTED_PTR(this, sizeof(VMArray));
-    size_t noBytes = GetObjectSize() - sizeof(VMArray);
+    const size_t noBytes = GetObjectSize() - sizeof(VMArray);
     memcpy(destination, source, noBytes);
     return clone;
 }
 
 void VMArray::MarkObjectAsInvalid() {
     VMObject::MarkObjectAsInvalid();
-    long numIndexableFields = GetNumberOfIndexableFields();
-    for (long i = 0; i < numIndexableFields; ++i) {
+    const size_t numIndexableFields = GetNumberOfIndexableFields();
+    for (size_t i = 0; i < numIndexableFields; ++i) {
         FIELDS[i] = INVALID_GC_POINTER;
     }
 }
 
 void VMArray::CopyIndexableFieldsTo(VMArray* to) const {
-    long numIndexableFields = GetNumberOfIndexableFields();
-    for (long i = 0; i < numIndexableFields; ++i) {
+    const size_t numIndexableFields = GetNumberOfIndexableFields();
+    for (size_t i = 0; i < numIndexableFields; ++i) {
         to->SetIndexableField(i, GetIndexableField(i));
     }
 }
 
 void VMArray::WalkObjects(walk_heap_fn walk) {
     clazz = static_cast<GCClass*>(walk(clazz));
-    long numFields          = GetNumberOfFields();
-    long numIndexableFields = GetNumberOfIndexableFields();
+    const size_t numFields          = GetNumberOfFields();
+    const size_t numIndexableFields = GetNumberOfIndexableFields();
     gc_oop_t* fields = FIELDS;
-    for (long i = 0; i < numFields + numIndexableFields; i++) {
+    for (size_t i = 0; i < numFields + numIndexableFields; i++) {
         fields[i] = walk(fields[i]);
     }
 }

--- a/src/vmobjects/VMArray.h
+++ b/src/vmobjects/VMArray.h
@@ -25,6 +25,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  */
+#include <cstddef>
 
 #include <vmobjects/VMObject.h>
 #include <vmobjects/VMInteger.h>
@@ -33,14 +34,17 @@ class VMArray: public VMObject {
 public:
     typedef GCArray Stored;
     
-    VMArray(long size, long nof = 0);
+    VMArray(size_t size, size_t nof = 0);
 
     virtual void WalkObjects(walk_heap_fn);
 
-    inline  long GetNumberOfIndexableFields() const;
+    inline  size_t GetNumberOfIndexableFields() const {
+        return GetAdditionalSpaceConsumption() / sizeof(VMObject*);
+    }
+    
     VMArray* CopyAndExtendWith(vm_oop_t) const;
-    vm_oop_t GetIndexableField(long idx) const;
-    void SetIndexableField(long idx, vm_oop_t value);
+    vm_oop_t GetIndexableField(size_t idx) const;
+    void SetIndexableField(size_t idx, vm_oop_t value);
     void CopyIndexableFieldsTo(VMArray*) const;
     virtual VMArray* Clone() const;
     
@@ -49,9 +53,5 @@ public:
 private:
     virtual void MarkObjectAsInvalid();
     
-    static const long VMArrayNumberOfFields;
+    static const size_t VMArrayNumberOfFields;
 };
-
-long VMArray::GetNumberOfIndexableFields() const {
-    return GetAdditionalSpaceConsumption() / sizeof(VMObject*);
-}

--- a/src/vmobjects/VMObject.cpp
+++ b/src/vmobjects/VMObject.cpp
@@ -23,6 +23,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  */
+#include <cstddef>
 
 #include <vm/Universe.h>
 
@@ -33,9 +34,9 @@
 #include "VMInvokable.h"
 
 // clazz is the only field of VMObject so
-const long VMObject::VMObjectNumberOfFields = 0;
+const size_t VMObject::VMObjectNumberOfFields = 0;
 
-VMObject::VMObject(long numberOfFields) {
+VMObject::VMObject(size_t numberOfFields) {
     // this line would be needed if the VMObject** is used instead of the macro:
     // FIELDS = (VMObject**)&clazz;
     SetNumberOfFields(numberOfFields + VMObjectNumberOfFields);

--- a/src/vmobjects/VMObject.h
+++ b/src/vmobjects/VMObject.h
@@ -25,7 +25,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  */
-
+#include <cstddef>
 #include <vector>
 #include <iostream>
 #include <cstring>
@@ -64,7 +64,7 @@ class VMObject: public AbstractVMObject {
 public:
     typedef GCObject Stored;
     
-    VMObject(long numberOfFields = 0);
+    VMObject(size_t numberOfFields = 0);
 
     virtual int64_t GetHash() { return hash; }
     virtual inline VMClass*  GetClass() const;
@@ -72,8 +72,18 @@ public:
     virtual        VMSymbol* GetFieldName(long index) const;
     virtual inline long      GetNumberOfFields() const;
     virtual        void      SetNumberOfFields(long nof);
-            inline vm_oop_t  GetField(long index) const;
-            inline void      SetField(long index, vm_oop_t value);
+    
+    inline vm_oop_t GetField(size_t index) const {
+        vm_oop_t result = load_ptr(FIELDS[index]);
+        assert(IsValidObject(result));
+        return result;
+    }
+    
+    inline void SetField(size_t index, vm_oop_t value) {
+        assert(IsValidObject(value));
+        store_ptr(FIELDS[index], value);
+    }
+    
     virtual        void      Assert(bool value) const;
     virtual        void      WalkObjects(walk_heap_fn walk);
     virtual        VMObject* Clone() const;
@@ -117,7 +127,7 @@ protected_testable:
     // clazz has index -1.
     
 private:
-    static const long VMObjectNumberOfFields;
+    static const size_t VMObjectNumberOfFields;
 };
 
 size_t VMObject::GetObjectSize() const {
@@ -145,15 +155,4 @@ long VMObject::GetAdditionalSpaceConsumption() const {
     return (objectSize
             - (sizeof(VMObject)
                + sizeof(VMObject*) * GetNumberOfFields()));
-}
-
-vm_oop_t VMObject::GetField(long index) const {
-    vm_oop_t result = load_ptr(FIELDS[index]);
-    assert(IsValidObject(result));
-    return result;
-}
-
-void VMObject::SetField(long index, vm_oop_t value) {
-    assert(IsValidObject(value));
-    store_ptr(FIELDS[index], value);
 }


### PR DESCRIPTION
These are some cleanup/simplification changes.

The goal is to eventually be able to run clang-tidy in CI, but I'll only do small cleanups here and there, step wise.