### PR TITLE
Adapt VMInvokable hierarchy to not be VMObjects

### DIFF
--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -47,26 +47,22 @@ MethodGenerationContext::MethodGenerationContext() :
 VMMethod* MethodGenerationContext::Assemble() {
     // create a method instance with the given number of bytecodes and literals
     size_t numLiterals = literals.size();
-
-    VMMethod* meth = GetUniverse()->NewMethod(signature, bytecode.size(),
-            numLiterals);
-
-    // populate the fields that are immediately available
     size_t numLocals = locals.size();
-    meth->SetNumberOfLocals(numLocals);
-
-    meth->SetMaximumNumberOfStackElements(maxStackDepth);
+    VMMethod* meth = GetUniverse()->NewMethod(signature, bytecode.size(),
+            numLiterals, numLocals, maxStackDepth);
 
     // copy literals into the method
     for (int i = 0; i < numLiterals; i++) {
         vm_oop_t l = literals[i];
         meth->SetIndexableField(i, l);
     }
+
     // copy bytecodes into method
     size_t bc_size = bytecode.size();
     for (size_t i = 0; i < bc_size; i++) {
         meth->SetBytecode(i, bytecode[i]);
     }
+
     // return the method - the holder field is to be set later on!
     return meth;
 }

--- a/src/misc/debug.cpp
+++ b/src/misc/debug.cpp
@@ -1,4 +1,6 @@
-#include "../vmobjects/AbstractObject.h"
+#include <string>
+
+#include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMClass.h"
 #include "../vmobjects/VMSymbol.h"
 #include "debug.h"

--- a/src/unitTests/CloneObjectsTest.cpp
+++ b/src/unitTests/CloneObjectsTest.cpp
@@ -111,7 +111,7 @@ void CloneObjectsTest::testCloneArray() {
 
 void CloneObjectsTest::testCloneBlock() {
     VMSymbol* methodSymbol = NewSymbol("someMethod");
-    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0);
+    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0);
     VMBlock* orig = GetUniverse()->NewBlock(method,
             GetUniverse()->GetInterpreter()->GetFrame(),
             method->GetNumberOfArguments());
@@ -128,9 +128,6 @@ void CloneObjectsTest::testClonePrimitive() {
     VMSymbol* primitiveSymbol = NewSymbol("myPrimitive");
     VMPrimitive* orig = VMPrimitive::GetEmptyPrimitive(primitiveSymbol, false);
     VMPrimitive* clone = orig->Clone();
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("class differs!!", orig->clazz, clone->clazz);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->objectSize, clone->objectSize);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfFields differs!!", orig->numberOfFields, clone->numberOfFields);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("signature differs!!", orig->signature, clone->signature);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("holder differs!!", orig->holder, clone->holder);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("empty differs!!", orig->empty, clone->empty);
@@ -141,9 +138,6 @@ void CloneObjectsTest::testCloneEvaluationPrimitive() {
     VMEvaluationPrimitive* orig = new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(1);
     VMEvaluationPrimitive* clone = orig->Clone();
 
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("class differs!!", orig->clazz, clone->clazz);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->objectSize, clone->objectSize);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfFields differs!!", orig->numberOfFields, clone->numberOfFields);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("signature differs!!", orig->signature, clone->signature);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("holder differs!!", orig->holder, clone->holder);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("empty differs!!", orig->empty, clone->empty);
@@ -153,7 +147,7 @@ void CloneObjectsTest::testCloneEvaluationPrimitive() {
 
 void CloneObjectsTest::testCloneFrame() {
     VMSymbol* methodSymbol = NewSymbol("frameMethod");
-    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0);
+    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0);
     VMFrame* orig = GetUniverse()->NewFrame(nullptr, method);
     VMFrame* context = orig->Clone();
     orig->SetContext(context);
@@ -174,29 +168,20 @@ void CloneObjectsTest::testCloneFrame() {
 
 void CloneObjectsTest::testCloneMethod() {
     VMSymbol* methodSymbol = NewSymbol("myMethod");
-    VMMethod* orig = GetUniverse()->NewMethod(methodSymbol, 0, 0);
+    VMMethod* orig = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0);
     VMMethod* clone = orig->Clone();
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("class differs!!", orig->clazz, clone->clazz);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->objectSize, clone->objectSize);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfFields differs!!", orig->numberOfFields, clone->numberOfFields);
-
     CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfLocals differs!!",
-            INT_VAL(load_ptr(orig->numberOfLocals)),
-            INT_VAL(load_ptr(clone->numberOfLocals)));
+            orig->numberOfLocals, clone->numberOfLocals);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("bcLength differs!!",
-            INT_VAL(load_ptr(orig->bcLength)),
-            INT_VAL(load_ptr(clone->bcLength)));
+            orig->bcLength, clone->bcLength);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("maximumNumberOfStackElements differs!!",
-            INT_VAL(load_ptr(orig->maximumNumberOfStackElements)),
-            INT_VAL(load_ptr(clone->maximumNumberOfStackElements)));
+            orig->maximumNumberOfStackElements, clone->maximumNumberOfStackElements);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfArguments differs!!",
-            INT_VAL(load_ptr(orig->numberOfArguments)),
-            INT_VAL(load_ptr(clone->numberOfArguments)));
+            orig->numberOfArguments, clone->numberOfArguments);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfConstants differs!!",
-            INT_VAL(load_ptr(orig->numberOfConstants)),
-            INT_VAL(load_ptr(clone->numberOfConstants)));
+            orig->numberOfConstants, clone->numberOfConstants);
 
     CPPUNIT_ASSERT_EQUAL_MESSAGE("GetHolder() differs!!", orig->GetHolder(), clone->GetHolder());
     CPPUNIT_ASSERT_EQUAL_MESSAGE("GetSignature() differs!!", orig->GetSignature(), clone->GetSignature());

--- a/src/unitTests/WriteBarrierTest.cpp
+++ b/src/unitTests/WriteBarrierTest.cpp
@@ -67,7 +67,7 @@ void WriteBarrierTest::testWriteBlock() {
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
 
     VMSymbol* methodSymbol = NewSymbol("someMethod");
-    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0);
+    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0);
     VMBlock* block = GetUniverse()->NewBlock(method,
             GetUniverse()->GetInterpreter()->GetFrame(),
             method->GetNumberOfArguments());
@@ -115,8 +115,6 @@ void WriteBarrierTest::testWriteMethod() {
     VMMethod* method = GetUniverse()->GetInterpreter()->GetFrame()->GetMethod()->Clone();
     method->SetHolder(load_ptr(integerClass));
     TEST_WB_CALLED("VMMethod failed to call writeBarrier on SetHolder", method, load_ptr(integerClass));
-    method->SetSignature(method->GetSignature());
-    TEST_WB_CALLED("VMMethod failed to call writeBarrier on SetSignature", method, method->GetSignature());
 }
 
 void WriteBarrierTest::testWriteEvaluationPrimitive() {
@@ -128,7 +126,6 @@ void WriteBarrierTest::testWriteEvaluationPrimitive() {
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
     VMEvaluationPrimitive* evPrim = new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(1);
     TEST_WB_CALLED("VMEvaluationPrimitive failed to call writeBarrier when creating", evPrim, evPrim->GetClass());
-    TEST_WB_CALLED("VMEvaluationPrimitive failed to call writeBarrier when creating", evPrim, load_ptr(evPrim->numberOfArguments));
 }
 
 void WriteBarrierTest::testWriteClass() {

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -104,7 +104,7 @@ void obtain_vtables_of_known_classes(VMSymbol* className) {
     VMInteger* i  = new (GetHeap<HEAP_CLS>()) VMInteger(0);
     vt_integer    = *(void**) i;
     
-    VMMethod* mth = new (GetHeap<HEAP_CLS>()) VMMethod(0, 0);
+    VMMethod* mth = new (GetHeap<HEAP_CLS>()) VMMethod(nullptr, 0, 0, 0, 0);
     vt_method     = *(void**) mth;
     vt_object     = *(void**) nilObject;
     

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -75,7 +75,7 @@ public:
     VMBlock* NewBlock(VMMethod*, VMFrame*, long);
     VMClass* NewClass(VMClass*) const;
     VMFrame* NewFrame(VMFrame*, VMMethod*) const;
-    VMMethod* NewMethod(VMSymbol*, size_t, size_t) const;
+    VMMethod* NewMethod(VMSymbol*, size_t numberOfBytecodes, size_t numberOfConstants, size_t numLocals, size_t maxStackDepth) const;
     VMObject* NewInstance(VMClass*) const;
     VMObject* NewInstanceWithoutFields() const;
     VMInteger* NewInteger(int64_t) const;

--- a/src/vmobjects/AbstractObject.h
+++ b/src/vmobjects/AbstractObject.h
@@ -31,15 +31,17 @@ class Interpreter;
 class AbstractVMObject: public VMObjectBase {
 public:
     typedef GCAbstractObject Stored;
-    
+
     virtual int64_t GetHash() const;
     virtual VMClass* GetClass() const = 0;
     virtual AbstractVMObject* Clone() const = 0;
-    virtual void Send(Interpreter*, StdString, vm_oop_t*, long);
+            void Send(Interpreter*, StdString, vm_oop_t*, long);
+
+    /** Size in bytes of the object. */
     virtual size_t GetObjectSize() const = 0;
-    
+
     virtual void MarkObjectAsInvalid() = 0;
-    
+
     virtual StdString AsDebugString() const = 0;
 
     AbstractVMObject() {
@@ -63,7 +65,7 @@ public:
 
     long GetFieldIndex(VMSymbol* fieldName) const;
 
-    inline virtual void WalkObjects(walk_heap_fn) {
+    virtual void WalkObjects(walk_heap_fn) {
         return;
     }
 

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -119,7 +119,7 @@ class GCArray  : public GCObject         { public: typedef VMArray  Loaded; };
 class GCBlock  : public GCObject         { public: typedef VMBlock  Loaded; };
 class GCDouble : public GCAbstractObject { public: typedef VMDouble Loaded; };
 class GCInteger : public GCAbstractObject { public: typedef VMInteger Loaded; };
-class GCInvokable : public GCObject      { public: typedef VMInvokable Loaded; };
+class GCInvokable : public GCAbstractObject { public: typedef VMInvokable Loaded; };
 class GCMethod : public GCInvokable      { public: typedef VMMethod    Loaded; };
 class GCPrimitive : public GCInvokable   { public: typedef VMPrimitive Loaded; };
 class GCEvaluationPrimitive : public GCPrimitive { public: typedef VMEvaluationPrimitive Loaded; };

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -263,8 +263,7 @@ void VMClass::setPrimitives(const std::string& cname, bool classSide) {
                 }
 
                 // set routine
-                thePrimitive->SetRoutine(routine);
-                thePrimitive->SetEmpty(false);
+                thePrimitive->SetRoutine(routine, false);
             } else {
                 if (anInvokable->IsPrimitive() && current == this) {
                     if (!routine || routine->isClassSide() == classSide) {

--- a/src/vmobjects/VMEvaluationPrimitive.cpp
+++ b/src/vmobjects/VMEvaluationPrimitive.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <cassert>
+#include <cstddef>
 #include <string>
 
 #include "../memory/Heap.h"
@@ -39,10 +40,8 @@
 #include "VMPrimitive.h"
 #include "VMSymbol.h"
 
-VMEvaluationPrimitive::VMEvaluationPrimitive(long argc) : VMPrimitive(computeSignatureString(argc)) {
-    SetRoutine(new EvaluationRoutine(this));
-    SetEmpty(false);
-    store_ptr(numberOfArguments, NEW_INT(argc));
+VMEvaluationPrimitive::VMEvaluationPrimitive(size_t argc) : VMPrimitive(computeSignatureString(argc)), numberOfArguments(argc) {
+    SetRoutine(new EvaluationRoutine(this), false);
 }
 
 VMEvaluationPrimitive* VMEvaluationPrimitive::Clone() const {
@@ -52,7 +51,6 @@ VMEvaluationPrimitive* VMEvaluationPrimitive::Clone() const {
 
 void VMEvaluationPrimitive::WalkObjects(walk_heap_fn walk) {
     VMPrimitive::WalkObjects(walk);
-    numberOfArguments = walk(numberOfArguments);
     static_cast<EvaluationRoutine*>(routine)->WalkObjects(walk);
 }
 
@@ -103,6 +101,5 @@ void EvaluationRoutine::WalkObjects(walk_heap_fn walk) {
 }
 
 std::string VMEvaluationPrimitive::AsDebugString() const {
-    return "VMEvaluationPrimitive(" + to_string(
-                    INT_VAL(load_ptr(numberOfArguments))) + ")";
+    return "VMEvaluationPrimitive(" + to_string(numberOfArguments) + ")";
 }

--- a/src/vmobjects/VMEvaluationPrimitive.h
+++ b/src/vmobjects/VMEvaluationPrimitive.h
@@ -32,19 +32,23 @@ class VMEvaluationPrimitive: public VMPrimitive {
 public:
     typedef GCEvaluationPrimitive Stored;
 
-    VMEvaluationPrimitive(long argc);
+    VMEvaluationPrimitive(size_t argc);
     void WalkObjects(walk_heap_fn) override;
     VMEvaluationPrimitive* Clone() const override;
 
     StdString AsDebugString() const override;
 
-    int64_t GetNumberOfArguments() { return INT_VAL(load_ptr(numberOfArguments)); };
+    int64_t GetNumberOfArguments() { return numberOfArguments; }
+    
+    inline size_t GetObjectSize() const override {
+        return sizeof(VMEvaluationPrimitive);
+    }
 
 private:
     static VMSymbol* computeSignatureString(long argc);
     void evaluationRoutine(Interpreter*, VMFrame*);
 private_testable:
-    gc_oop_t numberOfArguments;
+    size_t numberOfArguments;
 
 };
 

--- a/src/vmobjects/VMInvokable.cpp
+++ b/src/vmobjects/VMInvokable.cpp
@@ -37,12 +37,7 @@ VMSymbol* VMInvokable::GetSignature() const {
     return load_ptr(signature);
 }
 
-void VMInvokable::SetSignature(VMSymbol* sig) {
-    store_ptr(signature, sig);
-}
-
 void VMInvokable::WalkObjects(walk_heap_fn walk) {
-    clazz     = static_cast<GCClass*>(walk(clazz));
     signature = static_cast<GCSymbol*>(walk(signature));
     if (holder) {
         holder = static_cast<GCClass*>(walk(holder));

--- a/src/vmobjects/VMInvokable.h
+++ b/src/vmobjects/VMInvokable.h
@@ -28,24 +28,30 @@
 
 #include "ObjectFormats.h"
 #include "VMObject.h"
+#include "VMSymbol.h"
 
-class VMInvokable: public VMObject {
+class VMInvokable: public AbstractVMObject {
 public:
     typedef GCInvokable Stored;
 
-    VMInvokable(long nof = 0) : VMObject(nof + 2) {};
+    VMInvokable(VMSymbol* sig) : AbstractVMObject(), hash((intptr_t) this), signature(nullptr), holder(nullptr) {
+        store_ptr(signature, sig);
+    };
+
+    int64_t GetHash() const override { return hash; }
 
     virtual void      Invoke(Interpreter*, VMFrame*) = 0;
 
     virtual bool      IsPrimitive() const;
             VMSymbol* GetSignature() const;
-    virtual void      SetSignature(VMSymbol* sig);
             VMClass*  GetHolder() const;
     virtual void      SetHolder(VMClass* hld);
 
     void WalkObjects(walk_heap_fn) override;
 
 protected_testable:
+    int64_t hash;
+
     GCSymbol* signature;
     GCClass*  holder;
 };

--- a/src/vmobjects/VMPrimitive.cpp
+++ b/src/vmobjects/VMPrimitive.cpp
@@ -29,7 +29,7 @@
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../primitivesCore/Routine.h"
-#include "../vm/Globals.h"
+#include "../vm/Globals.h" // NOLINT (misc-include-cleaner)
 #include "../vm/Print.h"
 #include "ObjectFormats.h"
 #include "VMClass.h"
@@ -39,30 +39,15 @@
 
 VMPrimitive* VMPrimitive::GetEmptyPrimitive(VMSymbol* sig, bool classSide) {
     VMPrimitive* prim = new (GetHeap<HEAP_CLS>()) VMPrimitive(sig);
-    prim->empty = true;
-    prim->SetRoutine(new Routine<VMPrimitive>(prim, &VMPrimitive::EmptyRoutine, classSide));
+    prim->SetRoutine(new Routine<VMPrimitive>(prim, &VMPrimitive::EmptyRoutine, classSide), true);
     return prim;
 }
 
-const int VMPrimitive::VMPrimitiveNumberOfFields = 2;
-
-VMPrimitive::VMPrimitive(VMSymbol* signature) : VMInvokable(VMPrimitiveNumberOfFields) {
-    //the only class that explicitly does this.
-    SetClass(load_ptr(primitiveClass));
-    SetSignature(signature);
-    routine = nullptr;
-    empty = false;
-}
+VMPrimitive::VMPrimitive(VMSymbol* signature) : VMInvokable(signature), routine(nullptr), empty(false) {}
 
 VMPrimitive* VMPrimitive::Clone() const {
     VMPrimitive* prim = new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMPrimitive(*this);
     return prim;
-}
-
-void VMPrimitive::WalkObjects(walk_heap_fn walk) {
-    clazz     = static_cast<GCClass*>(walk(clazz));
-    signature = static_cast<GCSymbol*>(walk(signature));
-    holder    = static_cast<GCClass*>(walk(holder));
 }
 
 void VMPrimitive::EmptyRoutine(Interpreter*, VMFrame*) {
@@ -74,4 +59,3 @@ std::string VMPrimitive::AsDebugString() const {
     return "Primitive(" + GetClass()->GetName()->GetStdString() + ">>#"
                         + GetSignature()->GetStdString() + ")";
 }
-

--- a/src/vmobjects/VMPrimitive.h
+++ b/src/vmobjects/VMPrimitive.h
@@ -38,9 +38,23 @@ public:
 
     VMPrimitive(VMSymbol* sig);
 
-    inline  bool IsEmpty() const;
-    inline  void SetRoutine(PrimitiveRoutine* rtn);
-            void WalkObjects(walk_heap_fn) override;
+    VMClass* GetClass() const override {
+        return load_ptr(primitiveClass);
+    }
+
+    inline size_t GetObjectSize() const override {
+        return sizeof(VMPrimitive);
+    }
+
+    inline  bool IsEmpty() const {
+        return empty;
+    }
+
+    inline  void SetRoutine(PrimitiveRoutine* rtn, bool empty) {
+        routine = rtn;
+        this->empty = empty;
+    }
+
             void SetEmpty(bool value) {empty = value;};
             VMPrimitive* Clone() const override;
 
@@ -49,6 +63,10 @@ public:
     };
 
     bool IsPrimitive() const override {return true;};
+
+    void MarkObjectAsInvalid() override {
+        routine = (PrimitiveRoutine*) INVALID_GC_POINTER;
+    }
 
     StdString AsDebugString() const override;
 
@@ -63,16 +81,4 @@ protected_testable:
 
 private_testable:
     bool empty;
-
-private:
-    static const int VMPrimitiveNumberOfFields;
-
 };
-
-bool VMPrimitive::IsEmpty() const {
-    return empty;
-}
-
-void VMPrimitive::SetRoutine(PrimitiveRoutine* rtn) {
-    routine = rtn;
-}

--- a/src/vmobjects/VMSymbol.cpp
+++ b/src/vmobjects/VMSymbol.cpp
@@ -24,12 +24,14 @@
  THE SOFTWARE.
  */
 
+#include <cstdint>
 #include <cstring>
 #include <sstream>
 #include <string>
 
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
+#include "../vm/Globals.h"  // NOLINT (misc-include-cleaner)
 #include "AbstractObject.h"
 #include "ObjectFormats.h"
 #include "Signature.h"
@@ -37,8 +39,6 @@
 #include "VMInvokable.h"
 #include "VMString.h"
 #include "VMSymbol.h"
-
-extern GCClass* symbolClass;
 
 VMSymbol::VMSymbol(const size_t length, const char* const str) :
       // set the chars-pointer to point at the position of the first character
@@ -143,3 +143,18 @@ std::string VMSymbol::AsDebugString() const {
     return "Symbol(" + GetStdString() + ")";
 }
 
+VMInvokable* VMSymbol::GetCachedInvokable(const VMClass* cls) const {
+    if (cls == load_ptr(cachedClass_invokable[0]))
+        return load_ptr(cachedInvokable[0]);
+    else if (cls == load_ptr(cachedClass_invokable[1]))
+        return load_ptr(cachedInvokable[1]);
+    else if (cls == load_ptr(cachedClass_invokable[2]))
+        return load_ptr(cachedInvokable[2]);
+    return nullptr;
+}
+
+void VMSymbol::UpdateCachedInvokable(const VMClass* cls, VMInvokable* invo) {
+    store_ptr(cachedInvokable[nextCachePos], invo);
+    store_ptr(cachedClass_invokable[nextCachePos], const_cast<VMClass*>(cls));
+    nextCachePos = (nextCachePos + 1) % 3;
+}

--- a/src/vmobjects/VMSymbol.h
+++ b/src/vmobjects/VMSymbol.h
@@ -49,8 +49,8 @@ private:
     const GCClass* cachedClass_invokable[3];
     long nextCachePos;
     GCInvokable* cachedInvokable[3];
-    inline VMInvokable* GetCachedInvokable(const VMClass*) const;
-    inline void UpdateCachedInvokable(const VMClass* cls, VMInvokable* invo);
+    VMInvokable* GetCachedInvokable(const VMClass*) const;
+    void UpdateCachedInvokable(const VMClass* cls, VMInvokable* invo);
 
     friend class Signature;
     friend class VMClass;
@@ -59,24 +59,3 @@ private_testable:
     void WalkObjects(walk_heap_fn) override;
 
 };
-
-
-#include "VMClass.h"
-#include "VMInvokable.h"
-
-
-VMInvokable* VMSymbol::GetCachedInvokable(const VMClass* cls) const {
-    if (cls == load_ptr(cachedClass_invokable[0]))
-        return load_ptr(cachedInvokable[0]);
-    else if (cls == load_ptr(cachedClass_invokable[1]))
-        return load_ptr(cachedInvokable[1]);
-    else if (cls == load_ptr(cachedClass_invokable[2]))
-        return load_ptr(cachedInvokable[2]);
-    return nullptr;
-}
-
-void VMSymbol::UpdateCachedInvokable(const VMClass* cls, VMInvokable* invo) {
-    store_ptr(cachedInvokable[nextCachePos], invo);
-    store_ptr(cachedClass_invokable[nextCachePos], const_cast<VMClass*>(cls));
-    nextCachePos = (nextCachePos + 1) % 3;
-}


### PR DESCRIPTION
Since SOM changed and does not expose all the details it used to, we do not need to keep the various fields as SOM-level values.
This drastically simplifies things and avoids GC issues.
With the copying and generational GC, we do have to be very careful around cloning objects and walking objects that were already moved.
However, if we use VMIntegers to represent crucial info, that's rather hairy.
So, we just don't do that any longer.