### PR TITLE
Work on GC issues

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,8 +75,8 @@ build_and_test:
     - ./unittests -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
     - cd ..
 
-    # Test SomSom
     - |+
+      # Test SomSom
       if [ "$COMPILER" = "clang" ]; then
         # this is to load balance the SomSom testing
         # only when compiling with Clang, and only on one machine for each integer configuration

--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -1084,7 +1084,12 @@
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = (
 					"-DGC_TYPE=GENERATIONAL",
+					"-DDEBUG",
 					"-DUNITTESTS",
+					"-DCACHE_INTEGER=false",
+					"-DUSE_TAGGING=false",
+					"-Wall",
+					"-Wextra",
 				);
 				OTHER_LDFLAGS = (
 					"-lcppunit",
@@ -1130,7 +1135,12 @@
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = (
 					"-DGC_TYPE=GENERATIONAL",
+					"-DDEBUG",
 					"-DUNITTESTS",
+					"-DCACHE_INTEGER=false",
+					"-DUSE_TAGGING=false",
+					"-Wall",
+					"-Wextra",
 				);
 				OTHER_LDFLAGS = (
 					"-lcppunit",
@@ -1180,7 +1190,8 @@
 				OTHER_CFLAGS = (
 					"-DGC_TYPE=COPYING",
 					"-DUSE_TAGGING=false",
-					"-DDEBUG=true",
+					"-DDEBUG",
+					"-DLOG_LEVEL=3",
 				);
 				VALID_ARCHS = arm64;
 			};
@@ -1224,7 +1235,8 @@
 				OTHER_CFLAGS = (
 					"-DGC_TYPE=COPYING",
 					"-DUSE_TAGGING=false",
-					"-DDEBUG=true",
+					"-DDEBUG",
+					"-DLOG_LEVEL=3",
 				);
 				VALID_ARCHS = arm64;
 			};

--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -55,6 +55,10 @@
 		0A1C986C2C4D363A00735850 /* LogAllocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C986A2C4D363A00735850 /* LogAllocation.cpp */; };
 		0A1C986E2C4F1D3900735850 /* debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C986D2C4F1D3900735850 /* debug.cpp */; };
 		0A1C986F2C4F1D3900735850 /* debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C986D2C4F1D3900735850 /* debug.cpp */; };
+		0A1C98732C55269E00735850 /* DebugCopyingHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C98722C55269E00735850 /* DebugCopyingHeap.cpp */; };
+		0A1C98742C55269E00735850 /* DebugCopyingHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C98722C55269E00735850 /* DebugCopyingHeap.cpp */; };
+		0A1C98762C5526AD00735850 /* DebugCopyingCollector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C98752C5526AD00735850 /* DebugCopyingCollector.cpp */; };
+		0A1C98772C5526AD00735850 /* DebugCopyingCollector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C98752C5526AD00735850 /* DebugCopyingCollector.cpp */; };
 		0A32B7FE199D6143002825DF /* IntegerBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A32B7FC199D6143002825DF /* IntegerBox.cpp */; };
 		0A3A3C921A5D546D004CB03B /* Array.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F5203120FA6624C00E75857 /* Array.cpp */; };
 		0A3A3C931A5D546D004CB03B /* Block.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F5203160FA6624C00E75857 /* Block.cpp */; };
@@ -197,6 +201,10 @@
 		0A1C98692C4D35BB00735850 /* LogAllocation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LogAllocation.h; sourceTree = "<group>"; };
 		0A1C986A2C4D363A00735850 /* LogAllocation.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogAllocation.cpp; sourceTree = "<group>"; };
 		0A1C986D2C4F1D3900735850 /* debug.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = debug.cpp; sourceTree = "<group>"; };
+		0A1C98702C55250100735850 /* DebugCopyingHeap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DebugCopyingHeap.h; sourceTree = "<group>"; };
+		0A1C98712C55251100735850 /* DebugCopyingCollector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DebugCopyingCollector.h; sourceTree = "<group>"; };
+		0A1C98722C55269E00735850 /* DebugCopyingHeap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DebugCopyingHeap.cpp; sourceTree = "<group>"; };
+		0A1C98752C5526AD00735850 /* DebugCopyingCollector.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DebugCopyingCollector.cpp; sourceTree = "<group>"; };
 		0A32B7FC199D6143002825DF /* IntegerBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntegerBox.cpp; sourceTree = "<group>"; };
 		0A32B7FD199D6143002825DF /* IntegerBox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntegerBox.h; sourceTree = "<group>"; };
 		0A32B80119A12A03002825DF /* VMObjectBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMObjectBase.h; sourceTree = "<group>"; };
@@ -519,6 +527,10 @@
 				3F5203080FA6624C00E75857 /* GarbageCollector.h */,
 				3F5203090FA6624C00E75857 /* Heap.cpp */,
 				3F52030A0FA6624C00E75857 /* Heap.h */,
+				0A1C98702C55250100735850 /* DebugCopyingHeap.h */,
+				0A1C98712C55251100735850 /* DebugCopyingCollector.h */,
+				0A1C98722C55269E00735850 /* DebugCopyingHeap.cpp */,
+				0A1C98752C5526AD00735850 /* DebugCopyingCollector.cpp */,
 			);
 			path = memory;
 			sourceTree = "<group>";
@@ -854,6 +866,7 @@
 				0A3A3C991A5D546D004CB03B /* Primitive.cpp in Sources */,
 				0A1886FF1832BCF500A2CBCA /* VMFrame.cpp in Sources */,
 				0A1886E41832BCD300A2CBCA /* Interpreter.cpp in Sources */,
+				0A1C98762C5526AD00735850 /* DebugCopyingCollector.cpp in Sources */,
 				0A1886E71832BCDC00A2CBCA /* Heap.cpp in Sources */,
 				0A1886F71832BCF500A2CBCA /* Signature.cpp in Sources */,
 				0A1887351832C10E00A2CBCA /* MarkSweepCollector.cpp in Sources */,
@@ -869,6 +882,7 @@
 				0A3A3C981A5D546D004CB03B /* Object.cpp in Sources */,
 				0A1886E01832BCC800A2CBCA /* MethodGenerationContext.cpp in Sources */,
 				0A3A3C9C1A5D546D004CB03B /* System.cpp in Sources */,
+				0A1C98732C55269E00735850 /* DebugCopyingHeap.cpp in Sources */,
 				0A1886F91832BCF500A2CBCA /* VMArray.cpp in Sources */,
 				0A3A3C971A5D546D004CB03B /* Method.cpp in Sources */,
 				0A1886E51832BCD700A2CBCA /* Main.cpp in Sources */,
@@ -933,6 +947,7 @@
 				0A67EA8C19ACD82100830E3B /* Universe.cpp in Sources */,
 				0A67EA8019ACD74800830E3B /* VMBlock.cpp in Sources */,
 				0A67EA8919ACD74800830E3B /* VMString.cpp in Sources */,
+				0A1C98742C55269E00735850 /* DebugCopyingHeap.cpp in Sources */,
 				0A67EA9419ACD83900830E3B /* bytecodes.cpp in Sources */,
 				0A67EA8319ACD74800830E3B /* VMEvaluationPrimitive.cpp in Sources */,
 				0A67EA9219ACD83200830E3B /* Parser.cpp in Sources */,
@@ -960,6 +975,7 @@
 				0A1C98682C4D340300735850 /* Symbols.cpp in Sources */,
 				0AB80AD42C392B78006B6419 /* Print.cpp in Sources */,
 				0A3A3CA41A5D546D004CB03B /* Double.cpp in Sources */,
+				0A1C98772C5526AD00735850 /* DebugCopyingCollector.cpp in Sources */,
 				0A67EA8519ACD74800830E3B /* VMInteger.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1003,6 +1019,15 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					src,
 				);
+				OTHER_CFLAGS = (
+					"-DGC_TYPE=DEBUG_COPYING",
+					"-DUSE_TAGGING=false",
+					"-DDEBUG",
+					"-DLOG_LEVEL=3",
+					"-Wextra",
+					"-Wall",
+					"-DCACHE_INTEGER=false",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1038,6 +1063,15 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					src,
+				);
+				OTHER_CFLAGS = (
+					"-DGC_TYPE=DEBUG_COPYING",
+					"-DUSE_TAGGING=false",
+					"-DDEBUG",
+					"-DLOG_LEVEL=3",
+					"-Wextra",
+					"-Wall",
+					"-DCACHE_INTEGER=false",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1083,13 +1117,14 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = (
-					"-DGC_TYPE=GENERATIONAL",
+					"-DGC_TYPE=DEBUG_COPYING",
 					"-DDEBUG",
 					"-DUNITTESTS",
 					"-DCACHE_INTEGER=false",
 					"-DUSE_TAGGING=false",
 					"-Wall",
 					"-Wextra",
+					"-DLOG_LEVEL=3",
 				);
 				OTHER_LDFLAGS = (
 					"-lcppunit",
@@ -1134,13 +1169,14 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CFLAGS = (
-					"-DGC_TYPE=GENERATIONAL",
+					"-DGC_TYPE=DEBUG_COPYING",
 					"-DDEBUG",
 					"-DUNITTESTS",
 					"-DCACHE_INTEGER=false",
 					"-DUSE_TAGGING=false",
 					"-Wall",
 					"-Wextra",
+					"-DLOG_LEVEL=3",
 				);
 				OTHER_LDFLAGS = (
 					"-lcppunit",

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -49,6 +49,8 @@ int main(int argc, char** argv) {
         cout << "\tgarbage collector: copying" << endl;
     else if (GC_TYPE == MARK_SWEEP)
         cout << "\tgarbage collector: mark-sweep" << endl;
+    else if (GC_TYPE == DEBUG_COPYING)
+        cout << "\tgarbage collector: debug copying" << endl;
     else
         cout << "\tgarbage collector: unknown" << endl;
 

--- a/src/compiler/BytecodeGenerator.cpp
+++ b/src/compiler/BytecodeGenerator.cpp
@@ -122,6 +122,10 @@ void EmitPUSHBLOCK(MethodGenerationContext& mgenc, VMMethod* block) {
 }
 
 void EmitPUSHCONSTANT(MethodGenerationContext& mgenc, vm_oop_t cst) {
+    // this isn't very robust with respect to initialization order
+    // so, we check here, and hope it's working, but alternatively
+    // we also make sure that we don't miss anything in the else
+    // branch of the class check
     if (CLASS_OF(cst) == load_ptr(integerClass)) {
         if (INT_VAL(cst) == 0ll) {
             Emit1(mgenc, BC_PUSH_0, 1);
@@ -131,6 +135,8 @@ void EmitPUSHCONSTANT(MethodGenerationContext& mgenc, vm_oop_t cst) {
             Emit1(mgenc, BC_PUSH_1, 1);
             return;
         }
+    } else {
+        assert(!IsVMInteger(cst));
     }
 
     if (cst == load_ptr(nilObject)) {

--- a/src/compiler/BytecodeGenerator.cpp
+++ b/src/compiler/BytecodeGenerator.cpp
@@ -30,6 +30,7 @@
 
 #include "../interpreter/bytecodes.h"
 #include "../vm/Globals.h"
+#include "../vm/IsValidObject.h"
 #include "../vm/Symbols.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/Signature.h"

--- a/src/compiler/ClassGenerationContext.cpp
+++ b/src/compiler/ClassGenerationContext.cpp
@@ -24,11 +24,14 @@
  THE SOFTWARE.
  */
 
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
 #include "../misc/VectorUtil.h"
 #include "../vm/Globals.h"
+#include "../vm/IsValidObject.h"
 #include "../vm/Symbols.h"
 #include "../vm/Universe.h"
 #include "../vmobjects/ObjectFormats.h"

--- a/src/compiler/ClassGenerationContext.cpp
+++ b/src/compiler/ClassGenerationContext.cpp
@@ -56,6 +56,7 @@ void ClassGenerationContext::SetInstanceFieldsOfSuper(VMArray* fields) {
     size_t num = fields->GetNumberOfIndexableFields();
     for (size_t i = 0; i < num; i ++) {
         VMSymbol* fieldName = (VMSymbol*)fields->GetIndexableField(i);
+        assert(IsVMSymbol(fieldName));
         instanceFields.push_back(fieldName);
     }
 }
@@ -64,6 +65,7 @@ void ClassGenerationContext::SetClassFieldsOfSuper(VMArray* fields) {
     size_t num = fields->GetNumberOfIndexableFields();
     for (size_t i = 0; i < num; i ++) {
         VMSymbol* fieldName = (VMSymbol*)fields->GetIndexableField(i);
+        assert(IsVMSymbol(fieldName));
         classFields.push_back(fieldName);
     }
 }

--- a/src/compiler/ClassGenerationContext.cpp
+++ b/src/compiler/ClassGenerationContext.cpp
@@ -40,8 +40,9 @@
 
 
 ClassGenerationContext::ClassGenerationContext() :
-        instanceFields(), instanceMethods(), classFields(), classMethods(),
-        name(nullptr), superName(nullptr), classSide(false) { }
+        name(nullptr), superName(nullptr), classSide(false),
+        instanceFields(), instanceMethods(), classFields(),
+         classMethods() { }
 
 void ClassGenerationContext::AddClassField(VMSymbol* field) {
     classFields.push_back(field);
@@ -52,16 +53,16 @@ void ClassGenerationContext::AddInstanceField(VMSymbol* field) {
 }
 
 void ClassGenerationContext::SetInstanceFieldsOfSuper(VMArray* fields) {
-    long num = fields->GetNumberOfIndexableFields();
-    for (long i = 0; i < num; i ++) {
+    size_t num = fields->GetNumberOfIndexableFields();
+    for (size_t i = 0; i < num; i ++) {
         VMSymbol* fieldName = (VMSymbol*)fields->GetIndexableField(i);
         instanceFields.push_back(fieldName);
     }
 }
 
 void ClassGenerationContext::SetClassFieldsOfSuper(VMArray* fields) {
-    long num = fields->GetNumberOfIndexableFields();
-    for (long i = 0; i < num; i ++) {
+    size_t num = fields->GetNumberOfIndexableFields();
+    for (size_t i = 0; i < num; i ++) {
         VMSymbol* fieldName = (VMSymbol*)fields->GetIndexableField(i);
         classFields.push_back(fieldName);
     }

--- a/src/compiler/Disassembler.cpp
+++ b/src/compiler/Disassembler.cpp
@@ -132,7 +132,7 @@ void Disassembler::dumpMethod(uint8_t* bytecodes, size_t numberOfBytecodes, cons
     }
 
     // output bytecodes
-    for (long bc_idx = 0;
+    for (size_t bc_idx = 0;
          bc_idx < numberOfBytecodes;
          bc_idx += Bytecode::GetBytecodeLength(bytecodes[bc_idx])) {
         // the bytecode.

--- a/src/compiler/Disassembler.h
+++ b/src/compiler/Disassembler.h
@@ -27,8 +27,8 @@
  */
 
 #include "../vmobjects/VMClass.h"
-#include "../vmobjects/VMMethod.h"
 #include "../vmobjects/VMFrame.h"
+#include "../vmobjects/VMMethod.h"
 #include "MethodGenerationContext.h"
 
 class Disassembler {
@@ -39,6 +39,6 @@ public:
     static void DumpBytecode(VMFrame* frame, VMMethod* method, long bc_idx);
 private:
     static void dispatch(vm_oop_t o);
-    
+
     static void dumpMethod(uint8_t* bytecodes, size_t numberOfBytecodes, const char* indent, VMMethod* method);
 };

--- a/src/compiler/Lexer.cpp
+++ b/src/compiler/Lexer.cpp
@@ -38,7 +38,7 @@ Lexer::Lexer(istream &file) : infile(file), peekDone(false) {}
 #define _BC (buf[state.bufp])
 #define EOB (state.bufp >= buf.length())
 
-size_t Lexer::fillBuffer() {
+int64_t Lexer::fillBuffer() {
     if (!infile.good()) { // file stream
         return -1;
     }

--- a/src/compiler/Lexer.cpp
+++ b/src/compiler/Lexer.cpp
@@ -25,6 +25,7 @@
  */
 #include <cassert>
 #include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <istream>
 #include <string>

--- a/src/compiler/Lexer.h
+++ b/src/compiler/Lexer.h
@@ -76,12 +76,12 @@ static const char* symnames[] = { "NONE", "Integer", "Not", "And", "Or", "Star",
 
 class LexerState {
 public:
-    LexerState() : bufp(0), lineNumber(0), text(""), sym(Symbol::NONE), symc(0), startBufp(0) {}
-    
+    LexerState() : lineNumber(0), bufp(0), sym(Symbol::NONE), symc(0), text(""), startBufp(0) {}
+
     inline size_t incPtr() {
         return incPtr(1);
     }
-    
+
     inline size_t incPtr(size_t val) {
         const size_t cur = bufp;
         bufp += val;
@@ -91,11 +91,11 @@ public:
 
     size_t lineNumber;
     size_t bufp;
-    
+
     Symbol sym;
     char symc;
     StdString text;
-    
+
     size_t startBufp;
 };
 
@@ -108,55 +108,55 @@ public:
 
     Symbol GetSym();
     Symbol Peek();
-    
+
     StdString GetText() const {
         return state.text;
     }
-    
+
     StdString GetNextText() const {
         return stateAfterPeek.text;
     }
-    
+
     StdString GetRawBuffer() const {
         //for debug
         return StdString(buf);
     }
-    
+
     StdString GetCurrentLine();
-    
+
     size_t getCurrentColumn() {
         return state.startBufp + 1 - state.text.length();
     }
-    
+
     size_t GetCurrentLineNumber() {
         return state.lineNumber;
     }
-    
+
     bool GetPeekDone() const {
         return peekDone;
     }
 
 private:
-    size_t fillBuffer();
+    int64_t fillBuffer();
     void skipWhiteSpace();
     void skipComment();
-    
+
     bool hasMoreInput();
-    
+
     void lexNumber();
     void lexOperator();
     void lexEscapeChar();
     void lexStringChar();
     void lexString();
-    
+
     bool nextWordInBufferIsPrimitive();
 
     istream& infile;
 
     bool peekDone;
-    
+
     LexerState state;
     LexerState stateAfterPeek;
-    
+
     StdString buf;
 };

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -140,9 +140,20 @@ void MethodGenerationContext::AddLocal(const std::string& local) {
 }
 
 uint8_t MethodGenerationContext::AddLiteral(vm_oop_t lit) {
+    assert(!AS_OBJ(lit)->IsMarkedInvalid());
+    
     uint8_t idx = literals.size();
     literals.push_back(lit);
     return idx;
+}
+
+int8_t MethodGenerationContext::AddLiteralIfAbsent(vm_oop_t lit) {
+    int8_t idx = IndexOf(literals, lit);
+    if (idx != -1) {
+        assert(idx >= 0 && idx < literals.size() && "Expect index to be inside the literals vector.");
+        return idx;
+    }
+    return AddLiteral(lit);
 }
 
 void MethodGenerationContext::UpdateLiteral(vm_oop_t oldValue, uint8_t index, vm_oop_t newValue) {
@@ -166,15 +177,6 @@ bool MethodGenerationContext::AddLocalIfAbsent(const std::string& local) {
     }
     locals.push_back(localSym);
     return true;
-}
-
-int8_t MethodGenerationContext::AddLiteralIfAbsent(vm_oop_t lit) {
-    int8_t idx = IndexOf(literals, lit);
-    if (idx == -1) {
-        literals.push_back(lit);
-        idx = literals.size() - 1;
-    }
-    return idx;
 }
 
 void MethodGenerationContext::SetFinished(bool finished) {

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -40,8 +40,8 @@
 #include "MethodGenerationContext.h"
 
 MethodGenerationContext::MethodGenerationContext() :
-        signature(nullptr), holderGenc(nullptr), outerGenc(nullptr),
-        primitive(false), blockMethod(false), finished(false),
+        holderGenc(nullptr), outerGenc(nullptr),
+        blockMethod(false), signature(nullptr), primitive(false), finished(false),
         currentStackDepth(0), maxStackDepth(0) { }
 
 VMMethod* MethodGenerationContext::Assemble() {
@@ -52,7 +52,7 @@ VMMethod* MethodGenerationContext::Assemble() {
             numLiterals, numLocals, maxStackDepth);
 
     // copy literals into the method
-    for (int i = 0; i < numLiterals; i++) {
+    for (size_t i = 0; i < numLiterals; i++) {
         vm_oop_t l = literals[i];
         meth->SetIndexableField(i, l);
     }
@@ -84,7 +84,7 @@ uint8_t MethodGenerationContext::GetFieldIndex(VMSymbol* field) {
     return idx;
 }
 
-bool MethodGenerationContext::FindVar(VMSymbol* var, size_t* index,
+bool MethodGenerationContext::FindVar(VMSymbol* var, int64_t* index,
         int* context, bool* isArgument) {
     if ((*index = IndexOf(locals, var)) == -1) {
         if ((*index = IndexOf(arguments, var)) == -1) {
@@ -141,7 +141,7 @@ void MethodGenerationContext::AddLocal(const std::string& local) {
 
 uint8_t MethodGenerationContext::AddLiteral(vm_oop_t lit) {
     assert(!AS_OBJ(lit)->IsMarkedInvalid());
-    
+
     uint8_t idx = literals.size();
     literals.push_back(lit);
     return idx;
@@ -150,7 +150,7 @@ uint8_t MethodGenerationContext::AddLiteral(vm_oop_t lit) {
 int8_t MethodGenerationContext::AddLiteralIfAbsent(vm_oop_t lit) {
     int8_t idx = IndexOf(literals, lit);
     if (idx != -1) {
-        assert(idx >= 0 && idx < literals.size() && "Expect index to be inside the literals vector.");
+        assert(idx >= 0 && (size_t)idx < literals.size() && "Expect index to be inside the literals vector.");
         return idx;
     }
     return AddLiteral(lit);

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -42,10 +42,10 @@ public:
     VMPrimitive* AssemblePrimitive(bool classSide);
 
     int8_t FindLiteralIndex(vm_oop_t lit);
-    bool FindVar(VMSymbol* var, size_t* index,
+    bool FindVar(VMSymbol* var, int64_t* index,
             int* context, bool* isArgument);
     bool HasField(VMSymbol* field);
-    
+
     uint8_t GetFieldIndex(VMSymbol* field);
 
     void SetHolder(ClassGenerationContext* holder);
@@ -90,7 +90,7 @@ private:
     std::vector<vm_oop_t> literals;
     bool finished;
     std::vector<uint8_t> bytecode;
-    
+
     size_t currentStackDepth;
     size_t maxStackDepth;
 };

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -719,7 +719,7 @@ void Parser::literalArray(MethodGenerationContext& mgenc) {
     EmitPUSHCONSTANT(mgenc, arraySizeLiteralIndex);
     EmitSEND(mgenc, newMessage);
 
-    size_t i = 1;
+    int64_t i = 1;
 
     while (sym != EndTerm) {
         vm_oop_t pushIndex = NEW_INT(i);

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -244,9 +244,9 @@ void Parser::superclass(ClassGenerationContext& cgenc) {
         // We avoid here any kind of dynamic solution to avoid further complexity.
         // However, that makes it static, it is going to make it harder to
         // change the definition of Class and Object
-        vector<StdString> fieldNamesOfClass{ "class", "superClass", "name",
-            "instanceFields", "instanceInvokables" };
-        VMArray* fieldNames = GetUniverse()->NewArrayFromStrings(fieldNamesOfClass);
+        vector<StdString> fieldNamesOfClass{ "class", "name",
+            "instanceFields", "instanceInvokables", "superClass" };
+        VMArray* fieldNames = GetUniverse()->NewArrayOfSymbolsFromStrings(fieldNamesOfClass);
         cgenc.SetClassFieldsOfSuper(fieldNames);
     }
 }

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -67,7 +67,7 @@ void Parser::PeekForNextSymbolFromLexerIfNecessary() {
     }
 }
 
-Parser::Parser(istream& file, StdString& fname): fname(fname), sym(NONE), nextSym(NONE), lexer(file) {
+Parser::Parser(istream& file, StdString& fname): lexer(file), fname(fname), sym(NONE), nextSym(NONE) {
     GetSym();
 }
 
@@ -127,7 +127,7 @@ void Parser::genPushVariable(MethodGenerationContext& mgenc,
     // pushed on the stack is a local variable, argument, or object field. This
     // is done by examining all available lexical contexts, starting with the
     // innermost (i.e., the one represented by mgenc).
-    size_t index = 0;
+    int64_t index = 0;
     int context = 0;
     bool is_argument = false;
 
@@ -151,7 +151,7 @@ void Parser::genPopVariable(MethodGenerationContext& mgenc, VMSymbol* var) {
     // popped off the stack is a local variable, argument, or object field. This
     // is done by examining all available lexical contexts, starting with the
     // innermost (i.e., the one represented by mgenc).
-    size_t index = 0;
+    int64_t index = 0;
     int context = 0;
     bool is_argument = false;
 
@@ -463,7 +463,7 @@ void Parser::assignation(MethodGenerationContext& mgenc) {
 
 void Parser::assignments(MethodGenerationContext& mgenc, list<VMSymbol*>& l) {
     if (symIsIdentifier()) {
-        l.push_back(assignment(mgenc));
+        l.push_back(assignment());
         Peek();
 
         if (nextSym == Assign) {
@@ -472,7 +472,7 @@ void Parser::assignments(MethodGenerationContext& mgenc, list<VMSymbol*>& l) {
     }
 }
 
-VMSymbol* Parser::assignment(MethodGenerationContext& mgenc) {
+VMSymbol* Parser::assignment() {
     StdString v = variable();
 
     expect(Assign);

--- a/src/compiler/Parser.h
+++ b/src/compiler/Parser.h
@@ -85,7 +85,7 @@ private:
     void expression(MethodGenerationContext& mgenc);
     void assignation(MethodGenerationContext& mgenc);
     void assignments(MethodGenerationContext& mgenc, list<VMSymbol*>& l);
-    VMSymbol* assignment(MethodGenerationContext& mgenc);
+    VMSymbol* assignment();
     void evaluation(MethodGenerationContext& mgenc);
     bool primary(MethodGenerationContext& mgenc);
     StdString variable();

--- a/src/compiler/Parser.h
+++ b/src/compiler/Parser.h
@@ -31,11 +31,10 @@
 #include <string>
 
 #include "../misc/defs.h"
-
-#include "Lexer.h"
-#include "ClassGenerationContext.h"
-#include "MethodGenerationContext.h"
 #include "BytecodeGenerator.h"
+#include "ClassGenerationContext.h"
+#include "Lexer.h"
+#include "MethodGenerationContext.h"
 
 class Parser {
 public:
@@ -45,18 +44,18 @@ public:
     void Classdef(ClassGenerationContext& cgenc);
     void method(MethodGenerationContext& mgenc);
     void nestedBlock(MethodGenerationContext& mgenc);
-    
+
 private:
     __attribute__((noreturn)) void parseError(const char* msg, Symbol expected);
     __attribute__((noreturn)) void parseError(const char* msg, Symbol* expected);
     __attribute__((noreturn)) void parseError(const char* msg, StdString expected);
-    
+
     void GetSym();
     void Peek();
     void PeekForNextSymbolFromLexerIfNecessary();
-    
+
     bool eob(void);
-    
+
     bool symIsIdentifier();
 
     bool symIn(Symbol* ss);
@@ -95,7 +94,7 @@ private:
     void binaryMessage(MethodGenerationContext& mgenc, bool super);
     bool binaryOperand(MethodGenerationContext& mgenc);
     void keywordMessage(MethodGenerationContext& mgenc, bool super);
-    
+
     void formula(MethodGenerationContext& mgenc);
     void nestedTerm(MethodGenerationContext& mgenc);
     void literal(MethodGenerationContext& mgenc);

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -324,7 +324,8 @@ void Interpreter::doSuperSend(long bytecodeIndex) {
     VMFrame* ctxt = GetFrame()->GetOuterContext();
     VMMethod* realMethod = ctxt->GetMethod();
     VMClass* holder = realMethod->GetHolder();
-    VMClass* super = holder->GetSuperClass();
+    assert(holder->HasSuperClass());
+    VMClass* super = (VMClass*) holder->GetSuperClass();
     VMInvokable* invokable = static_cast<VMInvokable*>(super->LookupInvokable(signature));
 
     if (invokable != nullptr)

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -411,12 +411,12 @@ void Interpreter::doJump(long bytecodeIndex) {
 }
 
 void Interpreter::WalkGlobals(walk_heap_fn walk) {
-    method = load_ptr(static_cast<GCMethod*>(walk(_store_ptr(method))));
+    method = load_ptr(static_cast<GCMethod*>(walk(tmp_ptr(method))));
     
     // Get the current frame and mark it.
     // Since marking is done recursively, this automatically
     // marks the whole stack
-    frame  = load_ptr(static_cast<GCFrame*>(walk(_store_ptr(frame))));
+    frame  = load_ptr(static_cast<GCFrame*>(walk(tmp_ptr(frame))));
 }
 
 void Interpreter::startGC() {

--- a/src/memory/CopyingCollector.cpp
+++ b/src/memory/CopyingCollector.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "../misc/debug.h"
 #include "../misc/defs.h"
 #include "../vm/IsValidObject.h"
 #include "../vm/Universe.h"
@@ -47,6 +48,8 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
 }
 
 void CopyingCollector::Collect() {
+    DebugLog("CopyGC Collect\n");
+
     Timer::GCTimer->Resume();
     //reset collection trigger
     heap->resetGCTrigger();

--- a/src/memory/CopyingCollector.cpp
+++ b/src/memory/CopyingCollector.cpp
@@ -16,8 +16,9 @@
 
 static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     // don't process tagged objects
-    if (IS_TAGGED(oop))
+    if (IS_TAGGED(oop)) {
         return oop;
+    }
 
     AbstractVMObject* obj = AS_OBJ(oop);
     assert(IsValidObject(obj));
@@ -26,22 +27,24 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     long gcField = obj->GetGCField();
     //GCField is abused as forwarding pointer here
     //if someone has moved before, return the moved object
-    if (gcField != 0)
+    if (gcField != 0) {
         return (gc_oop_t) gcField;
+    }
 
     assert(!obj->IsMarkedInvalid());
-    
+
     // we have to clone ourselves
     AbstractVMObject* newObj = obj->Clone();
 
     // it looks to me like the Symbols get corrupted somehow, and when we try to clone them, it's too late
     // there are also waaaay too many symbols now.
     // I really can't create a new symbol for every fully qualified name, that's just bad
-    
-    
-    
-    if (DEBUG)
+
+
+
+    if (DEBUG) {
         obj->MarkObjectAsInvalid();
+    }
 
     obj->SetGCField((long)newObj);
     return tmp_ptr(newObj);
@@ -69,8 +72,9 @@ void CopyingCollector::Collect() {
                 (size_t)(0.9 * newSize));
         heap->currentBufferEnd = (void*)((size_t)(heap->currentBuffer) +
                 newSize);
-        if (heap->currentBuffer == nullptr)
-            GetUniverse()->ErrorExit("unable to allocate more memory");
+        if (heap->currentBuffer == nullptr) {
+            Universe::ErrorExit("unable to allocate more memory");
+        }
     }
 
     // init currentBuffer with zeros
@@ -90,8 +94,9 @@ void CopyingCollector::Collect() {
         increaseMemory = false;
         free(heap->oldBuffer);
         heap->oldBuffer = malloc(newSize);
-        if (heap->oldBuffer == nullptr)
-            GetUniverse()->ErrorExit("unable to allocate more memory");
+        if (heap->oldBuffer == nullptr) {
+            Universe::ErrorExit("unable to allocate more memory");
+        }
     }
 
     // if semispace is still 50% full after collection, we have to realloc

--- a/src/memory/CopyingCollector.cpp
+++ b/src/memory/CopyingCollector.cpp
@@ -35,7 +35,7 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     assert(!obj->IsMarkedInvalid());
 
     // we have to clone ourselves
-    AbstractVMObject* newObj = obj->Clone();
+    AbstractVMObject* newObj = obj->CloneForMovingGC();
 
     assert(GetHeap<CopyingHeap>()->IsInCurrentBuffer(newObj));
 

--- a/src/memory/CopyingCollector.cpp
+++ b/src/memory/CopyingCollector.cpp
@@ -44,7 +44,7 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
         obj->MarkObjectAsInvalid();
 
     obj->SetGCField((long)newObj);
-    return _store_ptr(newObj);
+    return tmp_ptr(newObj);
 }
 
 void CopyingCollector::Collect() {

--- a/src/memory/CopyingCollector.cpp
+++ b/src/memory/CopyingCollector.cpp
@@ -28,6 +28,8 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     if (gcField != 0)
         return (gc_oop_t) gcField;
 
+    assert(!obj->IsMarkedInvalid());
+    
     // we have to clone ourselves
     AbstractVMObject* newObj = obj->Clone();
 

--- a/src/memory/CopyingCollector.cpp
+++ b/src/memory/CopyingCollector.cpp
@@ -33,6 +33,12 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     // we have to clone ourselves
     AbstractVMObject* newObj = obj->Clone();
 
+    // it looks to me like the Symbols get corrupted somehow, and when we try to clone them, it's too late
+    // there are also waaaay too many symbols now.
+    // I really can't create a new symbol for every fully qualified name, that's just bad
+    
+    
+    
     if (DEBUG)
         obj->MarkObjectAsInvalid();
 

--- a/src/memory/CopyingCollector.cpp
+++ b/src/memory/CopyingCollector.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "../memory/Heap.h"
 #include "../misc/debug.h"
 #include "../misc/defs.h"
 #include "../vm/IsValidObject.h"

--- a/src/memory/CopyingCollector.h
+++ b/src/memory/CopyingCollector.h
@@ -6,7 +6,7 @@ class CopyingHeap;
 
 class CopyingCollector: public GarbageCollector<CopyingHeap> {
 public:
-    CopyingCollector(CopyingHeap* h) : GarbageCollector(h) {};
+    explicit CopyingCollector(CopyingHeap* h) : GarbageCollector(h) {};
 private:
-    void Collect();
+    void Collect() override;
 };

--- a/src/memory/CopyingHeap.cpp
+++ b/src/memory/CopyingHeap.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -19,7 +20,7 @@ CopyingHeap::CopyingHeap(size_t objectSpaceSize) : Heap<CopyingHeap>(new Copying
     memset(oldBuffer, 0x0, bufSize);
 
     currentBufferEnd = (void*)((size_t)currentBuffer + bufSize);
-    collectionLimit = (void*)((size_t)currentBuffer + ((size_t)(bufSize * 0.9)));
+    collectionLimit = (void*)((size_t)currentBuffer + ((size_t)((double)bufSize * 0.9)));
     nextFreePosition = currentBuffer;
 
     oldBufferEnd = (void*)((size_t)oldBuffer + bufSize);
@@ -27,7 +28,6 @@ CopyingHeap::CopyingHeap(size_t objectSpaceSize) : Heap<CopyingHeap>(new Copying
 }
 
 void CopyingHeap::switchBuffers(bool increaseMemory) {
-    size_t currentBufSizeBeforeSwitch = (size_t)currentBufferEnd - (size_t)currentBuffer;
     size_t oldBufSizeBeforeSwitch = (size_t)oldBufferEnd - (size_t)oldBuffer;
 
     void* oldBufferBeforeSwitch = oldBuffer;
@@ -38,7 +38,7 @@ void CopyingHeap::switchBuffers(bool increaseMemory) {
     oldBufferEnd = currentBufferEnd;
     oldBufferIsValid = true;
 
-    size_t currentBufSize;
+    size_t currentBufSize = 0;
     if (increaseMemory) {
         // increase memory if scheduled in collection before
         free(oldBufferBeforeSwitch);
@@ -48,11 +48,11 @@ void CopyingHeap::switchBuffers(bool increaseMemory) {
         currentBuffer = malloc(newSize);
 
         if (currentBuffer == nullptr) {
-            GetUniverse()->ErrorExit("unable to allocate heap memory");
+            Universe::ErrorExit("unable to allocate heap memory");
         }
 
         currentBufferEnd = (void*)((size_t)currentBuffer + newSize);
-        collectionLimit = (void*)((size_t)currentBuffer + ((size_t)(newSize * 0.9)));
+        collectionLimit = (void*)((size_t)currentBuffer + ((size_t)((double)newSize * 0.9)));
         nextFreePosition = currentBuffer;
         currentBufSize = newSize;
     } else {
@@ -60,7 +60,7 @@ void CopyingHeap::switchBuffers(bool increaseMemory) {
         currentBufferEnd = oldBufferEndBeforeSwitch;
         currentBufSize = oldBufSizeBeforeSwitch;
 
-        collectionLimit = (void*)((size_t)oldBufferBeforeSwitch + (size_t)(oldBufSizeBeforeSwitch * 0.9));
+        collectionLimit = (void*)((size_t)oldBufferBeforeSwitch + (size_t)((double)oldBufSizeBeforeSwitch * 0.9));
         nextFreePosition = currentBuffer;
     }
 
@@ -84,7 +84,7 @@ void CopyingHeap::invalidateOldBuffer() {
         oldBuffer = malloc(currentBufSize);
 
         if (oldBuffer == nullptr) {
-            GetUniverse()->ErrorExit("unable to allocate heap memory");
+            Universe::ErrorExit("unable to allocate heap memory");
         }
 
         oldBufferEnd = (void*)((size_t)oldBuffer + currentBufSize);

--- a/src/memory/CopyingHeap.cpp
+++ b/src/memory/CopyingHeap.cpp
@@ -9,7 +9,7 @@
 #include "CopyingHeap.h"
 #include "Heap.h"
 
-CopyingHeap::CopyingHeap(long objectSpaceSize) : Heap<CopyingHeap>(new CopyingCollector(this), objectSpaceSize) {
+CopyingHeap::CopyingHeap(size_t objectSpaceSize) : Heap<CopyingHeap>(new CopyingCollector(this)) {
     size_t bufSize = objectSpaceSize;
     currentBuffer = malloc(bufSize);
     oldBuffer = malloc(bufSize);

--- a/src/memory/CopyingHeap.cpp
+++ b/src/memory/CopyingHeap.cpp
@@ -11,25 +11,84 @@
 
 CopyingHeap::CopyingHeap(size_t objectSpaceSize) : Heap<CopyingHeap>(new CopyingCollector(this)) {
     size_t bufSize = objectSpaceSize;
+
     currentBuffer = malloc(bufSize);
     oldBuffer = malloc(bufSize);
+
     memset(currentBuffer, 0x0, bufSize);
     memset(oldBuffer, 0x0, bufSize);
+
     currentBufferEnd = (void*)((size_t)currentBuffer + bufSize);
-    collectionLimit = (void*)((size_t)currentBuffer + ((size_t)(bufSize *
-                            0.9)));
+    collectionLimit = (void*)((size_t)currentBuffer + ((size_t)(bufSize * 0.9)));
     nextFreePosition = currentBuffer;
+
+    oldBufferEnd = (void*)((size_t)oldBuffer + bufSize);
+    oldBufferIsValid = false;
 }
 
-void CopyingHeap::switchBuffers() {
-    size_t bufSize = (size_t)currentBufferEnd - (size_t)currentBuffer;
-    void* tmp = oldBuffer;
+void CopyingHeap::switchBuffers(bool increaseMemory) {
+    size_t currentBufSizeBeforeSwitch = (size_t)currentBufferEnd - (size_t)currentBuffer;
+    size_t oldBufSizeBeforeSwitch = (size_t)oldBufferEnd - (size_t)oldBuffer;
+
+    void* oldBufferBeforeSwitch = oldBuffer;
+    void* oldBufferEndBeforeSwitch = oldBufferEnd;
+
+    // make current buffer the old one
     oldBuffer = currentBuffer;
-    currentBuffer = tmp;
-    currentBufferEnd = (void*)((size_t)currentBuffer + bufSize);
-    nextFreePosition = currentBuffer;
-    collectionLimit = (void*)((size_t)currentBuffer + (size_t)(0.9 *
-                    bufSize));
+    oldBufferEnd = currentBufferEnd;
+    oldBufferIsValid = true;
+
+    size_t currentBufSize;
+    if (increaseMemory) {
+        // increase memory if scheduled in collection before
+        free(oldBufferBeforeSwitch);
+        oldBufferEndBeforeSwitch = nullptr;
+
+        size_t newSize = oldBufSizeBeforeSwitch * 2;
+        currentBuffer = malloc(newSize);
+
+        if (currentBuffer == nullptr) {
+            GetUniverse()->ErrorExit("unable to allocate heap memory");
+        }
+
+        currentBufferEnd = (void*)((size_t)currentBuffer + newSize);
+        collectionLimit = (void*)((size_t)currentBuffer + ((size_t)(newSize * 0.9)));
+        nextFreePosition = currentBuffer;
+        currentBufSize = newSize;
+    } else {
+        currentBuffer = oldBufferBeforeSwitch;
+        currentBufferEnd = oldBufferEndBeforeSwitch;
+        currentBufSize = oldBufSizeBeforeSwitch;
+
+        collectionLimit = (void*)((size_t)oldBufferBeforeSwitch + (size_t)(oldBufSizeBeforeSwitch * 0.9));
+        nextFreePosition = currentBuffer;
+    }
+
+    // init currentBuffer with zeros
+    memset(currentBuffer, 0x0, currentBufSize);
+}
+
+void CopyingHeap::invalidateOldBuffer() {
+    oldBufferIsValid = false;
+
+    size_t currentBufSize = (size_t)currentBufferEnd - (size_t)currentBuffer;
+    size_t oldBufSize = (size_t)oldBufferEnd - (size_t)oldBuffer;
+
+    if (DEBUG) {
+        memset(oldBuffer, 0xFF, oldBufSize);
+    }
+
+    if (currentBufSize > oldBufSize) {
+        free(oldBuffer);
+
+        oldBuffer = malloc(currentBufSize);
+
+        if (oldBuffer == nullptr) {
+            GetUniverse()->ErrorExit("unable to allocate heap memory");
+        }
+
+        oldBufferEnd = (void*)((size_t)oldBuffer + currentBufSize);
+    }
 }
 
 AbstractVMObject* CopyingHeap::AllocateObject(size_t size) {
@@ -39,9 +98,37 @@ AbstractVMObject* CopyingHeap::AllocateObject(size_t size) {
         ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
         Universe::Quit(-1);
     }
-    //let's see if we have to trigger the GC
+
+    // let's see if we have to trigger the GC
     if (nextFreePosition > collectionLimit) {
         requestGC();
     }
+
     return newObject;
+}
+
+bool CopyingHeap::IsInCurrentBuffer(AbstractVMObject* obj) {
+    if (obj == nullptr) {
+        return true;
+    }
+
+    size_t objAddress = (size_t) obj;
+    return (size_t) currentBuffer <= objAddress && objAddress < (size_t) currentBufferEnd;
+}
+
+bool CopyingHeap::IsInOldBufferAndOldBufferIsValid(AbstractVMObject* obj) {
+    if (obj == nullptr) {
+        return true;
+    }
+
+    if (!oldBufferIsValid) {
+        assert(oldBufferIsValid);
+        return false;
+    }
+
+    size_t objAddress = (size_t) obj;
+    assert((size_t) oldBuffer <= objAddress);
+    assert(objAddress < (size_t) oldBufferEnd);
+
+    return (size_t) oldBuffer <= objAddress && objAddress < (size_t) oldBufferEnd;
 }

--- a/src/memory/CopyingHeap.cpp
+++ b/src/memory/CopyingHeap.cpp
@@ -95,7 +95,7 @@ AbstractVMObject* CopyingHeap::AllocateObject(size_t size) {
     AbstractVMObject* newObject = (AbstractVMObject*) nextFreePosition;
     nextFreePosition = (void*)((size_t)nextFreePosition + size);
     if (nextFreePosition > currentBufferEnd) {
-        ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
+        ErrorPrint("\nFailed to allocate " + to_string(size) + " Bytes.\n");
         Universe::Quit(-1);
     }
 

--- a/src/memory/CopyingHeap.cpp
+++ b/src/memory/CopyingHeap.cpp
@@ -37,10 +37,11 @@ AbstractVMObject* CopyingHeap::AllocateObject(size_t size) {
     nextFreePosition = (void*)((size_t)nextFreePosition + size);
     if (nextFreePosition > currentBufferEnd) {
         ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
-        GetUniverse()->Quit(-1);
+        Universe::Quit(-1);
     }
     //let's see if we have to trigger the GC
-    if (nextFreePosition > collectionLimit)
+    if (nextFreePosition > collectionLimit) {
         requestGC();
+    }
     return newObject;
 }

--- a/src/memory/CopyingHeap.h
+++ b/src/memory/CopyingHeap.h
@@ -9,11 +9,21 @@ class CopyingHeap : public Heap<CopyingHeap> {
 public:
     explicit CopyingHeap(size_t objectSpaceSize);
     AbstractVMObject* AllocateObject(size_t size);
+
+    bool IsInCurrentBuffer(AbstractVMObject* obj);
+    bool IsInOldBufferAndOldBufferIsValid(AbstractVMObject* obj);
+
 private:
+    void switchBuffers(bool increaseMemory);
+    void invalidateOldBuffer();
+
     void* currentBuffer;
     void* collectionLimit;
-    void* oldBuffer;
     void* currentBufferEnd;
-    void switchBuffers(void);
+
+    void* oldBuffer;
+    void* oldBufferEnd;
+
     void* nextFreePosition;
+    bool oldBufferIsValid;
 };

--- a/src/memory/CopyingHeap.h
+++ b/src/memory/CopyingHeap.h
@@ -7,7 +7,7 @@
 class CopyingHeap : public Heap<CopyingHeap> {
     friend class CopyingCollector;
 public:
-    CopyingHeap(size_t objectSpaceSize);
+    explicit CopyingHeap(size_t objectSpaceSize);
     AbstractVMObject* AllocateObject(size_t size);
 private:
     void* currentBuffer;

--- a/src/memory/CopyingHeap.h
+++ b/src/memory/CopyingHeap.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <cstring>
+
 #include "Heap.h"
-#include <string.h>
 
 class CopyingHeap : public Heap<CopyingHeap> {
     friend class CopyingCollector;
 public:
-    CopyingHeap(long heapSize);
+    CopyingHeap(size_t objectSpaceSize);
     AbstractVMObject* AllocateObject(size_t size);
 private:
     void* currentBuffer;

--- a/src/memory/DebugCopyingCollector.cpp
+++ b/src/memory/DebugCopyingCollector.cpp
@@ -1,19 +1,16 @@
+
 #include <cassert>
 #include <cstddef>
-#include <cstdlib>
-#include <cstring>
 
 #include "../memory/Heap.h"
+#include "../misc/Timer.h"
 #include "../misc/debug.h"
 #include "../misc/defs.h"
 #include "../vm/IsValidObject.h"
 #include "../vm/Universe.h"
-#include "../vmobjects/AbstractObject.h"
-#include "../vmobjects/IntegerBox.h"
 #include "../vmobjects/ObjectFormats.h"
-#include "../vmobjects/VMFrame.h"
-#include "CopyingCollector.h"
-#include "CopyingHeap.h"
+#include "DebugCopyingCollector.h"
+#include "DebugCopyingHeap.h"
 
 static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     // don't process tagged objects
@@ -31,13 +28,13 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
         return (gc_oop_t) gcField;
     }
 
-    assert(GetHeap<CopyingHeap>()->IsInOldBufferAndOldBufferIsValid(obj));
+    assert(GetHeap<DebugCopyingHeap>()->IsInOldBufferAndOldBufferIsValid(obj));
     assert(!obj->IsMarkedInvalid());
 
     // we have to clone ourselves
     AbstractVMObject* newObj = obj->Clone();
 
-    assert(GetHeap<CopyingHeap>()->IsInCurrentBuffer(newObj));
+    assert(GetHeap<DebugCopyingHeap>()->IsInCurrentBuffer(newObj));
 
     if (DEBUG) {
         obj->MarkObjectAsInvalid();
@@ -47,8 +44,11 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     return tmp_ptr(newObj);
 }
 
-void CopyingCollector::Collect() {
-    DebugLog("CopyGC Collect\n");
+void DebugCopyingCollector::Collect() {
+    DebugLog("DebugCopyGC Collect\n");
+
+    // we assume the old heap is empty, because we want to switch to it
+    assert(heap->oldHeap.empty());
 
     Timer::GCTimer->Resume();
     //reset collection trigger
@@ -61,19 +61,16 @@ void CopyingCollector::Collect() {
     GetUniverse()->WalkGlobals(copy_if_necessary);
 
     // now copy all objects that are referenced by the objects we have moved so far
-    AbstractVMObject* curObject = (AbstractVMObject*)(heap->currentBuffer);
-    while (curObject < heap->nextFreePosition) {
-        curObject->WalkObjects(copy_if_necessary);
-        curObject = (AbstractVMObject*)((size_t)curObject + curObject->GetObjectSize());
+    for (size_t i = 0; i < heap->currentHeap.size(); i += 1) {
+        heap->currentHeap.at(i)->WalkObjects(copy_if_necessary);
     }
 
     heap->invalidateOldBuffer();
 
     // if semispace is still 50% full after collection, we have to realloc
     // bigger ones -> done in next collection
-    if ((size_t)(heap->nextFreePosition) - (size_t)(heap->currentBuffer) >=
-            (size_t)(heap->currentBufferEnd) -
-            (size_t)(heap->nextFreePosition)) {
+    size_t freeSpace = heap->currentHeapSize - heap->currentHeapUsage;
+    if (heap->currentHeapUsage > freeSpace) {
         increaseMemory = true;
     }
 

--- a/src/memory/DebugCopyingCollector.cpp
+++ b/src/memory/DebugCopyingCollector.cpp
@@ -32,7 +32,7 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     assert(!obj->IsMarkedInvalid());
 
     // we have to clone ourselves
-    AbstractVMObject* newObj = obj->Clone();
+    AbstractVMObject* newObj = obj->CloneForMovingGC();
 
     assert(GetHeap<DebugCopyingHeap>()->IsInCurrentBuffer(newObj));
 

--- a/src/memory/DebugCopyingCollector.h
+++ b/src/memory/DebugCopyingCollector.h
@@ -1,0 +1,12 @@
+# pragma once
+
+#include "GarbageCollector.h"
+
+class DebugCopyingHeap;
+
+class DebugCopyingCollector: public GarbageCollector<DebugCopyingHeap> {
+public:
+    explicit DebugCopyingCollector(DebugCopyingHeap* h) : GarbageCollector(h) {};
+private:
+    void Collect() override;
+};

--- a/src/memory/DebugCopyingHeap.cpp
+++ b/src/memory/DebugCopyingHeap.cpp
@@ -1,0 +1,85 @@
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <string>
+
+#include "../vm/Print.h"
+#include "../vm/Universe.h"
+#include "../vmobjects/AbstractObject.h"
+#include "DebugCopyingHeap.h"
+
+void DebugCopyingHeap::switchBuffers(bool increaseMemory) {
+    assert(oldHeap.empty() && "At this point, I'd assume the old heap is empty, because we want to use it to store into now");
+
+    oldHeap.swap(currentHeap);
+    oldHeapIsValid = true;
+    oldHeapSize = currentHeapSize;
+
+    if (increaseMemory) {
+        currentHeapSize += currentHeapSize;
+        collectionLimit = (double) currentHeapSize * 0.9;
+    }
+
+    currentHeapUsage = 0;
+    assert(currentHeap.empty() && "at the end, the current heap is expected to be empty");
+}
+
+void DebugCopyingHeap::invalidateOldBuffer() {
+    oldHeapIsValid = false;
+
+    for (AbstractVMObject*& obj : oldHeap) {
+        // I was thinking I can check here that the objects all have been
+        // invalidated, but of course I can't
+        // because only the reachable objects will have been invalidated
+        // but, the objects that were not reachable, well, they just remained
+        // in the heap.
+        free(obj);
+    }
+
+    oldHeap.clear();
+
+    if (currentHeapSize > oldHeapSize) {
+        oldHeapSize = currentHeapSize;
+    }
+}
+
+AbstractVMObject* DebugCopyingHeap::AllocateObject(size_t size) {
+    AbstractVMObject* newObject = (AbstractVMObject*) malloc(size);
+    currentHeap.push_back(newObject);
+
+    currentHeapUsage += size;
+
+    if (currentHeapUsage > currentHeapSize) {
+        ErrorPrint("\nFailed to allocate " + to_string(size) + " Bytes.\n");
+        Universe::Quit(-1);
+    }
+
+    // let's see if we have to trigger the GC
+    if (currentHeapUsage > collectionLimit) {
+        requestGC();
+    }
+
+    return newObject;
+}
+
+bool DebugCopyingHeap::IsInCurrentBuffer(AbstractVMObject* obj) {
+    if (obj == nullptr) {
+        return true;
+    }
+
+    return find(currentHeap.begin(), currentHeap.end(), obj) != currentHeap.end();
+}
+
+bool DebugCopyingHeap::IsInOldBufferAndOldBufferIsValid(AbstractVMObject* obj) {
+    if (obj == nullptr) {
+        return true;
+    }
+
+    if (!oldHeapIsValid) {
+        assert(oldHeapIsValid);
+        return false;
+    }
+
+    return find(oldHeap.begin(), oldHeap.end(), obj) != oldHeap.end();
+}

--- a/src/memory/DebugCopyingHeap.h
+++ b/src/memory/DebugCopyingHeap.h
@@ -1,0 +1,34 @@
+# pragma once
+
+#include <cstddef>
+
+#include "DebugCopyingCollector.h"
+#include "Heap.h"
+
+class DebugCopyingHeap : public Heap<DebugCopyingHeap> {
+    friend class DebugCopyingCollector;
+public:
+    explicit DebugCopyingHeap(size_t objectSpaceSize) :
+        Heap<DebugCopyingHeap>(new DebugCopyingCollector(this)),
+        currentHeapSize(objectSpaceSize),
+    collectionLimit((double)objectSpaceSize * 0.9) {}
+
+    AbstractVMObject* AllocateObject(size_t size);
+
+    bool IsInCurrentBuffer(AbstractVMObject* obj);
+    bool IsInOldBufferAndOldBufferIsValid(AbstractVMObject* obj);
+
+private:
+    void switchBuffers(bool increaseMemory);
+    void invalidateOldBuffer();
+
+    vector<AbstractVMObject*> currentHeap{};
+    size_t currentHeapSize;
+    size_t currentHeapUsage{0};
+    size_t collectionLimit;
+
+    vector<AbstractVMObject*> oldHeap{};
+    size_t oldHeapSize{0};
+
+    bool oldHeapIsValid{false};
+};

--- a/src/memory/GarbageCollector.h
+++ b/src/memory/GarbageCollector.h
@@ -32,8 +32,8 @@
 template <class HEAP_T>
 class GarbageCollector {
 public:
-    GarbageCollector(HEAP_T* h) : heap(h) {}
-    virtual ~GarbageCollector() {}
+    explicit GarbageCollector(HEAP_T* h) : heap(h) {}
+    virtual ~GarbageCollector() = default;
     virtual void Collect() = 0;
     void PrintGCStat() const;
     void PrintCollectStat() const;

--- a/src/memory/GenerationalCollector.cpp
+++ b/src/memory/GenerationalCollector.cpp
@@ -64,7 +64,7 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     }
 
     // we have to clone ourselves
-    AbstractVMObject* newObj = obj->Clone();
+    AbstractVMObject* newObj = obj->CloneForMovingGC();
 
     if (DEBUG) {
         obj->MarkObjectAsInvalid();

--- a/src/memory/GenerationalCollector.cpp
+++ b/src/memory/GenerationalCollector.cpp
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <vector>
 
+#include "../misc/debug.h"
 #include "../misc/defs.h"
 #include "../vm/IsValidObject.h"
 #include "../vm/Universe.h"
@@ -76,6 +77,8 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
 }
 
 void GenerationalCollector::MinorCollection() {
+    DebugLog("GenGC MinorCollection\n");
+
     // walk all globals of universe, and implicily the interpreter
     GetUniverse()->WalkGlobals(&copy_if_necessary);
 
@@ -96,6 +99,8 @@ void GenerationalCollector::MinorCollection() {
 }
 
 void GenerationalCollector::MajorCollection() {
+    DebugLog("GenGC MajorCollection\n");
+
     // first we have to mark all objects (globals and current frame recursively)
     GetUniverse()->WalkGlobals(&mark_object);
 

--- a/src/memory/GenerationalCollector.cpp
+++ b/src/memory/GenerationalCollector.cpp
@@ -22,27 +22,30 @@ GenerationalCollector::GenerationalCollector(GenerationalHeap* heap) : GarbageCo
 
 static gc_oop_t mark_object(gc_oop_t oop) {
     // don't process tagged objects
-    if (IS_TAGGED(oop))
+    if (IS_TAGGED(oop)) {
         return oop;
-    
+    }
+
     AbstractVMObject* obj = AS_OBJ(oop);
     assert(IsValidObject(obj));
-    
 
-    if (obj->GetGCField() & MASK_OBJECT_IS_MARKED)
+
+    if ((obj->GetGCField() & MASK_OBJECT_IS_MARKED) != 0) {
         return oop;
+    }
 
     obj->SetGCField(MASK_OBJECT_IS_OLD | MASK_OBJECT_IS_MARKED);
     obj->WalkObjects(&mark_object);
-    
+
     return oop;
 }
 
 static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     // don't process tagged objects
-    if (IS_TAGGED(oop))
+    if (IS_TAGGED(oop)) {
         return oop;
-    
+    }
+
     AbstractVMObject* obj = AS_OBJ(oop);
     assert(IsValidObject(obj));
 
@@ -50,29 +53,32 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     size_t gcField = obj->GetGCField();
 
     // if this is an old object already, we don't have to copy
-    if (gcField & MASK_OBJECT_IS_OLD)
+    if ((gcField & MASK_OBJECT_IS_OLD) != 0) {
         return oop;
+    }
 
     // GCField is abused as forwarding pointer here
     // if someone has moved before, return the moved object
-    if (gcField != 0)
+    if (gcField != 0) {
         return (gc_oop_t) gcField;
-    
+    }
+
     // we have to clone ourselves
     AbstractVMObject* newObj = obj->Clone();
 
-    if (DEBUG)
+    if (DEBUG) {
         obj->MarkObjectAsInvalid();
+    }
 
     assert( (((size_t) newObj) & MASK_OBJECT_IS_MARKED) == 0 );
     assert( obj->GetObjectSize() == newObj->GetObjectSize());
-    
+
     obj->SetGCField((size_t) newObj);
     newObj->SetGCField(MASK_OBJECT_IS_OLD);
 
     // walk recursively
     newObj->WalkObjects(copy_if_necessary);
-    
+
     return tmp_ptr(newObj);
 }
 
@@ -109,11 +115,11 @@ void GenerationalCollector::MajorCollection() {
     for (vector<AbstractVMObject*>::iterator objIter =
             heap->allocatedObjects->begin(); objIter !=
             heap->allocatedObjects->end(); objIter++) {
-        
+
         AbstractVMObject* obj = *objIter;
         assert(IsValidObject(obj));
-        
-        if (obj->GetGCField() & MASK_OBJECT_IS_MARKED) {
+
+        if ((obj->GetGCField() & MASK_OBJECT_IS_MARKED) != 0) {
             survivors->push_back(obj);
             obj->SetGCField(MASK_OBJECT_IS_OLD);
         }

--- a/src/memory/GenerationalCollector.cpp
+++ b/src/memory/GenerationalCollector.cpp
@@ -73,7 +73,7 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
     // walk recursively
     newObj->WalkObjects(copy_if_necessary);
     
-    return _store_ptr(newObj);
+    return tmp_ptr(newObj);
 }
 
 void GenerationalCollector::MinorCollection() {

--- a/src/memory/GenerationalCollector.h
+++ b/src/memory/GenerationalCollector.h
@@ -8,7 +8,7 @@ class GenerationalHeap;
 class GenerationalCollector : public GarbageCollector<GenerationalHeap> {
 public:
     GenerationalCollector(GenerationalHeap* heap);
-    void Collect();
+    void Collect() override;
 private:
     intptr_t majorCollectionThreshold;
     size_t matureObjectsSize;

--- a/src/memory/GenerationalCollector.h
+++ b/src/memory/GenerationalCollector.h
@@ -10,7 +10,7 @@ public:
     GenerationalCollector(GenerationalHeap* heap);
     void Collect() override;
 private:
-    intptr_t majorCollectionThreshold;
+    uintptr_t majorCollectionThreshold;
     size_t matureObjectsSize;
     void MajorCollection();
     void MinorCollection();

--- a/src/memory/GenerationalHeap.cpp
+++ b/src/memory/GenerationalHeap.cpp
@@ -35,7 +35,7 @@ AbstractVMObject* GenerationalHeap::AllocateNurseryObject(size_t size) {
     AbstractVMObject* newObject = (AbstractVMObject*) nextFreePosition;
     nextFreePosition = (void*)((size_t)nextFreePosition + size);
     if ((size_t)nextFreePosition > nursery_end) {
-        ErrorPrint("Failed to allocate " + to_string(size) + " Bytes in nursery.\n");
+        ErrorPrint("\nFailed to allocate " + to_string(size) + " Bytes in nursery.\n");
         GetUniverse()->Quit(-1);
     }
     //let's see if we have to trigger the GC
@@ -48,7 +48,7 @@ AbstractVMObject* GenerationalHeap::AllocateNurseryObject(size_t size) {
 AbstractVMObject* GenerationalHeap::AllocateMatureObject(size_t size) {
     AbstractVMObject* newObject = (AbstractVMObject*) malloc(size);
     if (newObject == nullptr) {
-        ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
+        ErrorPrint("\nFailed to allocate " + to_string(size) + " Bytes.\n");
         GetUniverse()->Quit(-1);
     }
     allocatedObjects->push_back(newObject);

--- a/src/memory/GenerationalHeap.cpp
+++ b/src/memory/GenerationalHeap.cpp
@@ -39,8 +39,9 @@ AbstractVMObject* GenerationalHeap::AllocateNurseryObject(size_t size) {
         GetUniverse()->Quit(-1);
     }
     //let's see if we have to trigger the GC
-    if (nextFreePosition > collectionLimit)
+    if (nextFreePosition > collectionLimit) {
         requestGC();
+    }
     return newObject;
 }
 
@@ -62,4 +63,3 @@ void GenerationalHeap::writeBarrier_OldHolder(VMObjectBase* holder,
         holder->SetGCField(holder->GetGCField() | MASK_SEEN_BY_WRITE_BARRIER);
     }
 }
-

--- a/src/memory/GenerationalHeap.cpp
+++ b/src/memory/GenerationalHeap.cpp
@@ -14,7 +14,7 @@
 
 using namespace std;
 
-GenerationalHeap::GenerationalHeap(long objectSpaceSize) : Heap<GenerationalHeap>(new GenerationalCollector(this), objectSpaceSize) {
+GenerationalHeap::GenerationalHeap(size_t objectSpaceSize) : Heap<GenerationalHeap>(new GenerationalCollector(this)) {
     //our initial collection limit is 90% of objectSpaceSize
     //collectionLimit = objectSpaceSize * 0.9;
 

--- a/src/memory/GenerationalHeap.h
+++ b/src/memory/GenerationalHeap.h
@@ -21,7 +21,7 @@ struct VMObjectCompare {
 class GenerationalHeap : public Heap<GenerationalHeap> {
     friend class GenerationalCollector;
 public:
-    GenerationalHeap(size_t objectSpaceSize = 1048576);
+    explicit GenerationalHeap(size_t objectSpaceSize = 1048576);
     AbstractVMObject* AllocateNurseryObject(size_t size);
     AbstractVMObject* AllocateMatureObject(size_t size);
     size_t GetMaxNurseryObjectSize();

--- a/src/memory/GenerationalHeap.h
+++ b/src/memory/GenerationalHeap.h
@@ -21,7 +21,7 @@ struct VMObjectCompare {
 class GenerationalHeap : public Heap<GenerationalHeap> {
     friend class GenerationalCollector;
 public:
-    GenerationalHeap(long objectSpaceSize = 1048576);
+    GenerationalHeap(size_t objectSpaceSize = 1048576);
     AbstractVMObject* AllocateNurseryObject(size_t size);
     AbstractVMObject* AllocateMatureObject(size_t size);
     size_t GetMaxNurseryObjectSize();

--- a/src/memory/GenerationalHeap.h
+++ b/src/memory/GenerationalHeap.h
@@ -37,8 +37,7 @@ private:
     size_t maxNurseryObjSize;
     size_t matureObjectsSize;
     void* nextFreePosition;
-    void writeBarrier_OldHolder(VMObjectBase* holder, const vm_oop_t
-            referencedObject);
+    void writeBarrier_OldHolder(VMObjectBase* holder, vm_oop_t referencedObject);
     void* collectionLimit;
     vector<size_t>* oldObjsWithRefToYoungObjs;
     vector<AbstractVMObject*>* allocatedObjects;
@@ -46,7 +45,7 @@ private:
 
 inline bool GenerationalHeap::isObjectInNursery(vm_oop_t obj) {
     assert(IsValidObject(obj));
-    
+
     return (size_t) obj >= (size_t)nursery && (size_t) obj < nursery_end;
 }
 
@@ -58,11 +57,12 @@ inline void GenerationalHeap::writeBarrier(VMObjectBase* holder, vm_oop_t refere
 #ifdef UNITTESTS
     writeBarrierCalledOn.insert(make_pair(holder, referencedObject));
 #endif
-    
+
     assert(IsValidObject(referencedObject));
     assert(IsValidObject(holder));
 
     const size_t gcfield = *(((size_t*)holder)+1);
-    if ((gcfield & 6 /* MASK_OBJECT_IS_OLD + MASK_SEEN_BY_WRITE_BARRIER */) == 2 /* MASK_OBJECT_IS_OLD */)
+    if ((gcfield & 6U /* MASK_OBJECT_IS_OLD + MASK_SEEN_BY_WRITE_BARRIER */) == 2U /* MASK_OBJECT_IS_OLD */) {
         writeBarrier_OldHolder(holder, referencedObject);
+    }
 }

--- a/src/memory/Heap.cpp
+++ b/src/memory/Heap.cpp
@@ -29,6 +29,7 @@
 #include "../misc/defs.h"
 #include "../vm/Print.h"
 #include "CopyingHeap.h" // NOLINT(misc-include-cleaner)
+#include "DebugCopyingHeap.h" // NOLINT(misc-include-cleaner)
 #include "GenerationalHeap.h" // NOLINT(misc-include-cleaner)
 #include "Heap.h"
 #include "MarkSweepHeap.h" // NOLINT(misc-include-cleaner)

--- a/src/memory/Heap.cpp
+++ b/src/memory/Heap.cpp
@@ -45,8 +45,9 @@ void Heap<HEAP_T>::InitializeHeap(long objectSpaceSize) {
 
 template<class HEAP_T>
 void Heap<HEAP_T>::DestroyHeap() {
-    if (theHeap)
+    if (theHeap) {
         delete theHeap;
+    }
 }
 
 template<class HEAP_T>

--- a/src/memory/Heap.h
+++ b/src/memory/Heap.h
@@ -43,7 +43,7 @@ class Heap {
 public:
     static void InitializeHeap(long objectSpaceSize);
     static void DestroyHeap();
-    Heap(GarbageCollector<HEAP_T>* const gc, long objectSpaceSize) : gc(gc), gcWasRequested(false) {}
+    Heap(GarbageCollector<HEAP_T>* const gc) : gc(gc), gcWasRequested(false) {}
     ~Heap();
     inline void requestGC()      { gcWasRequested = true; }
     inline void resetGCTrigger() { gcWasRequested = false; }

--- a/src/memory/Heap.h
+++ b/src/memory/Heap.h
@@ -43,7 +43,7 @@ class Heap {
 public:
     static void InitializeHeap(long objectSpaceSize);
     static void DestroyHeap();
-    Heap(GarbageCollector<HEAP_T>* const gc) : gc(gc), gcWasRequested(false) {}
+    explicit Heap(GarbageCollector<HEAP_T>* const gc) : gc(gc) {}
     ~Heap();
     inline void requestGC()      { gcWasRequested = true; }
     inline void resetGCTrigger() { gcWasRequested = false; }
@@ -55,9 +55,9 @@ protected:
 private:
     template<class HEAP_U> friend HEAP_U* GetHeap();
     static HEAP_T* theHeap;
-    
+
     // flag that shows if a Collection is triggered
-    bool gcWasRequested;
+    bool gcWasRequested{false};
 };
 
 template<class HEAP_T> HEAP_T* Heap<HEAP_T>::theHeap;

--- a/src/memory/Heap.h
+++ b/src/memory/Heap.h
@@ -34,6 +34,13 @@
 #include "../vmobjects/ObjectFormats.h"
 #include "GarbageCollector.h"
 
+/*
+ * macro for padding - only word-aligned memory must be allocated
+ */
+#define PADDED_SIZE(N) ((((size_t)(N))+(sizeof(void*)-1) & ~(sizeof(void*)-1)))
+
+#define IS_PADDED_SIZE(N) ((N) == PADDED_SIZE((N)))
+
 using namespace std;
 
 template<class HEAP_T>

--- a/src/memory/MarkSweepCollector.cpp
+++ b/src/memory/MarkSweepCollector.cpp
@@ -49,13 +49,15 @@ void MarkSweepCollector::Collect() {
 }
 
 static gc_oop_t mark_object(gc_oop_t oop) {
-    if (IS_TAGGED(oop))
+    if (IS_TAGGED(oop)) {
         return oop;
-    
+    }
+
     AbstractVMObject* obj = AS_OBJ(oop);
 
-    if (obj->GetGCField())
+    if (obj->GetGCField() != 0) {
         return oop;
+    }
 
     obj->SetGCField(GC_MARKED);
     obj->WalkObjects(mark_object);

--- a/src/memory/MarkSweepCollector.h
+++ b/src/memory/MarkSweepCollector.h
@@ -9,7 +9,7 @@ class MarkSweepCollector : public GarbageCollector<MarkSweepHeap> {
 public:
     MarkSweepCollector(MarkSweepHeap* heap) : GarbageCollector(heap) {
     }
-    void Collect();
+    void Collect() override;
 private:
     void markReachableObjects();
 };

--- a/src/memory/MarkSweepHeap.cpp
+++ b/src/memory/MarkSweepHeap.cpp
@@ -22,13 +22,12 @@ AbstractVMObject* MarkSweepHeap::AllocateObject(size_t size) {
     //TODO: PADDING wird eigentlich auch durch malloc erledigt
     AbstractVMObject* newObject = (AbstractVMObject*) malloc(size);
     if (newObject == nullptr) {
-        ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
+        ErrorPrint("\nFailed to allocate " + to_string(size) + " Bytes.\n");
         Universe::Quit(-1);
     }
     spcAlloc += size;
     memset((void*) newObject, 0, size);
     //AbstractObjects (Integer,...) have no Size field anymore -> set within VMObject's new operator
-    //newObject->SetObjectSize(size);
     allocatedObjects->push_back(newObject);
     //let's see if we have to trigger the GC
     if (spcAlloc >= collectionLimit) {

--- a/src/memory/MarkSweepHeap.cpp
+++ b/src/memory/MarkSweepHeap.cpp
@@ -11,7 +11,7 @@
 #include "MarkSweepHeap.h"
 
 
-MarkSweepHeap::MarkSweepHeap(long objectSpaceSize) : Heap<MarkSweepHeap>(new MarkSweepCollector(this), objectSpaceSize) {
+MarkSweepHeap::MarkSweepHeap(size_t objectSpaceSize) : Heap<MarkSweepHeap>(new MarkSweepCollector(this)) {
     //our initial collection limit is 90% of objectSpaceSize
     collectionLimit = objectSpaceSize * 0.9;
     spcAlloc = 0;

--- a/src/memory/MarkSweepHeap.cpp
+++ b/src/memory/MarkSweepHeap.cpp
@@ -19,7 +19,6 @@ MarkSweepHeap::MarkSweepHeap(size_t objectSpaceSize) : Heap<MarkSweepHeap>(new M
 }
 
 AbstractVMObject* MarkSweepHeap::AllocateObject(size_t size) {
-    //TODO: PADDING wird eigentlich auch durch malloc erledigt
     AbstractVMObject* newObject = (AbstractVMObject*) malloc(size);
     if (newObject == nullptr) {
         ErrorPrint("\nFailed to allocate " + to_string(size) + " Bytes.\n");

--- a/src/memory/MarkSweepHeap.cpp
+++ b/src/memory/MarkSweepHeap.cpp
@@ -23,7 +23,7 @@ AbstractVMObject* MarkSweepHeap::AllocateObject(size_t size) {
     AbstractVMObject* newObject = (AbstractVMObject*) malloc(size);
     if (newObject == nullptr) {
         ErrorPrint("Failed to allocate " + to_string(size) + " Bytes.\n");
-        GetUniverse()->Quit(-1);
+        Universe::Quit(-1);
     }
     spcAlloc += size;
     memset((void*) newObject, 0, size);
@@ -31,7 +31,8 @@ AbstractVMObject* MarkSweepHeap::AllocateObject(size_t size) {
     //newObject->SetObjectSize(size);
     allocatedObjects->push_back(newObject);
     //let's see if we have to trigger the GC
-    if (spcAlloc >= collectionLimit)
+    if (spcAlloc >= collectionLimit) {
         requestGC();
+    }
     return newObject;
 }

--- a/src/memory/MarkSweepHeap.h
+++ b/src/memory/MarkSweepHeap.h
@@ -12,6 +12,6 @@ public:
 private:
     vector<AbstractVMObject*>* allocatedObjects;
     size_t spcAlloc;
-    long collectionLimit;
+    size_t collectionLimit;
 
 };

--- a/src/memory/MarkSweepHeap.h
+++ b/src/memory/MarkSweepHeap.h
@@ -7,7 +7,7 @@
 class MarkSweepHeap : public Heap<MarkSweepHeap> {
     friend class MarkSweepCollector;
 public:
-    MarkSweepHeap(size_t objectSpaceSize = 1048576);
+    explicit MarkSweepHeap(size_t objectSpaceSize = 1048576);
     AbstractVMObject* AllocateObject(size_t size);
 private:
     vector<AbstractVMObject*>* allocatedObjects;

--- a/src/memory/MarkSweepHeap.h
+++ b/src/memory/MarkSweepHeap.h
@@ -7,7 +7,7 @@
 class MarkSweepHeap : public Heap<MarkSweepHeap> {
     friend class MarkSweepCollector;
 public:
-    MarkSweepHeap(long objectSpaceSize = 1048576);
+    MarkSweepHeap(size_t objectSpaceSize = 1048576);
     AbstractVMObject* AllocateObject(size_t size);
 private:
     vector<AbstractVMObject*>* allocatedObjects;

--- a/src/misc/ParseInteger.h
+++ b/src/misc/ParseInteger.h
@@ -2,8 +2,8 @@
 
 #include <string>
 
-#include "defs.h"
 #include "../vmobjects/ObjectFormats.h"
+#include "defs.h"
 
 vm_oop_t ParseInteger(const char* str, int base, bool negateValue);
 vm_oop_t ParseInteger(std::string& str, int base, bool negateValue);

--- a/src/misc/Timer.h
+++ b/src/misc/Timer.h
@@ -7,7 +7,7 @@
 static int64_t get_microseconds() {
 #if defined(CLOCK_PROCESS_CPUTIME_ID)
     // this is for Linux
-    timespec now;
+    timespec now{};
     clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &now);
 
     return (now.tv_sec * 1000 * 1000) +// seconds
@@ -38,7 +38,7 @@ public:
     }
 
     double GetTotalTime() {
-        return total / 1000.0;
+        return (double)total / 1000.0;
     }
 
 };

--- a/src/misc/VectorUtil.h
+++ b/src/misc/VectorUtil.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <vector>
-#include <algorithm>
 
 template<typename T>
 inline bool Contains(std::vector<T>& vec, T elem) {

--- a/src/misc/debug.h
+++ b/src/misc/debug.h
@@ -52,26 +52,30 @@ static inline void DebugPrefix(const char* prefix) {
     va_end(ap)
 
 static inline void DebugInfo(const char* fmt, ...) {
-#if DEBUG
+#if LOG_LEVEL >= LOG_LEVEL_INFO
     DebugPrefix("INFO:");
     DebugPass(fmt);
 #else
     (void) fmt;
-#endif // DEBUG
+#endif
 }
 
 static inline void DebugLog(const char* fmt, ...) {
-#if DEBUG
+#if LOG_LEVEL >= LOG_LEVEL_LOG
     DebugPrefix("LOG:");
     DebugPass(fmt);
 #else
     (void) fmt;
-#endif // DEBUG
+#endif
 }
 
 static inline void DebugWarn(const char* fmt, ...) {
+#if LOG_LEVEL >= LOG_LEVEL_WARN
     DebugPrefix("WARN:");
     DebugPass(fmt);
+#else
+    (void) fmt;
+#endif
 }
 
 static inline void DebugError(const char* fmt, ...) {

--- a/src/misc/defs.h
+++ b/src/misc/defs.h
@@ -151,6 +151,17 @@
   #define protected_testable public
 #endif
 
+//
+// Log Levels
+//
+#define LOG_LEVEL_ERROR 0
+#define LOG_LEVEL_WARN  1
+#define LOG_LEVEL_LOG   2
+#define LOG_LEVEL_INFO  3
+
+#ifndef LOG_LEVEL
+  #define LOG_LEVEL LOG_LEVEL_ERROR
+#endif
 
 //
 // Performance Optimization

--- a/src/misc/defs.h
+++ b/src/misc/defs.h
@@ -68,6 +68,7 @@
 #define GENERATIONAL 1
 #define COPYING      2
 #define MARK_SWEEP   3
+#define DEBUG_COPYING 4
 
 #if   GC_TYPE == GENERATIONAL
   class   GenerationalHeap;
@@ -86,6 +87,13 @@
 #elif GC_TYPE == MARK_SWEEP
   class   MarkSweepHeap;
   typedef MarkSweepHeap HEAP_CLS;
+  #define write_barrier(obj, value_ptr)
+  #define ALLOC_MATURE
+  #define ALLOC_OUTSIDE_NURSERY(X)
+  #define ALLOC_OUTSIDE_NURSERY_DECL
+#elif GC_TYPE == DEBUG_COPYING
+  class   DebugCopyingHeap;
+  typedef DebugCopyingHeap HEAP_CLS;
   #define write_barrier(obj, value_ptr)
   #define ALLOC_MATURE
   #define ALLOC_OUTSIDE_NURSERY(X)

--- a/src/primitives/Array.cpp
+++ b/src/primitives/Array.cpp
@@ -24,6 +24,8 @@
  THE SOFTWARE.
  */
 
+#include <cstdint>
+
 #include "../primitivesCore/PrimitiveContainer.h"
 #include "../primitivesCore/Routine.h"
 #include "../vm/Universe.h"

--- a/src/primitives/Array.cpp
+++ b/src/primitives/Array.cpp
@@ -56,7 +56,7 @@ void _Array::At_Put_(Interpreter*, VMFrame* frame) {
 
 void _Array::Length(Interpreter*, VMFrame* frame) {
     VMArray* self = static_cast<VMArray*>(frame->Pop());
-    vm_oop_t new_int = NEW_INT(self->GetNumberOfIndexableFields());
+    vm_oop_t new_int = NEW_INT((int64_t) self->GetNumberOfIndexableFields());
     frame->Push(new_int);
 }
 
@@ -66,4 +66,3 @@ void _Array::New_(Interpreter*, VMFrame* frame) {
     long size = INT_VAL(arg);
     frame->Push(GetUniverse()->NewArray(size));
 }
-

--- a/src/primitives/Integer.cpp
+++ b/src/primitives/Integer.cpp
@@ -107,7 +107,7 @@ void _Integer::Plus(Interpreter* interp, VMFrame* frame) {
     frame->Push(NEW_INT(result));
 }
 
-void _Integer::BitwiseAnd(Interpreter* interp, VMFrame* frame) {
+void _Integer::BitwiseAnd(Interpreter*, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
 
@@ -115,7 +115,7 @@ void _Integer::BitwiseAnd(Interpreter* interp, VMFrame* frame) {
     frame->Push(NEW_INT(result));
 }
 
-void _Integer::BitwiseXor(Interpreter* interp, VMFrame* frame) {
+void _Integer::BitwiseXor(Interpreter*, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
 
@@ -124,7 +124,7 @@ void _Integer::BitwiseXor(Interpreter* interp, VMFrame* frame) {
 }
 
 
-void _Integer::LeftShift(Interpreter* interp, VMFrame* frame) {
+void _Integer::LeftShift(Interpreter*, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
 
@@ -132,7 +132,7 @@ void _Integer::LeftShift(Interpreter* interp, VMFrame* frame) {
     frame->Push(NEW_INT(result));
 }
 
-void _Integer::UnsignedRightShift(Interpreter* interp, VMFrame* frame) {
+void _Integer::UnsignedRightShift(Interpreter*, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
 
@@ -241,7 +241,7 @@ void _Integer::Equal(Interpreter* interp, VMFrame* frame) {
     }
 }
 
-void _Integer::EqualEqual(Interpreter* interp, VMFrame* frame) {
+void _Integer::EqualEqual(Interpreter*, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj  = frame->Pop();
 

--- a/src/primitives/Object.cpp
+++ b/src/primitives/Object.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <cstddef>
+#include <cstdint>
 
 #include "../primitivesCore/PrimitiveContainer.h"
 #include "../primitivesCore/Routine.h"
@@ -53,7 +54,7 @@ _Object::_Object() : PrimitiveContainer() {
     SetPrimitive("instVarAt_",     new Routine<_Object>(this, &_Object::InstVarAt, false));
     SetPrimitive("instVarAt_put_", new Routine<_Object>(this, &_Object::InstVarAtPut, false));
     SetPrimitive("instVarNamed_",  new Routine<_Object>(this, &_Object::InstVarNamed, false));
-    
+
     SetPrimitive("class", new Routine<_Object>(this, &_Object::Class, false));
 }
 

--- a/src/primitives/Object.cpp
+++ b/src/primitives/Object.cpp
@@ -67,7 +67,7 @@ void _Object::Equalequal(Interpreter*, VMFrame* frame) {
 void _Object::ObjectSize(Interpreter*, VMFrame* frame) {
     vm_oop_t self = frame->Pop();
 
-    frame->Push(NEW_INT(AS_OBJ(self)->GetObjectSize()));
+    frame->Push(NEW_INT((int64_t) AS_OBJ(self)->GetObjectSize()));
 }
 
 void _Object::Hashcode(Interpreter*, VMFrame* frame) {

--- a/src/primitives/Primitive.cpp
+++ b/src/primitives/Primitive.cpp
@@ -16,12 +16,12 @@ _Primitive::_Primitive() : PrimitiveContainer() {
 }
 
 void _Primitive::Holder(Interpreter*, VMFrame* frame) {
-    VMMethod* self = static_cast<VMMethod*>(frame->Pop());
+    VMInvokable* self = static_cast<VMInvokable*>(frame->Pop());
     frame->Push(self->GetHolder());
 }
 
 void _Primitive::Signature(Interpreter*, VMFrame* frame) {
-    VMMethod* self = static_cast<VMMethod*>(frame->Pop());
+    VMInvokable* self = static_cast<VMInvokable*>(frame->Pop());
     frame->Push(self->GetSignature());
 }
 
@@ -29,8 +29,8 @@ void _Primitive::InvokeOn_With_(Interpreter* interp, VMFrame* frame) {
     // REM: this is a clone with _Primitive::InvokeOn_With_
     VMArray* args  = static_cast<VMArray*>(frame->Pop());
     vm_oop_t rcvr  = static_cast<vm_oop_t>(frame->Pop());
-    VMMethod* mthd = static_cast<VMMethod*>(frame->Pop());
-    
+    VMInvokable* mthd = static_cast<VMInvokable*>(frame->Pop());
+
     
     frame->Push(rcvr);
     

--- a/src/primitives/String.cpp
+++ b/src/primitives/String.cpp
@@ -81,7 +81,7 @@ void _String::Length(Interpreter*, VMFrame* frame) {
     VMString* self = static_cast<VMString*>(frame->Pop());
 
     size_t len = self->GetStringLength();
-    frame->Push(NEW_INT(len));
+    frame->Push(NEW_INT((int64_t) len));
 }
 
 void _String::Equal(Interpreter*, VMFrame* frame) {

--- a/src/primitivesCore/PrimitiveContainer.cpp
+++ b/src/primitivesCore/PrimitiveContainer.cpp
@@ -30,20 +30,12 @@
 #include "../vmobjects/PrimitiveRoutine.h"
 #include "PrimitiveContainer.h"
 
-PrimitiveContainer::PrimitiveContainer() {
-    methods = new map<std::string, PrimitiveRoutine*>();
-}
-
-PrimitiveContainer::~PrimitiveContainer() {
-    delete methods;
-}
-
 void PrimitiveContainer::SetPrimitive(const char* name,
         PrimitiveRoutine* routine) {
-    (*methods)[std::string(name)] = routine;
+    methods[std::string(name)] = routine;
 }
 
 PrimitiveRoutine* PrimitiveContainer::GetPrimitive(
         const std::string& routineName) {
-    return (*methods)[routineName];
+    return methods[routineName];
 }

--- a/src/primitivesCore/PrimitiveContainer.h
+++ b/src/primitivesCore/PrimitiveContainer.h
@@ -38,8 +38,8 @@
 class PrimitiveContainer {
 
 public:
-    PrimitiveContainer();
-    virtual ~PrimitiveContainer();
+    PrimitiveContainer() = default;
+    virtual ~PrimitiveContainer() = default;
 
     ///Every derived Class must use this method to initialize the methods
     //map with the mapping of a StdString with the smalltalk message
@@ -52,5 +52,5 @@ public:
     virtual PrimitiveRoutine* GetPrimitive(const std::string& routineName);
 
 private:
-    std::map<std::string, PrimitiveRoutine*>* methods;
+    std::map<std::string, PrimitiveRoutine*> methods{};
 };

--- a/src/primitivesCore/PrimitiveLoader.cpp
+++ b/src/primitivesCore/PrimitiveLoader.cpp
@@ -46,8 +46,6 @@
 PrimitiveLoader PrimitiveLoader::loader;
 
 PrimitiveLoader::PrimitiveLoader() {
-    primitiveObjects = map<std::string, PrimitiveContainer*>();
-    
     AddPrimitiveObject("Array",     new _Array());
     AddPrimitiveObject("Block",     new _Block());
     AddPrimitiveObject("Class",     new _Class());
@@ -88,13 +86,12 @@ PrimitiveRoutine* PrimitiveLoader::GetPrimitiveRoutine(const std::string& cname,
 
 PrimitiveRoutine* PrimitiveLoader::getPrimitiveRoutine(const std::string& cname,
         const std::string& mname, bool isPrimitive) {
-    PrimitiveRoutine* result;
     PrimitiveContainer* primitive = primitiveObjects[cname];
     if (!primitive) {
         ErrorPrint("Primitive object not found for name: " + cname + "\n");
         return nullptr;
     }
-    result = primitive->GetPrimitive(mname);
+    PrimitiveRoutine* result = primitive->GetPrimitive(mname);
     if (!result) {
         if (isPrimitive) {
             ErrorPrint("method " + mname + " not found in class " + cname + "\n");

--- a/src/primitivesCore/PrimitiveLoader.h
+++ b/src/primitivesCore/PrimitiveLoader.h
@@ -59,7 +59,7 @@ private:
 
 
     
-    std::map<StdString, PrimitiveContainer*> primitiveObjects;
+    std::map<StdString, PrimitiveContainer*> primitiveObjects{};
     
     static PrimitiveLoader loader;
 };

--- a/src/primitivesCore/Routine.h
+++ b/src/primitivesCore/Routine.h
@@ -44,8 +44,8 @@ public:
     // takes pointer to an object, pointer to a member, and a bool indicating whether it is a class-side primitive or not
     Routine(TClass* primContainerObj, void (TClass::*_fpt)(Interpreter*, VMFrame*),
             bool classSide)
-        : classSide(classSide), primContainerObj(primContainerObj),
-          func(_fpt), PrimitiveRoutine() {};
+        : PrimitiveRoutine(), func(_fpt), primContainerObj(primContainerObj), classSide(classSide)
+           {};
 
     void Invoke(Interpreter* interp, VMFrame* frm) override {
         (*primContainerObj.*func)(interp, frm);  // execute member function

--- a/src/unitTests/CloneObjectsTest.cpp
+++ b/src/unitTests/CloneObjectsTest.cpp
@@ -29,7 +29,7 @@
 
 
 void CloneObjectsTest::testCloneObject() {
-    VMObject* orig = new (GetHeap<HEAP_CLS>()) VMObject();
+    VMObject* orig = new (GetHeap<HEAP_CLS>(), 0) VMObject(0, sizeof(VMObject));
     VMObject* clone = orig->Clone();
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("class differs!!", orig->GetClass(),
@@ -97,7 +97,9 @@ void CloneObjectsTest::testCloneArray() {
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("class differs!!", orig->clazz, clone->clazz);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->objectSize, clone->objectSize);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!",
+                                 orig->totalObjectSize,
+                                 clone->totalObjectSize);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfFields differs!!", orig->numberOfFields, clone->numberOfFields);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfFields differs!!", orig->GetNumberOfIndexableFields(), clone->GetNumberOfIndexableFields());
 
@@ -119,7 +121,7 @@ void CloneObjectsTest::testCloneBlock() {
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("class differs!!", orig->clazz, clone->clazz);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->objectSize, clone->objectSize);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->totalObjectSize, clone->totalObjectSize);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfFields differs!!", orig->numberOfFields, clone->numberOfFields);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("blockMethod differs!!", orig->blockMethod, clone->blockMethod);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("context differs!!", orig->context, clone->context);
@@ -135,7 +137,7 @@ void CloneObjectsTest::testClonePrimitive() {
 }
 
 void CloneObjectsTest::testCloneEvaluationPrimitive() {
-    VMEvaluationPrimitive* orig = new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(1);
+    VMEvaluationPrimitive* orig = new (GetHeap<HEAP_CLS>(), 0) VMEvaluationPrimitive(1);
     VMEvaluationPrimitive* clone = orig->Clone();
 
     CPPUNIT_ASSERT_EQUAL_MESSAGE("signature differs!!", orig->signature, clone->signature);
@@ -157,7 +159,7 @@ void CloneObjectsTest::testCloneFrame() {
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("class differs!!", orig->clazz, clone->clazz);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->objectSize, clone->objectSize);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->totalObjectSize, clone->totalObjectSize);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfFields differs!!", orig->numberOfFields, clone->numberOfFields);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("GetPreviousFrame differs!!", orig->GetPreviousFrame(), clone->GetPreviousFrame());
     CPPUNIT_ASSERT_EQUAL_MESSAGE("GetContext differs!!", orig->GetContext(), clone->GetContext());
@@ -197,7 +199,7 @@ void CloneObjectsTest::testCloneClass() {
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("class differs!!", orig->clazz, clone->clazz);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->objectSize, clone->objectSize);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->totalObjectSize, clone->totalObjectSize);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfFields differs!!", orig->numberOfFields, clone->numberOfFields);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("superClass differs!!", orig->superClass, clone->superClass);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("name differs!!", orig->name, clone->name);

--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -147,8 +147,8 @@ void WalkObjectsTest::testWalkFrame() {
     VMSymbol* methodSymbol = NewSymbol("frameMethod");
     VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0);
     VMFrame* frame = GetUniverse()->NewFrame(nullptr, method);
-    frame->SetPreviousFrame(frame->Clone());
-    frame->SetContext(frame->Clone());
+    frame->SetPreviousFrame(frame->CloneForMovingGC());
+    frame->SetContext(frame->CloneForMovingGC());
     VMInteger* dummyArg = GetUniverse()->NewInteger(1111);
     frame->SetArgument(0, 0, dummyArg);
     frame->WalkObjects(collectMembers);

--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -78,7 +78,7 @@ void WalkObjectsTest::testWalkDouble() {
 void WalkObjectsTest::testWalkEvaluationPrimitive() {
     walkedObjects.clear();
 
-    VMEvaluationPrimitive* evPrim = new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(1);
+    VMEvaluationPrimitive* evPrim = new (GetHeap<HEAP_CLS>(), 0) VMEvaluationPrimitive(1);
     evPrim->SetHolder(load_ptr(classClass));
     evPrim->WalkObjects(collectMembers);
 
@@ -91,7 +91,7 @@ void WalkObjectsTest::testWalkEvaluationPrimitive() {
 void WalkObjectsTest::testWalkObject() {
     walkedObjects.clear();
 
-    VMObject* obj = new (GetHeap<HEAP_CLS>()) VMObject();
+    VMObject* obj = new (GetHeap<HEAP_CLS>(), 0) VMObject(0, sizeof(VMObject));
     obj->WalkObjects(collectMembers);
 
     //Objects should only have one member -> Class

--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -83,9 +83,9 @@ void WalkObjectsTest::testWalkEvaluationPrimitive() {
     evPrim->SetHolder(load_ptr(classClass));
     evPrim->WalkObjects(collectMembers);
 
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(evPrim->GetSignature())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(evPrim->GetHolder())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(evPrim)));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(evPrim->GetSignature())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(evPrim->GetHolder())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(evPrim)));
     CPPUNIT_ASSERT_EQUAL(NoOfFields_EvaluationPrimitive, walkedObjects.size());
 }
 
@@ -97,7 +97,7 @@ void WalkObjectsTest::testWalkObject() {
 
     //Objects should only have one member -> Class
     CPPUNIT_ASSERT_EQUAL(NoOfFields_Object, walkedObjects.size());
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(obj->GetClass())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(obj->GetClass())));
 }
 
 void WalkObjectsTest::testWalkString() {
@@ -123,11 +123,11 @@ void WalkObjectsTest::testWalkClass() {
     meta->WalkObjects(collectMembers);
 
     //Now check if we found all class fields
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(meta->GetClass())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(meta->GetSuperClass())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(meta->GetName())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(meta->GetInstanceFields())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(meta->GetInstanceInvokables())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(meta->GetClass())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(meta->GetSuperClass())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(meta->GetName())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(meta->GetInstanceFields())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(meta->GetInstanceInvokables())));
     CPPUNIT_ASSERT_EQUAL(NoOfFields_Class, walkedObjects.size());
 }
 
@@ -139,8 +139,8 @@ void WalkObjectsTest::testWalkPrimitive() {
 
     prim->WalkObjects(collectMembers);
     CPPUNIT_ASSERT_EQUAL(NoOfFields_Primitive, walkedObjects.size());
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(prim->GetSignature())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(prim->GetHolder())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(prim->GetSignature())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(prim->GetHolder())));
 }
 
 void WalkObjectsTest::testWalkFrame() {
@@ -154,11 +154,11 @@ void WalkObjectsTest::testWalkFrame() {
     frame->SetArgument(0, 0, dummyArg);
     frame->WalkObjects(collectMembers);
 
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(frame->GetPreviousFrame())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(frame->GetContext())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(frame->GetMethod())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(frame->GetPreviousFrame())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(frame->GetContext())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(frame->GetMethod())));
     //CPPUNIT_ASSERT(WalkerHasFound(frame->bytecodeIndex));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(dummyArg)));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(dummyArg)));
     CPPUNIT_ASSERT_EQUAL(
             (long) (NoOfFields_Frame + method->GetNumberOfArguments()),
             (long) walkedObjects.size() + 1);  // + 1 for the class field that's still in there
@@ -172,8 +172,8 @@ void WalkObjectsTest::testWalkMethod() {
     method->WalkObjects(collectMembers);
 
     //the following fields had no getters -> had to become friend
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(method->GetHolder())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(method->GetSignature())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(method->GetHolder())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(method->GetSignature())));
     CPPUNIT_ASSERT_EQUAL(NoOfFields_Method, walkedObjects.size());
 }
 
@@ -186,9 +186,9 @@ void WalkObjectsTest::testWalkBlock() {
             method->GetNumberOfArguments());
     block->WalkObjects(collectMembers);
     CPPUNIT_ASSERT_EQUAL(NoOfFields_Block, walkedObjects.size());
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(block->GetClass())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(block->GetContext())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(method)));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(block->GetClass())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(block->GetContext())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(method)));
 }
 
 void WalkObjectsTest::testWalkArray() {
@@ -201,7 +201,7 @@ void WalkObjectsTest::testWalkArray() {
     a->WalkObjects(collectMembers);
 
     CPPUNIT_ASSERT_EQUAL(NoOfFields_Array + 2, walkedObjects.size());
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(a->GetClass())));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(str1)));
-    CPPUNIT_ASSERT(WalkerHasFound(_store_ptr(int1)));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(a->GetClass())));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(str1)));
+    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(int1)));
 }

--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -32,7 +32,6 @@ static const size_t NoOfFields_String = 0;
 static const size_t NoOfFields_Symbol = 0;
 static const size_t NoOfFields_Double = 0;
 static const size_t NoOfFields_Integer = 0;
-static const size_t NoOfFields_BigInteger = 0;
 static const size_t NoOfFields_Array = NoOfFields_Object;
 static const size_t NoOfFields_Invokable = 2;
 static const size_t NoOfFields_Method = NoOfFields_Invokable;

--- a/src/unitTests/WalkObjectsTest.h
+++ b/src/unitTests/WalkObjectsTest.h
@@ -8,17 +8,16 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
-#include "../vmobjects/VMSymbol.h"
+#include "../vmobjects/VMArray.h"
+#include "../vmobjects/VMBlock.h"
 #include "../vmobjects/VMClass.h"
 #include "../vmobjects/VMDouble.h"
-#include "../vmobjects/VMInteger.h"
-#include "../vmobjects/VMArray.h"
-#include "../vmobjects/VMMethod.h"
-#include "../vmobjects/VMBlock.h"
-#include "../vmobjects/VMPrimitive.h"
-#include "../vmobjects/VMFrame.h"
 #include "../vmobjects/VMEvaluationPrimitive.h"
-#include "WalkObjectsTest.h"
+#include "../vmobjects/VMFrame.h"
+#include "../vmobjects/VMInteger.h"
+#include "../vmobjects/VMMethod.h"
+#include "../vmobjects/VMPrimitive.h"
+#include "../vmobjects/VMSymbol.h"
 
 using namespace std;
 

--- a/src/unitTests/WriteBarrierTest.cpp
+++ b/src/unitTests/WriteBarrierTest.cpp
@@ -77,13 +77,6 @@ void WriteBarrierTest::testWriteBlock() {
             block->GetMethod());
     TEST_WB_CALLED("VMBlock failed to call writeBarrier when creating", block,
             block->GetContext());
-
-    block->SetMethod(method->Clone());
-    TEST_WB_CALLED("VMBlock failed to call writeBarrier on SetMethod", block,
-            block->GetMethod());
-    block->SetContext(block->GetContext()->Clone());
-    TEST_WB_CALLED("VMBlock failed to call writeBarrier on SetContext", block,
-            block->GetContext());
 }
 
 void WriteBarrierTest::testWriteFrame() {
@@ -124,7 +117,7 @@ void WriteBarrierTest::testWriteEvaluationPrimitive() {
 
     //reset set...
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
-    VMEvaluationPrimitive* evPrim = new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(1);
+    VMEvaluationPrimitive* evPrim = new (GetHeap<HEAP_CLS>(), 0) VMEvaluationPrimitive(1);
     TEST_WB_CALLED("VMEvaluationPrimitive failed to call writeBarrier when creating", evPrim, evPrim->GetClass());
 }
 

--- a/src/unitTests/WriteBarrierTest.cpp
+++ b/src/unitTests/WriteBarrierTest.cpp
@@ -39,8 +39,8 @@ void WriteBarrierTest::testWriteArray() {
     VMInteger* newInt = GetUniverse()->NewInteger(12345);
     VMString* str = GetUniverse()->NewString("asdfghjkl");
     VMDouble* doub = GetUniverse()->NewDouble(9876.654);
-    VMClass* cloneClass = load_ptr(arrayClass)->Clone();
-    VMClass* clone2Class = cloneClass->Clone();
+    VMClass* cloneClass = load_ptr(arrayClass)->CloneForMovingGC();
+    VMClass* clone2Class = cloneClass->CloneForMovingGC();
     arr->SetClass(cloneClass);
     arr->SetField(0, clone2Class);
     arr->SetIndexableField(0, newInt);
@@ -87,12 +87,12 @@ void WriteBarrierTest::testWriteFrame() {
     // reset set...
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
 
-    VMFrame* frame = GetUniverse()->GetInterpreter()->GetFrame()->Clone();
-    frame->SetContext(frame->Clone());
+    VMFrame* frame = GetUniverse()->GetInterpreter()->GetFrame()->CloneForMovingGC();
+    frame->SetContext(frame->CloneForMovingGC());
 
     frame->SetPreviousFrame(GetUniverse()->GetInterpreter()->GetFrame());
     TEST_WB_CALLED("VMFrame failed to call writeBarrier on SetPreviousFrame", frame, GetUniverse()->GetInterpreter()->GetFrame());
-    frame->SetContext(frame->GetContext()->Clone());
+    frame->SetContext(frame->GetContext()->CloneForMovingGC());
     TEST_WB_CALLED("VMFrame failed to call writeBarrier on SetContext", frame, frame->GetContext());
     frame->ClearPreviousFrame();
     TEST_WB_CALLED("VMFrame failed to call writeBarrier on ClearPreviousFrame", frame, load_ptr(nilObject));
@@ -105,7 +105,7 @@ void WriteBarrierTest::testWriteMethod() {
 
     // reset set...
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
-    VMMethod* method = GetUniverse()->GetInterpreter()->GetFrame()->GetMethod()->Clone();
+    VMMethod* method = GetUniverse()->GetInterpreter()->GetFrame()->GetMethod()->CloneForMovingGC();
     method->SetHolder(load_ptr(integerClass));
     TEST_WB_CALLED("VMMethod failed to call writeBarrier on SetHolder", method, load_ptr(integerClass));
 }
@@ -128,7 +128,7 @@ void WriteBarrierTest::testWriteClass() {
 
     //reset set...
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
-    VMClass* cl = load_ptr(integerClass)->Clone();
+    VMClass* cl = load_ptr(integerClass)->CloneForMovingGC();
     //now test all methods that change members
     cl->SetSuperClass(load_ptr(integerClass));
     TEST_WB_CALLED("VMClass failed to call writeBarrier on SetSuperClass", cl,
@@ -137,11 +137,11 @@ void WriteBarrierTest::testWriteClass() {
     cl->SetName(newName);
     TEST_WB_CALLED("VMClass failed to call writeBarrier on SetName", cl,
             newName);
-    VMArray* newInstFields = cl->GetInstanceFields()->Clone();
+    VMArray* newInstFields = cl->GetInstanceFields()->CloneForMovingGC();
     cl->SetInstanceFields(newInstFields);
     TEST_WB_CALLED("VMClass failed to call writeBarrier on SetInstanceFields", cl,
             newName);
-    VMArray* newInstInvokables = cl->GetInstanceInvokables()->Clone();
+    VMArray* newInstInvokables = cl->GetInstanceInvokables()->CloneForMovingGC();
     cl->SetInstanceInvokables(newInstInvokables);
     TEST_WB_CALLED("VMClass failed to call writeBarrier on SetInstanceInvokables", cl,
             newName);

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -67,7 +67,7 @@ bool IsValidObject(vm_oop_t obj) {
         return false;
     }
 
-# if GC_TYPE == COPYING
+# if GC_TYPE == COPYING || GC_TYPE == DEBUG_COPYING
     if (AS_OBJ(obj)->GetGCField() != 0) {
         // this is a properly forwarded object
         return true;

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -6,7 +6,7 @@
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMArray.h"
 #include "../vmobjects/VMBlock.h"
-#include "../vmobjects/VMClass.h"
+#include "../vmobjects/VMClass.h" // NOLINT(misc-include-cleaner) it's required to make the types complete
 #include "../vmobjects/VMDouble.h"
 #include "../vmobjects/VMEvaluationPrimitive.h"
 #include "../vmobjects/VMFrame.h"
@@ -34,7 +34,7 @@ bool IsValidObject(vm_oop_t obj) {
     if (!DEBUG) {
         return true;
     }
-    
+
     if (obj == nullptr)
         return true;
 

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -110,6 +110,11 @@ bool IsVMInteger(vm_oop_t obj) {
     return get_vtable(AS_OBJ(obj)) == vt_integer;
 }
 
+bool IsVMSymbol(vm_oop_t obj) {
+    assert(vt_symbol != nullptr);
+    return get_vtable(AS_OBJ(obj)) == vt_symbol;
+}
+
 void obtain_vtables_of_known_classes(VMSymbol* className) {
     VMArray* arr  = new (GetHeap<HEAP_CLS>()) VMArray(0, 0);
     vt_array      = get_vtable(arr);

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -116,31 +116,32 @@ bool IsVMSymbol(vm_oop_t obj) {
 }
 
 void obtain_vtables_of_known_classes(VMSymbol* className) {
-    VMArray* arr  = new (GetHeap<HEAP_CLS>()) VMArray(0, 0);
+    // These objects are allocated on the heap. So, they will get GC'ed soon enough.
+    VMArray* arr  = new (GetHeap<HEAP_CLS>(), 0) VMArray(0, 0);
     vt_array      = get_vtable(arr);
 
-    VMBlock* blck = new (GetHeap<HEAP_CLS>()) VMBlock();
+    VMBlock* blck = new (GetHeap<HEAP_CLS>(), 0) VMBlock(nullptr, nullptr);
     vt_block      = get_vtable(blck);
 
     vt_class      = get_vtable(load_ptr(symbolClass));
 
-    VMDouble* dbl = new (GetHeap<HEAP_CLS>()) VMDouble(0.0);
+    VMDouble* dbl = new (GetHeap<HEAP_CLS>(), 0) VMDouble(0.0);
     vt_double     = get_vtable(dbl);
 
-    VMEvaluationPrimitive* ev = new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(1);
+    VMEvaluationPrimitive* ev = new (GetHeap<HEAP_CLS>(), 0) VMEvaluationPrimitive(1);
     vt_eval_primitive = get_vtable(ev);
 
-    VMFrame* frm  = new (GetHeap<HEAP_CLS>()) VMFrame(0, 0);
+    VMFrame* frm  = new (GetHeap<HEAP_CLS>(), 0) VMFrame(0, 0);
     vt_frame      = get_vtable(frm);
 
-    VMInteger* i  = new (GetHeap<HEAP_CLS>()) VMInteger(0);
+    VMInteger* i  = new (GetHeap<HEAP_CLS>(), 0) VMInteger(0);
     vt_integer    = get_vtable(i);
 
-    VMMethod* mth = new (GetHeap<HEAP_CLS>()) VMMethod(nullptr, 0, 0, 0, 0);
+    VMMethod* mth = new (GetHeap<HEAP_CLS>(), 0) VMMethod(nullptr, 0, 0, 0, 0);
     vt_method     = get_vtable(mth);
     vt_object     = get_vtable(load_ptr(nilObject));
 
-    VMPrimitive* prm = new (GetHeap<HEAP_CLS>()) VMPrimitive(className);
+    VMPrimitive* prm = new (GetHeap<HEAP_CLS>(), 0) VMPrimitive(className);
     vt_primitive  = get_vtable(prm);
 
     VMString* str = new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -6,6 +6,7 @@
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMArray.h"
 #include "../vmobjects/VMBlock.h"
+#include "../vmobjects/VMClass.h"
 #include "../vmobjects/VMDouble.h"
 #include "../vmobjects/VMEvaluationPrimitive.h"
 #include "../vmobjects/VMFrame.h"
@@ -100,35 +101,44 @@ void set_vt_to_null() {
     vt_symbol     = nullptr;
 }
 
+static void* get_vtable(AbstractVMObject* obj) {
+    return *(void**) obj;
+}
+
+bool IsVMInteger(vm_oop_t obj) {
+    assert(vt_integer != nullptr);
+    return get_vtable(AS_OBJ(obj)) == vt_integer;
+}
+
 void obtain_vtables_of_known_classes(VMSymbol* className) {
     VMArray* arr  = new (GetHeap<HEAP_CLS>()) VMArray(0, 0);
-    vt_array      = *(void**) arr;
-    
+    vt_array      = get_vtable(arr);
+
     VMBlock* blck = new (GetHeap<HEAP_CLS>()) VMBlock();
-    vt_block      = *(void**) blck;
-    
-    vt_class      = *(void**) symbolClass;
-    
+    vt_block      = get_vtable(blck);
+
+    vt_class      = get_vtable(load_ptr(symbolClass));
+
     VMDouble* dbl = new (GetHeap<HEAP_CLS>()) VMDouble(0.0);
-    vt_double     = *(void**) dbl;
-    
+    vt_double     = get_vtable(dbl);
+
     VMEvaluationPrimitive* ev = new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(1);
-    vt_eval_primitive = *(void**) ev;
-    
+    vt_eval_primitive = get_vtable(ev);
+
     VMFrame* frm  = new (GetHeap<HEAP_CLS>()) VMFrame(0, 0);
-    vt_frame      = *(void**) frm;
-    
+    vt_frame      = get_vtable(frm);
+
     VMInteger* i  = new (GetHeap<HEAP_CLS>()) VMInteger(0);
-    vt_integer    = *(void**) i;
-    
+    vt_integer    = get_vtable(i);
+
     VMMethod* mth = new (GetHeap<HEAP_CLS>()) VMMethod(nullptr, 0, 0, 0, 0);
-    vt_method     = *(void**) mth;
-    vt_object     = *(void**) nilObject;
-    
+    vt_method     = get_vtable(mth);
+    vt_object     = get_vtable(load_ptr(nilObject));
+
     VMPrimitive* prm = new (GetHeap<HEAP_CLS>()) VMPrimitive(className);
-    vt_primitive  = *(void**) prm;
-    
+    vt_primitive  = get_vtable(prm);
+
     VMString* str = new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);
-    vt_string     = *(void**) str;
-    vt_symbol     = *(void**) className;
+    vt_string     = get_vtable(str);
+    vt_symbol     = get_vtable(className);
 }

--- a/src/vm/IsValidObject.h
+++ b/src/vm/IsValidObject.h
@@ -6,6 +6,7 @@
 bool IsValidObject(vm_oop_t obj);
 
 bool IsVMInteger(vm_oop_t obj);
+bool IsVMSymbol(vm_oop_t obj);
 
 void set_vt_to_null();
 

--- a/src/vm/IsValidObject.h
+++ b/src/vm/IsValidObject.h
@@ -5,6 +5,8 @@
 
 bool IsValidObject(vm_oop_t obj);
 
+bool IsVMInteger(vm_oop_t obj);
+
 void set_vt_to_null();
 
 void obtain_vtables_of_known_classes(VMSymbol* className);

--- a/src/vm/Symbols.cpp
+++ b/src/vm/Symbols.cpp
@@ -17,7 +17,7 @@ GCSymbol* symbolIfFalse;
 
 VMSymbol* NewSymbol(const size_t length, const char* str) {
     VMSymbol* result = new (GetHeap<HEAP_CLS>(), PADDED_SIZE(length)) VMSymbol(length, str);
-    symbolsMap[StdString(str, length)] = _store_ptr(result);
+    symbolsMap[StdString(str, length)] = store_root(result);
 
     LOG_ALLOCATION("VMSymbol", result->GetObjectSize());
     return result;
@@ -33,8 +33,8 @@ VMSymbol* SymbolFor(const std::string& str) {
 }
 
 void InitializeSymbols() {
-    symbolIfTrue  = _store_ptr(SymbolFor("ifTrue:"));
-    symbolIfFalse = _store_ptr(SymbolFor("ifFalse:"));
+    symbolIfTrue  = store_root(SymbolFor("ifTrue:"));
+    symbolIfFalse = store_root(SymbolFor("ifFalse:"));
 }
 
 void WalkSymbols(walk_heap_fn walk) {

--- a/src/vm/Symbols.cpp
+++ b/src/vm/Symbols.cpp
@@ -4,7 +4,6 @@
 
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
-#include "../vmobjects/AbstractObject.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMSymbol.h"
 #include "LogAllocation.h"

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -32,7 +32,7 @@
 #include <exception>
 #include <iostream>
 #include <map>
-#include <sstream> 
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -122,7 +122,7 @@ __attribute__((noreturn)) void Universe::Quit(long err) {
 #endif
 
     OutputAllocationLogFile();
-    
+
     if (theUniverse)
         delete (theUniverse);
 
@@ -265,7 +265,7 @@ VMMethod* Universe::createBootstrapMethod(VMClass* holder, long numArgsOfMsgSend
 vm_oop_t Universe::interpret(StdString className, StdString methodName) {
   // This method assumes that SOM++ was already initialized by executing a
   // Hello World program as part of the unittest main.
-  
+
   bm_name = "BasicInterpreterTests";
 
   interpreter = new Interpreter();
@@ -320,7 +320,7 @@ void Universe::initialize(long _argc, char** _argv) {
     heapSize = 1 * 1024 * 1024;
 
     vector<StdString> argv = handleArguments(_argc, _argv);
-    
+
     // remember file that was executed (for writing statistics)
     if (argv.size() > 0)
         bm_name = argv[0];
@@ -365,14 +365,14 @@ Universe::~Universe() {
 
 VMObject* Universe::InitializeGlobals() {
     set_vt_to_null();
-    
+
     //
     //allocate nil object
     //
     VMObject* nil = NewInstanceWithoutFields();
     nilObject = _store_ptr(nil);
     nil->SetClass((VMClass*) nil);
-    
+
     trueObject = _store_ptr(NewInstanceWithoutFields());
     falseObject = _store_ptr(NewInstanceWithoutFields());
 
@@ -407,7 +407,7 @@ VMObject* Universe::InitializeGlobals() {
     load_ptr(objectClass)->SetSuperClass((VMClass*) nil);
 
     obtain_vtables_of_known_classes(nil->GetClass()->GetName());
-    
+
 #if USE_TAGGING
     GlobalBox::updateIntegerBox(NewInteger(1));
 #endif
@@ -429,24 +429,24 @@ VMObject* Universe::InitializeGlobals() {
     VMSymbol* trueClassName = SymbolFor("True");
     trueClass  = _store_ptr(LoadClass(trueClassName));
     load_ptr(trueObject)->SetClass(load_ptr(trueClass));
-    
+
     VMSymbol* falseClassName = SymbolFor("False");
     falseClass  = _store_ptr(LoadClass(falseClassName));
     load_ptr(falseObject)->SetClass(load_ptr(falseClass));
 
     systemClass = _store_ptr(LoadClass(SymbolFor("System")));
-    
-    
+
+
     VMObject* systemObject = NewInstance(load_ptr(systemClass));
-    
+
     SetGlobal(SymbolFor("nil"),    load_ptr(nilObject));
     SetGlobal(SymbolFor("true"),   load_ptr(trueObject));
     SetGlobal(SymbolFor("false"),  load_ptr(falseObject));
     SetGlobal(SymbolFor("system"), systemObject);
     SetGlobal(SymbolFor("System"), load_ptr(systemClass));
     SetGlobal(SymbolFor("Block"),  load_ptr(blockClass));
-    
-    InitializeSymbols();    
+
+    InitializeSymbols();
     return systemObject;
 }
 
@@ -532,7 +532,7 @@ VMClass* superClass, const char* name) {
 
 VMClass* Universe::LoadClass(VMSymbol* name) {
     VMClass* result = static_cast<VMClass*>(GetGlobal(name));
-    
+
     if (result != nullptr)
         return result;
 
@@ -545,7 +545,7 @@ VMClass* Universe::LoadClass(VMSymbol* name) {
 
     if (result->HasPrimitives() || result->GetClass()->HasPrimitives())
         result->LoadPrimitives(classPath);
-    
+
     SetGlobal(name, result);
 
     return result;
@@ -591,9 +591,9 @@ void Universe::LoadSystemClass(VMClass* systemClass) {
 
 VMArray* Universe::NewArray(long size) const {
     long additionalBytes = size * sizeof(VMObject*);
-    
+
     bool outsideNursery;
-    
+
 #if GC_TYPE == GENERATIONAL
     // if the array is too big for the nursery, we will directly allocate a
     // mature object
@@ -605,7 +605,7 @@ VMArray* Universe::NewArray(long size) const {
         result->SetGCField(MASK_OBJECT_IS_OLD);
 
     result->SetClass(load_ptr(arrayClass));
-    
+
     LOG_ALLOCATION("VMArray", result->GetObjectSize());
     return result;
 }
@@ -617,7 +617,7 @@ VMArray* Universe::NewArrayFromStrings(const vector<StdString>& argv) const {
             i != argv.end(); ++i) {
         result->SetIndexableField(j, NewString(*i));
         ++j;
-    }
+}
 
     return result;
 }
@@ -694,7 +694,7 @@ VMFrame* Universe::NewFrame(VMFrame* previousFrame, VMMethod* method) const {
     result->method        = _store_ptr(method);
     result->previousFrame = _store_ptr(previousFrame);
     result->ResetStackPointer();
-    
+
     LOG_ALLOCATION("VMFrame", result->GetObjectSize());
     return result;
 }
@@ -766,7 +766,7 @@ void Universe::WalkGlobals(walk_heap_fn walk) {
     systemClass     = static_cast<GCClass*>(walk(systemClass));
     blockClass      = static_cast<GCClass*>(walk(blockClass));
     doubleClass     = static_cast<GCClass*>(walk(doubleClass));
-    
+
     trueClass  = static_cast<GCClass*>(walk(trueClass));
     falseClass = static_cast<GCClass*>(walk(falseClass));
 
@@ -790,9 +790,9 @@ void Universe::WalkGlobals(walk_heap_fn walk) {
         gc_oop_t val = walk(iter->second);
         globals[key] = val;
     }
-    
+
     WalkSymbols(walk);
-    
+
 
     map<long, GCClass*>::iterator bcIter;
     for (bcIter = blockClassesByNoOfArgs.begin();
@@ -800,7 +800,7 @@ void Universe::WalkGlobals(walk_heap_fn walk) {
          bcIter++) {
         bcIter->second = static_cast<GCClass*>(walk(bcIter->second));
     }
-    
+
     interpreter->WalkGlobals(walk);
 }
 
@@ -808,13 +808,8 @@ VMMethod* Universe::NewMethod(VMSymbol* signature,
         size_t numberOfBytecodes, size_t numberOfConstants, size_t numLocals, size_t maxStackDepth) const {
     // method needs space for the bytecodes and the pointers to the constants
     size_t additionalBytes = PADDED_SIZE(numberOfBytecodes + numberOfConstants*sizeof(VMObject*));
-//#if GC_TYPE==GENERATIONAL
-//    VMMethod* result = new (GetHeap<HEAP_CLS>(),additionalBytes, true) 
-//                VMMethod(numberOfBytecodes, numberOfConstants);
-//#else
     VMMethod* result = new (GetHeap<HEAP_CLS>(), additionalBytes)
         VMMethod(signature, numberOfBytecodes, numberOfConstants, numLocals, maxStackDepth);
-//#endif
 
     LOG_ALLOCATION("VMMethod", result->GetObjectSize());
     return result;

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -610,15 +610,23 @@ VMArray* Universe::NewArray(long size) const {
     return result;
 }
 
-VMArray* Universe::NewArrayFromStrings(const vector<StdString>& argv) const {
-    VMArray* result = NewArray(argv.size());
-    long j = 0;
-    for (vector<StdString>::const_iterator i = argv.begin();
-            i != argv.end(); ++i) {
-        result->SetIndexableField(j, NewString(*i));
-        ++j;
+VMArray* Universe::NewArrayFromStrings(const vector<std::string>& strings) const {
+    VMArray* result = NewArray(strings.size());
+    size_t j = 0;
+    for (const std::string& str : strings) {
+        result->SetIndexableField(j, NewString(str));
+        j += 1;
     }
+    return result;
+}
 
+VMArray* Universe::NewArrayOfSymbolsFromStrings(const vector<std::string>& strings) const {
+    VMArray* result = NewArray(strings.size());
+    size_t j = 0;
+    for (const std::string& str : strings) {
+        result->SetIndexableField(j, SymbolFor(str));
+        j += 1;
+    }
     return result;
 }
 

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -187,8 +187,8 @@ long Universe::getClassPathExt(vector<StdString>& tokens,
         const StdString& arg) const {
 #define EXT_TOKENS 2
     long result = ERR_SUCCESS;
-    long fpIndex = arg.find_last_of(fileSeparator);
-    long ssepIndex = arg.find(".som");
+    size_t fpIndex = arg.find_last_of(fileSeparator);
+    size_t ssepIndex = arg.find(".som");
 
     if (fpIndex == StdString::npos) { //no new path
         //different from CSOM (see also HandleArguments):
@@ -215,10 +215,8 @@ long Universe::setupClassPath(const StdString& cp) {
         std::stringstream ss(cp);
         StdString token;
 
-        long i = 0;
         while (getline(ss, token, pathSeparator)) {
             classPath.push_back(token);
-            ++i;
         }
 
         return ERR_SUCCESS;
@@ -532,8 +530,9 @@ VMClass* superClass, const char* name) {
 VMClass* Universe::LoadClass(VMSymbol* name) {
     VMClass* result = static_cast<VMClass*>(GetGlobal(name));
 
-    if (result != nullptr)
+    if (result != nullptr) {
         return result;
+    }
 
     result = LoadClassBasic(name, nullptr);
 
@@ -542,8 +541,9 @@ VMClass* Universe::LoadClass(VMSymbol* name) {
 		return (VMClass*) nilObject;
     }
 
-    if (result->HasPrimitives() || result->GetClass()->HasPrimitives())
-        result->LoadPrimitives(classPath);
+    if (result->HasPrimitives() || result->GetClass()->HasPrimitives()) {
+        result->LoadPrimitives();
+    }
 
     SetGlobal(name, result);
 
@@ -584,8 +584,9 @@ void Universe::LoadSystemClass(VMClass* systemClass) {
         Universe::Quit(ERR_FAIL);
     }
 
-    if (result->HasPrimitives() || result->GetClass()->HasPrimitives())
-        result->LoadPrimitives(classPath);
+    if (result->HasPrimitives() || result->GetClass()->HasPrimitives()) {
+        result->LoadPrimitives();
+    }
 }
 
 VMArray* Universe::NewArray(long size) const {
@@ -600,8 +601,9 @@ VMArray* Universe::NewArray(long size) const {
 #endif
 
     VMArray* result = new (GetHeap<HEAP_CLS>(), additionalBytes ALLOC_OUTSIDE_NURSERY(outsideNursery)) VMArray(size);
-    if ((GC_TYPE == GENERATIONAL) && outsideNursery)
+    if ((GC_TYPE == GENERATIONAL) && outsideNursery) {
         result->SetGCField(MASK_OBJECT_IS_OLD);
+    }
 
     result->SetClass(load_ptr(arrayClass));
 

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -330,7 +330,7 @@ void Universe::initialize(long _argc, char** _argv) {
 #if CACHE_INTEGER
     // create prebuilt integers
     for (long it = INT_CACHE_MIN_VALUE; it <= INT_CACHE_MAX_VALUE; ++it) {
-        prebuildInts[(unsigned long)(it - INT_CACHE_MIN_VALUE)] = store_root(new (GetHeap<HEAP_CLS>()) VMInteger(it));
+        prebuildInts[(unsigned long)(it - INT_CACHE_MIN_VALUE)] = store_root(new (GetHeap<HEAP_CLS>(), 0) VMInteger(it));
     }
 #endif
 

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -368,7 +368,6 @@ VMObject* Universe::InitializeGlobals() {
     //
     VMObject* nil = NewInstanceWithoutFields();
     nilObject = store_root(nil);
-    nil->SetClass((VMClass*) nil);
 
     trueObject = store_root(NewInstanceWithoutFields());
     falseObject = store_root(NewInstanceWithoutFields());
@@ -401,7 +400,7 @@ VMObject* Universe::InitializeGlobals() {
     InitializeSystemClass(load_ptr(doubleClass),    load_ptr(objectClass), "Double");
 
     // Fix up objectClass
-    load_ptr(objectClass)->SetSuperClass((VMClass*) nil);
+    load_ptr(objectClass)->SetSuperClass(nil);
 
     obtain_vtables_of_known_classes(nil->GetClass()->GetName());
 
@@ -735,9 +734,8 @@ VMInteger* Universe::NewInteger(int64_t value) const {
 
 VMClass* Universe::NewMetaclassClass() const {
     VMClass* result = new (GetHeap<HEAP_CLS>()) VMClass;
-    result->SetClass(new (GetHeap<HEAP_CLS>()) VMClass);
-
-    VMClass* mclass = result->GetClass();
+    VMClass* mclass = new (GetHeap<HEAP_CLS>()) VMClass;
+    result->SetClass(mclass);
     mclass->SetClass(result);
 
     LOG_ALLOCATION("VMClass", result->GetObjectSize());
@@ -829,10 +827,9 @@ VMString* Universe::NewString(const size_t length, const char* str) const {
 
 VMClass* Universe::NewSystemClass() const {
     VMClass* systemClass = new (GetHeap<HEAP_CLS>()) VMClass();
+    VMClass* mclass = new (GetHeap<HEAP_CLS>()) VMClass();
 
-    systemClass->SetClass(new (GetHeap<HEAP_CLS>()) VMClass());
-    VMClass* mclass = systemClass->GetClass();
-
+    systemClass->SetClass(mclass);
     mclass->SetClass(load_ptr(metaClassClass));
 
     LOG_ALLOCATION("VMClass", systemClass->GetObjectSize());

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -26,7 +26,6 @@
  THE SOFTWARE.
  */
 
-//#define __DEBUG
 #include <map>
 #include <vector>
 

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -64,7 +64,7 @@ public:
     void Assert(bool) const;
 
     //VMObject instanciation methods. These should probably be refactored to a new class
-    VMArray* NewArray(long) const;
+    VMArray* NewArray(size_t) const;
 
     VMArray* NewArrayList(std::vector<vm_oop_t>& list) const;
     VMArray* NewArrayList(std::vector<VMInvokable*>& list) const;

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -60,16 +60,16 @@ public:
     Interpreter* GetInterpreter() {
         return interpreter;
     }
-    
+
     void Assert(bool) const;
 
     //VMObject instanciation methods. These should probably be refactored to a new class
     VMArray* NewArray(long) const;
-    
+
     VMArray* NewArrayList(std::vector<vm_oop_t>& list) const;
     VMArray* NewArrayList(std::vector<VMInvokable*>& list) const;
     VMArray* NewArrayList(std::vector<VMSymbol*>& list) const;
-    
+
     VMArray* NewArrayFromStrings(const vector<StdString>&) const;
     VMBlock* NewBlock(VMMethod*, VMFrame*, long);
     VMClass* NewClass(VMClass*) const;
@@ -129,7 +129,7 @@ private:
 
     long heapSize;
     map<GCSymbol*, gc_oop_t> globals;
-    
+
     map<long, GCClass*> blockClassesByNoOfArgs;
     vector<StdString> classPath;
 
@@ -139,14 +139,14 @@ private:
 //Singleton accessor
 inline Universe* GetUniverse() __attribute__ ((always_inline));
 Universe* GetUniverse() {
-    if (DEBUG && !Universe::theUniverse) {
+    if (DEBUG && Universe::theUniverse == nullptr) {
         Universe::ErrorExit("Trying to access uninitialized Universe, exiting.");
     }
     return Universe::theUniverse;
 }
 
 Universe* Universe::operator->() {
-    if (DEBUG && !theUniverse) {
+    if (DEBUG && theUniverse == nullptr) {
         ErrorExit("Trying to access uninitialized Universe, exiting.");
     }
     return theUniverse;

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -71,6 +71,8 @@ public:
     VMArray* NewArrayList(std::vector<VMSymbol*>& list) const;
 
     VMArray* NewArrayFromStrings(const vector<StdString>&) const;
+    VMArray* NewArrayOfSymbolsFromStrings(const vector<StdString>&) const;
+
     VMBlock* NewBlock(VMMethod*, VMFrame*, long);
     VMClass* NewClass(VMClass*) const;
     VMFrame* NewFrame(VMFrame*, VMMethod*) const;

--- a/src/vmobjects/AbstractObject.cpp
+++ b/src/vmobjects/AbstractObject.cpp
@@ -17,10 +17,6 @@
 #include "VMInvokable.h"
 #include "VMSymbol.h"
 
-int64_t AbstractVMObject::GetHash() const {
-    return (int64_t) this;
-}
-
 void AbstractVMObject::Send(Interpreter* interp, std::string selectorString, vm_oop_t* arguments, long argc) {
     VMFrame* frame = interp->GetFrame();
     VMSymbol* selector = SymbolFor(selectorString);

--- a/src/vmobjects/AbstractObject.h
+++ b/src/vmobjects/AbstractObject.h
@@ -19,11 +19,6 @@
 #include "ObjectFormats.h"
 #include "VMObjectBase.h"
 
-/*
- * macro for padding - only word-aligned memory must be allocated
- */
-#define PADDED_SIZE(N) ((((uint32_t)(N))+(sizeof(void*)-1) & ~(sizeof(void*)-1)))
-
 using namespace std;
 
 class Interpreter;

--- a/src/vmobjects/AbstractObject.h
+++ b/src/vmobjects/AbstractObject.h
@@ -28,9 +28,9 @@ class AbstractVMObject: public VMObjectBase {
 public:
     typedef GCAbstractObject Stored;
 
-    virtual int64_t GetHash() const;
+    virtual int64_t GetHash() const = 0;
     virtual VMClass* GetClass() const = 0;
-    virtual AbstractVMObject* Clone() const = 0;
+    virtual AbstractVMObject* CloneForMovingGC() const = 0;
             void Send(Interpreter*, StdString, vm_oop_t*, long);
 
     /** Size in bytes of the object. */

--- a/src/vmobjects/AbstractObject.h
+++ b/src/vmobjects/AbstractObject.h
@@ -21,7 +21,7 @@
 /*
  * macro for padding - only word-aligned memory must be allocated
  */
-#define PADDED_SIZE(N) ((((uint32_t)N)+(sizeof(void*)-1) & ~(sizeof(void*)-1)))
+#define PADDED_SIZE(N) ((((uint32_t)(N))+(sizeof(void*)-1) & ~(sizeof(void*)-1)))
 
 using namespace std;
 
@@ -48,9 +48,9 @@ public:
     AbstractVMObject() {
         gcfield = 0;
     }
-    virtual ~AbstractVMObject() = default;
+    ~AbstractVMObject() override = default;
 
-    inline virtual void SetObjectSize(size_t size) {
+    inline virtual void SetObjectSize(size_t) {
         ErrorPrint("this object doesn't support SetObjectSize\n");
     }
 
@@ -59,17 +59,15 @@ public:
         return -1;
     }
 
-    inline virtual void SetClass(VMClass* cl) {
+    inline virtual void SetClass(VMClass*) {
         ErrorPrint("this object doesn't support SetClass\n");
     }
 
     long GetFieldIndex(VMSymbol* fieldName) const;
 
-    virtual void WalkObjects(walk_heap_fn) {
-        return;
-    }
+    virtual void WalkObjects(walk_heap_fn) {}
 
-    inline virtual VMSymbol* GetFieldName(long index) const {
+    inline virtual VMSymbol* GetFieldName(long) const {
         ErrorPrint("this object doesn't support GetFieldName\n");
         return nullptr;
     }
@@ -79,7 +77,7 @@ public:
         // if outsideNursery flag is set or object is too big for nursery, we
         // allocate a mature object
         const unsigned long add = PADDED_SIZE(additionalBytes);
-        void* result;
+        void* result = nullptr;
 #if GC_TYPE==GENERATIONAL
         if (outsideNursery) {
             result = (void*) heap->AllocateMatureObject(numBytes + add);

--- a/src/vmobjects/AbstractObject.h
+++ b/src/vmobjects/AbstractObject.h
@@ -48,6 +48,7 @@ public:
     AbstractVMObject() {
         gcfield = 0;
     }
+    virtual ~AbstractVMObject() = default;
 
     inline virtual void SetObjectSize(size_t size) {
         ErrorPrint("this object doesn't support SetObjectSize\n");

--- a/src/vmobjects/AbstractObject.h
+++ b/src/vmobjects/AbstractObject.h
@@ -41,6 +41,7 @@ public:
     virtual size_t GetObjectSize() const = 0;
 
     virtual void MarkObjectAsInvalid() = 0;
+    virtual bool IsMarkedInvalid() const = 0;
 
     virtual StdString AsDebugString() const = 0;
 

--- a/src/vmobjects/AbstractObject.h
+++ b/src/vmobjects/AbstractObject.h
@@ -11,6 +11,7 @@
 #include <iostream>
 
 #include "../memory/CopyingHeap.h"
+#include "../memory/DebugCopyingHeap.h"
 #include "../memory/GenerationalHeap.h"
 #include "../memory/MarkSweepHeap.h"
 #include "../misc/defs.h"

--- a/src/vmobjects/AbstractObject.h
+++ b/src/vmobjects/AbstractObject.h
@@ -52,17 +52,15 @@ public:
 
     inline virtual void SetObjectSize(size_t size) {
         ErrorPrint("this object doesn't support SetObjectSize\n");
-        throw "this object doesn't support SetObjectSize";
     }
 
     inline virtual long GetNumberOfFields() const {
         ErrorPrint("this object doesn't support GetNumberOfFields\n");
-        throw "this object doesn't support GetNumberOfFields";
+        return -1;
     }
 
     inline virtual void SetClass(VMClass* cl) {
         ErrorPrint("this object doesn't support SetClass\n");
-        throw "this object doesn't support SetClass";
     }
 
     long GetFieldIndex(VMSymbol* fieldName) const;
@@ -73,7 +71,7 @@ public:
 
     inline virtual VMSymbol* GetFieldName(long index) const {
         ErrorPrint("this object doesn't support GetFieldName\n");
-        throw "this object doesn't support GetFieldName";
+        return nullptr;
     }
 
     void* operator new(size_t numBytes, HEAP_CLS* heap,

--- a/src/vmobjects/IntegerBox.cpp
+++ b/src/vmobjects/IntegerBox.cpp
@@ -5,7 +5,7 @@
 GCInteger* GlobalBox::integerBox = nullptr;
 
 void GlobalBox::updateIntegerBox(VMInteger* newValue) {
-    integerBox = _store_ptr(newValue);
+    integerBox = store_root(newValue);
 }
 
 VMInteger* GlobalBox::IntegerBox() {

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -49,7 +49,7 @@
 
 #if USE_TAGGING
   #define INT_VAL(X) (IS_TAGGED(X) ? ((int64_t)(X)>>1) : (((VMInteger*)(X))->GetEmbeddedInteger()))
-  #define NEW_INT(X) (TAG_INTEGER((X)))
+  #define NEW_INT(X) (TAG_INTEGER((uint64_t)(X)))
   #define IS_TAGGED(X) ((int64_t)X&1)
   #define CLASS_OF(X) (IS_TAGGED(X)?load_ptr(integerClass):((AbstractVMObject*)(X))->GetClass())
   #define AS_OBJ(X) (IS_TAGGED(X)?GlobalBox::IntegerBox():((AbstractVMObject*)(X)))

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -33,23 +33,23 @@
  * 01111111 11111111 ... 11111111 1111111X
  *
  */
-#define VMTAGGEDINTEGER_MAX  0x3FFFFFFFFFFFFFFF
+#define VMTAGGEDINTEGER_MAX  0x3FFFFFFFFFFFFFFFLL
 
 /**
  * min value for tagged integers
  * 10000000 00000000 ... 00000000 0000000X
  */
-#define VMTAGGEDINTEGER_MIN (-0x4000000000000000)
+#define VMTAGGEDINTEGER_MIN (-0x4000000000000000LL)
 
 #if ADDITIONAL_ALLOCATION
 #define TAG_INTEGER(X) (((X) >= VMTAGGEDINTEGER_MIN && (X) <= VMTAGGEDINTEGER_MAX && GetUniverse()->NewInteger(0)) ? ((vm_oop_t)(((X) << 1) | 1)) : (GetUniverse()->NewInteger(X)))
 #else
-#define TAG_INTEGER(X) (((X) >= VMTAGGEDINTEGER_MIN && (X) <= VMTAGGEDINTEGER_MAX) ? ((vm_oop_t)(((X) << 1) | 1)) : (GetUniverse()->NewInteger(X)))
+#define TAG_INTEGER(X) (((X) >= VMTAGGEDINTEGER_MIN && (X) <= VMTAGGEDINTEGER_MAX) ? ((vm_oop_t)((((uint64_t)(X)) << 1) | 1U)) : (GetUniverse()->NewInteger(X)))
 #endif
 
 #if USE_TAGGING
   #define INT_VAL(X) (IS_TAGGED(X) ? ((int64_t)(X)>>1) : (((VMInteger*)(X))->GetEmbeddedInteger()))
-  #define NEW_INT(X) (TAG_INTEGER((uint64_t)(X)))
+  #define NEW_INT(X) (TAG_INTEGER((X)))
   #define IS_TAGGED(X) ((int64_t)X&1)
   #define CLASS_OF(X) (IS_TAGGED(X)?load_ptr(integerClass):((AbstractVMObject*)(X))->GetClass())
   #define AS_OBJ(X) (IS_TAGGED(X)?GlobalBox::IntegerBox():((AbstractVMObject*)(X)))

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -39,7 +39,7 @@
  * min value for tagged integers
  * 10000000 00000000 ... 00000000 0000000X
  */
-#define VMTAGGEDINTEGER_MIN -0x4000000000000000
+#define VMTAGGEDINTEGER_MIN (-0x4000000000000000)
 
 #if ADDITIONAL_ALLOCATION
 #define TAG_INTEGER(X) (((X) >= VMTAGGEDINTEGER_MIN && (X) <= VMTAGGEDINTEGER_MAX && GetUniverse()->NewInteger(0)) ? ((vm_oop_t)(((X) << 1) | 1)) : (GetUniverse()->NewInteger(X)))

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -138,13 +138,26 @@ inline typename T::Loaded* load_ptr(T* gc_val) {
     return (typename T::Loaded*) gc_val;
 }
 
+/** To store object into a root. */
 template<typename T>
-inline typename T::Stored* _store_ptr(T* vm_val) {
+inline typename T::Stored* store_root(T* vm_val) {
     return (typename T::Stored*) vm_val;
 }
 
+/** For temporary use, but can't be stored, and can't be alive across GC invocations. */
+template<typename T>
+inline typename T::Stored* tmp_ptr(T* vm_val) {
+    return (typename T::Stored*) vm_val;
+}
 
-#define store_ptr(field, val) field = _store_ptr(val); write_barrier(this, val)
+/** To store object a field, needs special care to correctly call `write_barrier()` separately. */
+template<typename T>
+inline typename T::Stored* store_with_separate_barrier(T* vm_val) {
+    return (typename T::Stored*) vm_val;
+}
+
+/** Standard assignment of pointer to field, including write barrier. */
+#define store_ptr(field, val) field = store_with_separate_barrier(val); write_barrier(this, val)
 
 typedef gc_oop_t (*walk_heap_fn)(gc_oop_t);
 

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -89,9 +89,12 @@ class VMOop {
     virtual void dummyVirtualFunctionToForceVTableCreation() {
         /* With the current class hierarchy, we need to force the compiler to
            create a VTable early, otherwise, the object layout is having
-           vtables in the body of the objects, and casting is messed up, 
+           vtables in the body of the objects, and casting is messed up,
            leading to offset pointers to the vtables of subclasses. */ };
-    public: typedef GCOop Stored; };
+public:
+    typedef GCOop Stored;
+    virtual ~VMOop() = default;
+};
 class GCOop { public: typedef VMOop Loaded; };
 
 // oop_t: Ordinary Object Pointer type
@@ -104,10 +107,10 @@ typedef GCOop* gc_oop_t;
 /**
  We need to distinguish between pointers that need to be handled with a
  read barrier, and between pointers that already went through it.
- 
+
  So, we call pointers that need to go through the barrier:
  heap values, or GC* pointers.
- 
+
  And all the stuff that was already processed:
  loaded values, or VM* pointers.
  */
@@ -160,5 +163,3 @@ inline typename T::Stored* store_with_separate_barrier(T* vm_val) {
 #define store_ptr(field, val) field = store_with_separate_barrier(val); write_barrier(this, val)
 
 typedef gc_oop_t (*walk_heap_fn)(gc_oop_t);
-
-

--- a/src/vmobjects/PrimitiveRoutine.h
+++ b/src/vmobjects/PrimitiveRoutine.h
@@ -26,8 +26,8 @@
  THE SOFTWARE.
  */
 
-#include "VMObject.h"
 #include "VMFrame.h"
+#include "VMObject.h"
 
 // abstract base class
 class PrimitiveRoutine {
@@ -44,4 +44,3 @@ typedef PrimitiveRoutine* CreatePrimitive(const std::string&,
 typedef bool SupportsClass(const char*);
 typedef void TearDown();
 typedef void Setup();
-

--- a/src/vmobjects/VMArray.cpp
+++ b/src/vmobjects/VMArray.cpp
@@ -37,16 +37,10 @@
 
 const size_t VMArray::VMArrayNumberOfFields = 0;
 
-VMArray::VMArray(size_t size, size_t nof) :
-        VMObject(nof + VMArrayNumberOfFields) {
-    // initialize fields with nilObject
-    // SetIndexableField is not used to prevent the write barrier to be called
-    // too often.
-    // Fields start after clazz and other fields (GetNumberOfFields)
-    gc_oop_t* arrFields = FIELDS + GetNumberOfFields();
-    for (size_t i = 0; i < size; ++i) {
-        arrFields[i] = nilObject;
-    }
+VMArray::VMArray(size_t arraySize, size_t additionalBytes) :
+        VMObject(arraySize + 0 /* VMArray is not allowed to have any fields itself */, additionalBytes + sizeof(VMArray)) {
+    assert(VMArrayNumberOfFields == 0);
+    nilInitializeFields();
 }
 
 vm_oop_t VMArray::GetIndexableField(size_t idx) const {
@@ -55,7 +49,7 @@ vm_oop_t VMArray::GetIndexableField(size_t idx) const {
                              to_string(idx) + ", but array size is only " +
                              to_string(GetNumberOfIndexableFields()) + "\n").c_str());
     }
-    return GetField(GetNumberOfFields() + idx);
+    return GetField(idx);
 }
 
 void VMArray::SetIndexableField(size_t idx, vm_oop_t value) {
@@ -64,7 +58,7 @@ void VMArray::SetIndexableField(size_t idx, vm_oop_t value) {
                              to_string(idx) + ", but array size is only " +
                              to_string(GetNumberOfIndexableFields()) + "\n").c_str());
     }
-    SetField(GetNumberOfFields() + idx, value);
+    SetField(idx, value);
 }
 
 VMArray* VMArray::CopyAndExtendWith(vm_oop_t item) const {
@@ -76,12 +70,11 @@ VMArray* VMArray::CopyAndExtendWith(vm_oop_t item) const {
 }
 
 VMArray* VMArray::Clone() const {
-    const size_t addSpace = objectSize - sizeof(VMArray);
+    const size_t addSpace = totalObjectSize - sizeof(VMArray);
     auto* clone = new (GetHeap<HEAP_CLS>(), addSpace ALLOC_MATURE) VMArray(*this);
     void* destination  = SHIFTED_PTR(clone, sizeof(VMArray));
     const void* source = SHIFTED_PTR(this, sizeof(VMArray));
-    const size_t noBytes = GetObjectSize() - sizeof(VMArray);
-    memcpy(destination, source, noBytes);
+    memcpy(destination, source, addSpace);
     return clone;
 }
 
@@ -97,16 +90,6 @@ void VMArray::CopyIndexableFieldsTo(VMArray* to) const {
     const size_t numIndexableFields = GetNumberOfIndexableFields();
     for (size_t i = 0; i < numIndexableFields; ++i) {
         to->SetIndexableField(i, GetIndexableField(i));
-    }
-}
-
-void VMArray::WalkObjects(walk_heap_fn walk) {
-    clazz = static_cast<GCClass*>(walk(clazz));
-    const size_t numFields          = GetNumberOfFields();
-    const size_t numIndexableFields = GetNumberOfIndexableFields();
-    gc_oop_t* fields = FIELDS;
-    for (size_t i = 0; i < numFields + numIndexableFields; i++) {
-        fields[i] = walk(fields[i]);
     }
 }
 

--- a/src/vmobjects/VMArray.cpp
+++ b/src/vmobjects/VMArray.cpp
@@ -23,13 +23,14 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  */
+
+#include <cassert>
 #include <cstddef>
 #include <cstring>
 #include <string>
 
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
-#include "../vm/Globals.h"
 #include "../vm/Universe.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMArray.h"

--- a/src/vmobjects/VMArray.cpp
+++ b/src/vmobjects/VMArray.cpp
@@ -70,7 +70,7 @@ VMArray* VMArray::CopyAndExtendWith(vm_oop_t item) const {
     return result;
 }
 
-VMArray* VMArray::Clone() const {
+VMArray* VMArray::CloneForMovingGC() const {
     const size_t addSpace = totalObjectSize - sizeof(VMArray);
     auto* clone = new (GetHeap<HEAP_CLS>(), addSpace ALLOC_MATURE) VMArray(*this);
     void* destination  = SHIFTED_PTR(clone, sizeof(VMArray));

--- a/src/vmobjects/VMArray.h
+++ b/src/vmobjects/VMArray.h
@@ -34,7 +34,7 @@ class VMArray: public VMObject {
 public:
     typedef GCArray Stored;
 
-    VMArray(size_t size, size_t nof = 0);
+    explicit VMArray(size_t size, size_t nof = 0);
 
     void WalkObjects(walk_heap_fn) override;
 

--- a/src/vmobjects/VMArray.h
+++ b/src/vmobjects/VMArray.h
@@ -51,7 +51,7 @@ public:
     vm_oop_t GetIndexableField(size_t idx) const;
     void SetIndexableField(size_t idx, vm_oop_t value);
     void CopyIndexableFieldsTo(VMArray*) const;
-    VMArray* Clone() const override;
+    VMArray* CloneForMovingGC() const override;
 
     StdString AsDebugString() const override;
 

--- a/src/vmobjects/VMArray.h
+++ b/src/vmobjects/VMArray.h
@@ -30,16 +30,21 @@
 #include "../vmobjects/VMInteger.h"
 #include "../vmobjects/VMObject.h"
 
+/**
+ * For the VMArray, we assume that there are no subclasses, and that `Array` doesn't
+ * have any fields itself. This way, we just used the fields as indexable fields.
+ */
 class VMArray: public VMObject {
 public:
     typedef GCArray Stored;
 
-    explicit VMArray(size_t size, size_t nof = 0);
+    explicit VMArray(size_t arraySize, size_t additionalBytes);
 
-    void WalkObjects(walk_heap_fn) override;
+    // VMArray doesn't need to customize `void WalkObjects(walk_heap_fn)`,
+    // because it doesn't need anything special.
 
-    inline  size_t GetNumberOfIndexableFields() const {
-        return GetAdditionalSpaceConsumption() / sizeof(VMObject*);
+    inline size_t GetNumberOfIndexableFields() const {
+        return numberOfFields;
     }
 
     VMArray* CopyAndExtendWith(vm_oop_t) const;

--- a/src/vmobjects/VMBlock.cpp
+++ b/src/vmobjects/VMBlock.cpp
@@ -36,17 +36,17 @@
 
 const int VMBlock::VMBlockNumberOfFields = 2;
 
-VMBlock::VMBlock() :
-        VMObject(VMBlockNumberOfFields), blockMethod(), context() {
-}
-
-void VMBlock::SetMethod(VMMethod* bMethod) {
-    store_ptr(blockMethod, bMethod);
+VMBlock::VMBlock(VMMethod* method, VMFrame* context) :
+        VMObject(VMBlockNumberOfFields, sizeof(VMBlock)),
+        blockMethod(store_with_separate_barrier(method)),
+        context(store_with_separate_barrier(context)) {
+    write_barrier(this, method);
+    write_barrier(this, context);
 }
 
 VMBlock* VMBlock::Clone() const {
     VMBlock* clone;
-    clone = new (GetHeap<HEAP_CLS>(), GetAdditionalSpaceConsumption() ALLOC_MATURE) VMBlock(*this);
+    clone = new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMBlock(*this);
     return clone;
 }
 
@@ -55,7 +55,7 @@ VMMethod* VMBlock::GetMethod() const {
 }
 
 VMEvaluationPrimitive* VMBlock::GetEvaluationPrimitive(int numberOfArguments) {
-    return new (GetHeap<HEAP_CLS>()) VMEvaluationPrimitive(numberOfArguments);
+    return new (GetHeap<HEAP_CLS>(), 0) VMEvaluationPrimitive(numberOfArguments);
 }
 
 std::string VMBlock::AsDebugString() const {

--- a/src/vmobjects/VMBlock.cpp
+++ b/src/vmobjects/VMBlock.cpp
@@ -61,3 +61,8 @@ VMEvaluationPrimitive* VMBlock::GetEvaluationPrimitive(int numberOfArguments) {
 std::string VMBlock::AsDebugString() const {
     return "Block(" + load_ptr(blockMethod)->AsDebugString() + ")";
 }
+
+void VMBlock::MarkObjectAsInvalid() {
+    blockMethod = (GCMethod*) INVALID_GC_POINTER;
+    context = (GCFrame*) INVALID_GC_POINTER;
+}

--- a/src/vmobjects/VMBlock.cpp
+++ b/src/vmobjects/VMBlock.cpp
@@ -44,7 +44,7 @@ VMBlock::VMBlock(VMMethod* method, VMFrame* context) :
     write_barrier(this, context);
 }
 
-VMBlock* VMBlock::Clone() const {
+VMBlock* VMBlock::CloneForMovingGC() const {
     VMBlock* clone;
     clone = new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMBlock(*this);
     return clone;

--- a/src/vmobjects/VMBlock.h
+++ b/src/vmobjects/VMBlock.h
@@ -43,6 +43,8 @@ public:
     StdString AsDebugString() const override;
 
     static VMEvaluationPrimitive* GetEvaluationPrimitive(int);
+    
+    void MarkObjectAsInvalid() override;
 
 private_testable:
     GCMethod* blockMethod;

--- a/src/vmobjects/VMBlock.h
+++ b/src/vmobjects/VMBlock.h
@@ -41,7 +41,7 @@ public:
         return load_ptr(context);
     }
 
-            VMBlock*  Clone() const override;
+            VMBlock*  CloneForMovingGC() const override;
 
     StdString AsDebugString() const override;
 

--- a/src/vmobjects/VMBlock.h
+++ b/src/vmobjects/VMBlock.h
@@ -43,7 +43,7 @@ public:
     StdString AsDebugString() const override;
 
     static VMEvaluationPrimitive* GetEvaluationPrimitive(int);
-    
+
     void MarkObjectAsInvalid() override;
 
 private_testable:

--- a/src/vmobjects/VMBlock.h
+++ b/src/vmobjects/VMBlock.h
@@ -26,18 +26,21 @@
  THE SOFTWARE.
  */
 
+#include "VMFrame.h"
 #include "VMObject.h"
 
 class VMBlock: public VMObject {
 public:
     typedef GCBlock Stored;
 
-    VMBlock();
+    VMBlock(VMMethod* method, VMFrame* context);
 
             VMMethod* GetMethod() const;
-            void      SetMethod(VMMethod*);
-    inline  void      SetContext(VMFrame*);
-    inline  VMFrame*  GetContext() const;
+    
+    inline  VMFrame*  GetContext() const {
+        return load_ptr(context);
+    }
+
             VMBlock*  Clone() const override;
 
     StdString AsDebugString() const override;
@@ -53,13 +56,3 @@ private_testable:
 private:
     static const int VMBlockNumberOfFields;
 };
-
-#include "VMFrame.h"
-
-void VMBlock::SetContext(VMFrame* contxt) {
-    store_ptr(context, contxt);
-}
-
-VMFrame* VMBlock::GetContext() const {
-    return load_ptr(context);
-}

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -51,7 +51,7 @@ VMClass::VMClass() :
                 nullptr), instanceInvokables(nullptr), superClass(nullptr) {
 }
 
-VMClass* VMClass::Clone() const {
+VMClass* VMClass::CloneForMovingGC() const {
     VMClass* clone = new (GetHeap<HEAP_CLS>(), totalObjectSize - sizeof(VMClass) ALLOC_MATURE) VMClass(*this);
     memcpy(SHIFTED_PTR(clone,sizeof(VMObject)),
             SHIFTED_PTR(this,sizeof(VMObject)), GetObjectSize() -

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -27,7 +27,6 @@
 #include <cassert>
 #include <cstring>
 #include <string>
-#include <vector>
 
 #include "../memory/Heap.h"
 #include "../misc/defs.h"

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -48,8 +48,8 @@
 const long VMClass::VMClassNumberOfFields = 4;
 
 VMClass::VMClass() :
-        VMObject(VMClassNumberOfFields), superClass(nullptr), name(nullptr), instanceFields(
-                nullptr), instanceInvokables(nullptr) {
+        VMObject(VMClassNumberOfFields), name(nullptr), instanceFields(
+                nullptr), instanceInvokables(nullptr), superClass(nullptr) {
 }
 
 VMClass* VMClass::Clone() const {
@@ -94,8 +94,8 @@ bool VMClass::AddInstanceInvokable(VMInvokable* ptr) {
     }
     //Check whether an invokable with the same signature exists and replace it if that's the case
     VMArray* instInvokables = load_ptr(instanceInvokables);
-    long numIndexableFields = instInvokables->GetNumberOfIndexableFields();
-    for (long i = 0; i < numIndexableFields; ++i) {
+    size_t numIndexableFields = instInvokables->GetNumberOfIndexableFields();
+    for (size_t i = 0; i < numIndexableFields; ++i) {
         VMInvokable* inv = static_cast<VMInvokable*>(instInvokables->GetIndexableField(i));
         if (inv != nullptr) {
             if (ptr->GetSignature() == inv->GetSignature()) {
@@ -162,7 +162,7 @@ void VMClass::SetInstanceInvokable(long index, VMInvokable* invokable) {
 
 VMInvokable* VMClass::LookupInvokable(VMSymbol* name) const {
     assert(IsValidObject(const_cast<VMClass*>(this)));
-    
+
     VMInvokable* invokable = name->GetCachedInvokable(this);
     if (invokable != nullptr)
         return invokable;
@@ -180,7 +180,7 @@ VMInvokable* VMClass::LookupInvokable(VMSymbol* name) const {
     if (HasSuperClass()) {
         return load_ptr(superClass)->LookupInvokable(name);
     }
-    
+
     // invokable not found
     return nullptr;
 }
@@ -210,9 +210,9 @@ bool VMClass::HasPrimitives() const {
     return false;
 }
 
-void VMClass::LoadPrimitives(const vector<std::string>& cp) {
+void VMClass::LoadPrimitives() {
     std::string cname = load_ptr(name)->GetStdString();
-    
+
     if (hasPrimitivesFor(cname)) {
         setPrimitives(cname, false);
         GetClass()->setPrimitives(cname, true);
@@ -233,12 +233,12 @@ bool VMClass::hasPrimitivesFor(const std::string& cl) const {
  * set the routines for primitive marked invokables of the given class
  */
 void VMClass::setPrimitives(const std::string& cname, bool classSide) {
-    
+
     VMClass* current = this;
-    
+
     // Try loading class-specific primitives for all super class' methods as well.
     while (current != load_ptr(nilObject)) {
-    
+
         // iterate invokables
         long numInvokables = current->GetNumberOfInstanceInvokables();
         for (long i = 0; i < numInvokables; i++) {
@@ -250,10 +250,10 @@ void VMClass::setPrimitives(const std::string& cname, bool classSide) {
 
             VMSymbol* sig = anInvokable->GetSignature();
             std::string selector = sig->GetPlainString();
-            
+
             PrimitiveRoutine* routine = PrimitiveLoader::GetPrimitiveRoutine(
                 cname, selector, anInvokable->IsPrimitive() && current == this);
-            
+
             if (routine && classSide == routine->isClassSide()) {
                 VMPrimitive* thePrimitive;
                 if (this == current && anInvokable->IsPrimitive()) {

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -80,6 +80,7 @@ void VMClass::WalkObjects(walk_heap_fn walk) {
 }
 
 void VMClass::MarkObjectAsInvalid() {
+    VMObject::MarkObjectAsInvalid();
     superClass         = (GCClass*)  INVALID_GC_POINTER;
     name               = (GCSymbol*) INVALID_GC_POINTER;
     instanceFields     = (GCArray*)  INVALID_GC_POINTER;

--- a/src/vmobjects/VMClass.h
+++ b/src/vmobjects/VMClass.h
@@ -47,8 +47,8 @@ public:
     VMClass();
     VMClass(long numberOfFields);
 
-           VMClass*     GetSuperClass() const;
-           void         SetSuperClass(VMClass*);
+           VMObject*    GetSuperClass() const;
+           void         SetSuperClass(VMObject*);
            bool         HasSuperClass() const;
            VMSymbol*    GetName() const;
            void         SetName(VMSymbol*);
@@ -82,8 +82,9 @@ private:
     static const long VMClassNumberOfFields;
 
 private_testable:
+    // Remember to update Parser::superclass when the fields are changed
     GCSymbol* name;
     GCArray* instanceFields;
     GCArray* instanceInvokables;
-    GCClass* superClass;
+    GCObject* superClass;
 };

--- a/src/vmobjects/VMClass.h
+++ b/src/vmobjects/VMClass.h
@@ -66,7 +66,7 @@ public:
            VMSymbol*    GetInstanceFieldName(long)const;
            long         GetNumberOfInstanceFields() const;
            bool         HasPrimitives() const;
-           void         LoadPrimitives(const vector<StdString>&);
+           void         LoadPrimitives();
            VMClass*    Clone() const override;
            void         WalkObjects(walk_heap_fn walk) override;
 

--- a/src/vmobjects/VMClass.h
+++ b/src/vmobjects/VMClass.h
@@ -45,7 +45,7 @@ public:
     typedef GCClass Stored;
 
     VMClass();
-    VMClass(long numberOfFields);
+    VMClass(size_t numberOfFields, size_t additionalBytes);
 
            VMObject*    GetSuperClass() const;
            void         SetSuperClass(VMObject*);
@@ -56,7 +56,7 @@ public:
            void         SetInstanceFields(VMArray*);
            VMArray*     GetInstanceInvokables() const;
            void         SetInstanceInvokables(VMArray*);
-           long         GetNumberOfInstanceInvokables() const;
+           size_t       GetNumberOfInstanceInvokables() const;
            VMInvokable* GetInstanceInvokable(long) const;
            void         SetInstanceInvokable(long, VMInvokable*);
            VMInvokable* LookupInvokable(VMSymbol*) const;
@@ -64,7 +64,7 @@ public:
            bool         AddInstanceInvokable(VMInvokable*);
            void         AddInstancePrimitive(VMPrimitive*);
            VMSymbol*    GetInstanceFieldName(long)const;
-           long         GetNumberOfInstanceFields() const;
+           size_t       GetNumberOfInstanceFields() const;
            bool         HasPrimitives() const;
            void         LoadPrimitives();
            VMClass*    Clone() const override;
@@ -77,9 +77,9 @@ public:
 private:
     bool hasPrimitivesFor(const StdString& cl) const;
     void setPrimitives(const StdString& cname, bool classSide);
-    long numberOfSuperInstanceFields() const;
+    size_t numberOfSuperInstanceFields() const;
 
-    static const long VMClassNumberOfFields;
+    static const size_t VMClassNumberOfFields;
 
 private_testable:
     // Remember to update Parser::superclass when the fields are changed

--- a/src/vmobjects/VMClass.h
+++ b/src/vmobjects/VMClass.h
@@ -29,8 +29,8 @@
 #include <vector>
 
 #include "../misc/defs.h"
-#include "../vm/IsValidObject.h"
 #include "../vm/Globals.h"
+#include "../vm/IsValidObject.h"
 #include "VMObject.h"
 
 #if defined(_MSC_VER)   //Visual Studio

--- a/src/vmobjects/VMClass.h
+++ b/src/vmobjects/VMClass.h
@@ -67,7 +67,7 @@ public:
            size_t       GetNumberOfInstanceFields() const;
            bool         HasPrimitives() const;
            void         LoadPrimitives();
-           VMClass*    Clone() const override;
+           VMClass*     CloneForMovingGC() const override;
            void         WalkObjects(walk_heap_fn walk) override;
 
     void MarkObjectAsInvalid() override;

--- a/src/vmobjects/VMDouble.cpp
+++ b/src/vmobjects/VMDouble.cpp
@@ -33,7 +33,7 @@
 #include "VMClass.h"
 #include "VMDouble.h"
 
-VMDouble* VMDouble::Clone() const {
+VMDouble* VMDouble::CloneForMovingGC() const {
     return new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMDouble(*this);
 }
 

--- a/src/vmobjects/VMDouble.cpp
+++ b/src/vmobjects/VMDouble.cpp
@@ -44,3 +44,13 @@ VMClass* VMDouble::GetClass() const {
 std::string VMDouble::AsDebugString() const {
     return "Double(" + to_string(embeddedDouble) + ")";
 }
+
+#define INVALID_DBL_MARKER 9007000000000990
+
+void VMDouble::MarkObjectAsInvalid() {
+    embeddedDouble = INVALID_DBL_MARKER;
+}
+
+bool VMDouble::IsMarkedInvalid() const {
+    return embeddedDouble == INVALID_DBL_MARKER;
+}

--- a/src/vmobjects/VMDouble.h
+++ b/src/vmobjects/VMDouble.h
@@ -39,12 +39,13 @@ public:
     VMClass* GetClass() const override;
     inline size_t GetObjectSize() const override;
 
-    void MarkObjectAsInvalid() override {}
+    void MarkObjectAsInvalid() override;
+    bool IsMarkedInvalid() const override;
 
     StdString AsDebugString() const override;
 
 private_testable:
-    const double embeddedDouble;
+    double embeddedDouble;
 };
 
 double VMDouble::GetEmbeddedDouble() const {

--- a/src/vmobjects/VMDouble.h
+++ b/src/vmobjects/VMDouble.h
@@ -32,7 +32,7 @@ class VMDouble: public AbstractVMObject {
 public:
     typedef GCDouble Stored;
 
-    VMDouble(double val) : embeddedDouble(val), AbstractVMObject() {}
+    VMDouble(double val) : AbstractVMObject(), embeddedDouble(val) {}
 
     VMDouble* Clone() const override;
     inline  double   GetEmbeddedDouble() const;

--- a/src/vmobjects/VMDouble.h
+++ b/src/vmobjects/VMDouble.h
@@ -34,10 +34,16 @@ public:
 
     VMDouble(double val) : AbstractVMObject(), embeddedDouble(val) {}
 
-    VMDouble* Clone() const override;
+    VMDouble* CloneForMovingGC() const override;
     inline  double   GetEmbeddedDouble() const;
     VMClass* GetClass() const override;
     inline size_t GetObjectSize() const override;
+
+    inline int64_t GetHash() const override {
+        // try to avoid a smart cast of the double value.
+        // instead, try to get to the bit pattern as a int64_t
+        return (*(int64_t*) &embeddedDouble);
+    }
 
     void MarkObjectAsInvalid() override;
     bool IsMarkedInvalid() const override;

--- a/src/vmobjects/VMEvaluationPrimitive.cpp
+++ b/src/vmobjects/VMEvaluationPrimitive.cpp
@@ -44,7 +44,7 @@ VMEvaluationPrimitive::VMEvaluationPrimitive(size_t argc) : VMPrimitive(computeS
     SetRoutine(new EvaluationRoutine(this), false);
 }
 
-VMEvaluationPrimitive* VMEvaluationPrimitive::Clone() const {
+VMEvaluationPrimitive* VMEvaluationPrimitive::CloneForMovingGC() const {
     VMEvaluationPrimitive* evPrim = new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMEvaluationPrimitive(*this);
     return evPrim;
 }

--- a/src/vmobjects/VMEvaluationPrimitive.cpp
+++ b/src/vmobjects/VMEvaluationPrimitive.cpp
@@ -103,3 +103,13 @@ void EvaluationRoutine::WalkObjects(walk_heap_fn walk) {
 std::string VMEvaluationPrimitive::AsDebugString() const {
     return "VMEvaluationPrimitive(" + to_string(numberOfArguments) + ")";
 }
+
+
+void VMEvaluationPrimitive::MarkObjectAsInvalid() {
+    VMPrimitive::MarkObjectAsInvalid();
+    numberOfArguments = INVALID_GC_POINTER;
+}
+
+bool VMEvaluationPrimitive::IsMarkedInvalid() const {
+    return numberOfArguments == INVALID_GC_POINTER;
+}

--- a/src/vmobjects/VMEvaluationPrimitive.cpp
+++ b/src/vmobjects/VMEvaluationPrimitive.cpp
@@ -104,12 +104,13 @@ std::string VMEvaluationPrimitive::AsDebugString() const {
     return "VMEvaluationPrimitive(" + to_string(numberOfArguments) + ")";
 }
 
+#define INVALID_INT_MARKER 9002002002002002002
 
 void VMEvaluationPrimitive::MarkObjectAsInvalid() {
     VMPrimitive::MarkObjectAsInvalid();
-    numberOfArguments = INVALID_GC_POINTER;
+    numberOfArguments = INVALID_INT_MARKER;
 }
 
 bool VMEvaluationPrimitive::IsMarkedInvalid() const {
-    return numberOfArguments == INVALID_GC_POINTER;
+    return numberOfArguments == INVALID_INT_MARKER;
 }

--- a/src/vmobjects/VMEvaluationPrimitive.h
+++ b/src/vmobjects/VMEvaluationPrimitive.h
@@ -44,6 +44,9 @@ public:
         return sizeof(VMEvaluationPrimitive);
     }
 
+    void MarkObjectAsInvalid() override;
+    bool IsMarkedInvalid() const override;
+
 private:
     static VMSymbol* computeSignatureString(long argc);
     void evaluationRoutine(Interpreter*, VMFrame*);

--- a/src/vmobjects/VMEvaluationPrimitive.h
+++ b/src/vmobjects/VMEvaluationPrimitive.h
@@ -60,7 +60,12 @@ private:
     GCEvaluationPrimitive* evalPrim;
 public:
     EvaluationRoutine(VMEvaluationPrimitive* prim)
-        : PrimitiveRoutine(), evalPrim(_store_ptr(prim)) {};
+        : PrimitiveRoutine(),
+            // the store without barrier is fine here,
+            // because it's a cyclic structure with `prim` itself,
+            // which will be store in another object,
+            // which will then have a barrier
+            evalPrim(store_with_separate_barrier(prim)) {};
     void WalkObjects(walk_heap_fn);
     bool isClassSide() override { return false; }
     void Invoke(Interpreter* interp, VMFrame* frame) override;

--- a/src/vmobjects/VMEvaluationPrimitive.h
+++ b/src/vmobjects/VMEvaluationPrimitive.h
@@ -34,7 +34,7 @@ public:
 
     VMEvaluationPrimitive(size_t argc);
     void WalkObjects(walk_heap_fn) override;
-    VMEvaluationPrimitive* Clone() const override;
+    VMEvaluationPrimitive* CloneForMovingGC() const override;
 
     StdString AsDebugString() const override;
 

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -99,7 +99,7 @@ VMFrame* VMFrame::Clone() const {
     // Use of GetMethod() is problematic here, because it may be invalid object while cloning/moving within GC
     // Use of GetMethod()->GetNumberOfArguments() is problematic here, because it may be invalid object while cloning/moving within GC
 
-#if GC_TYPE == GENERATIONAL || GC_TYPE == COPYING
+#if GC_TYPE == GENERATIONAL || GC_TYPE == COPYING || GC_TYPE == DEBUG_COPYING
     VMMethod* meth = load_ptr(method);
     if (meth->GetGCField() != 0 && meth->GetGCField() != MASK_OBJECT_IS_OLD) {
         meth = (VMMethod*) meth->GetGCField();

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -117,7 +117,7 @@ VMFrame* VMFrame::Clone() const {
 
 const long VMFrame::VMFrameNumberOfFields = 0;
 
-VMFrame::VMFrame(long size, long nof) :
+VMFrame::VMFrame(long, long nof) :
         VMObject(nof + VMFrameNumberOfFields), previousFrame(nullptr), context(
                 nullptr), method(nullptr) {
     clazz = nullptr; // Not a proper class anymore

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -87,7 +87,7 @@ VMFrame* VMFrame::EmergencyFrameFrom(VMFrame* from, long extraLength) {
     return result;
 }
 
-VMFrame* VMFrame::Clone() const {
+VMFrame* VMFrame::CloneForMovingGC() const {
     size_t addSpace = totalObjectSize - sizeof(VMFrame);
     VMFrame* clone = new (GetHeap<HEAP_CLS>(), addSpace ALLOC_MATURE) VMFrame(*this);
     void* destination = SHIFTED_PTR(clone, sizeof(VMFrame));

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -114,7 +114,7 @@ public:
 
     void PrintStack() const;
     void PrintBytecode() const;
-    inline void* GetStackPointer() const;
+
     long RemainingStackSize() const;
 
     StdString AsDebugString() const override;
@@ -161,10 +161,6 @@ VMFrame* VMFrame::GetContext() const {
 
 void VMFrame::SetContext(VMFrame* frm) {
     store_ptr(context, frm);
-}
-
-void* VMFrame::GetStackPointer() const {
-    return stack_ptr;
 }
 
 VMFrame* VMFrame::GetPreviousFrame() const {

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -38,7 +38,7 @@ public:
 
     static VMFrame* EmergencyFrameFrom(VMFrame* from, long extraLength);
 
-    explicit VMFrame(long size, long nof = 0);
+    explicit VMFrame(size_t size, size_t additionalBytes);
 
     inline VMFrame* GetPreviousFrame() const;
     inline void SetPreviousFrame(VMFrame*);

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -38,7 +38,7 @@ public:
 
     static VMFrame* EmergencyFrameFrom(VMFrame* from, long extraLength);
 
-    VMFrame(long size, long nof = 0);
+    explicit VMFrame(long size, long nof = 0);
 
     inline VMFrame* GetPreviousFrame() const;
     inline void SetPreviousFrame(VMFrame*);

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -110,7 +110,7 @@ public:
     long ArgumentStackIndex(long index) const;
     void CopyArgumentsFrom(VMFrame* frame);
     void WalkObjects(walk_heap_fn) override;
-    VMFrame* Clone() const override;
+    VMFrame* CloneForMovingGC() const override;
 
     void PrintStack() const;
     void PrintBytecode() const;

--- a/src/vmobjects/VMInteger.cpp
+++ b/src/vmobjects/VMInteger.cpp
@@ -33,7 +33,7 @@
 #include "VMClass.h"
 #include "VMInteger.h"
 
-VMInteger* VMInteger::Clone() const {
+VMInteger* VMInteger::CloneForMovingGC() const {
     return new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMInteger(*this);
 }
 

--- a/src/vmobjects/VMInteger.cpp
+++ b/src/vmobjects/VMInteger.cpp
@@ -44,3 +44,13 @@ VMClass* VMInteger::GetClass() const {
 std::string VMInteger::AsDebugString() const {
     return "Integer(" + to_string(embeddedInteger) + ")";
 }
+
+#define INVALID_INT_MARKER 9002002002002002002
+
+void VMInteger::MarkObjectAsInvalid() {
+    embeddedInteger = INVALID_INT_MARKER;
+}
+
+bool VMInteger::IsMarkedInvalid() const {
+    return embeddedInteger == INVALID_INT_MARKER;
+}

--- a/src/vmobjects/VMInteger.h
+++ b/src/vmobjects/VMInteger.h
@@ -42,12 +42,13 @@ public:
     VMClass* GetClass() const override;
     inline size_t GetObjectSize() const override;
 
-    void MarkObjectAsInvalid() override {}
+    void MarkObjectAsInvalid() override;
+    bool IsMarkedInvalid() const override;
 
     StdString AsDebugString() const override;
 
 private_testable:
-    const int64_t embeddedInteger;
+    int64_t embeddedInteger;
 };
 
 int64_t VMInteger::GetEmbeddedInteger() const {

--- a/src/vmobjects/VMInteger.h
+++ b/src/vmobjects/VMInteger.h
@@ -35,7 +35,7 @@ class VMInteger: public AbstractVMObject {
 public:
     typedef GCInteger Stored;
 
-    VMInteger(int64_t val) : embeddedInteger(val), AbstractVMObject() {}
+    explicit VMInteger(int64_t val) : embeddedInteger(val) {}
     ~VMInteger() override = default;
 
     inline int64_t GetEmbeddedInteger() const;

--- a/src/vmobjects/VMInteger.h
+++ b/src/vmobjects/VMInteger.h
@@ -36,6 +36,7 @@ public:
     typedef GCInteger Stored;
 
     VMInteger(int64_t val) : embeddedInteger(val), AbstractVMObject() {}
+    ~VMInteger() override = default;
 
     inline int64_t GetEmbeddedInteger() const;
     VMInteger* Clone() const override;

--- a/src/vmobjects/VMInteger.h
+++ b/src/vmobjects/VMInteger.h
@@ -39,9 +39,13 @@ public:
     ~VMInteger() override = default;
 
     inline int64_t GetEmbeddedInteger() const;
-    VMInteger* Clone() const override;
+    VMInteger* CloneForMovingGC() const override;
     VMClass* GetClass() const override;
     inline size_t GetObjectSize() const override;
+
+    inline int64_t GetHash() const override {
+        return (int64_t) embeddedInteger;
+    }
 
     void MarkObjectAsInvalid() override;
     bool IsMarkedInvalid() const override;

--- a/src/vmobjects/VMInvokable.h
+++ b/src/vmobjects/VMInvokable.h
@@ -34,8 +34,7 @@ class VMInvokable: public AbstractVMObject {
 public:
     typedef GCInvokable Stored;
 
-    VMInvokable(VMSymbol* sig) : AbstractVMObject(), hash((intptr_t) this), signature(nullptr), holder(nullptr) {
-        store_ptr(signature, sig);
+    VMInvokable(VMSymbol* sig) : AbstractVMObject(), hash((intptr_t) this), signature(_store_ptr(sig)), holder(nullptr) {
     };
 
     int64_t GetHash() const override { return hash; }

--- a/src/vmobjects/VMInvokable.h
+++ b/src/vmobjects/VMInvokable.h
@@ -34,8 +34,7 @@ class VMInvokable: public AbstractVMObject {
 public:
     typedef GCInvokable Stored;
 
-    VMInvokable(VMSymbol* sig) : AbstractVMObject(), hash((intptr_t) this), signature(store_with_separate_barrier(sig)), holder(nullptr) {
-    };
+    explicit VMInvokable(VMSymbol* sig) : hash((intptr_t) this), signature(store_with_separate_barrier(sig)) {}
 
     int64_t GetHash() const override { return hash; }
 
@@ -52,5 +51,5 @@ protected_testable:
     int64_t hash;
 
     GCSymbol* signature;
-    GCClass*  holder;
+    GCClass*  holder{nullptr};
 };

--- a/src/vmobjects/VMInvokable.h
+++ b/src/vmobjects/VMInvokable.h
@@ -34,7 +34,7 @@ class VMInvokable: public AbstractVMObject {
 public:
     typedef GCInvokable Stored;
 
-    VMInvokable(VMSymbol* sig) : AbstractVMObject(), hash((intptr_t) this), signature(_store_ptr(sig)), holder(nullptr) {
+    VMInvokable(VMSymbol* sig) : AbstractVMObject(), hash((intptr_t) this), signature(store_with_separate_barrier(sig)), holder(nullptr) {
     };
 
     int64_t GetHash() const override { return hash; }

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -52,6 +52,8 @@ VMMethod::VMMethod(VMSymbol* signature, size_t bcCount, size_t numberOfConstants
         indexableFields[i] = nilObject;
     }
     bytecodes = (uint8_t*)(&indexableFields + 2 + GetNumberOfIndexableFields());
+
+    write_barrier(this, signature);
 }
 
 VMMethod* VMMethod::Clone() const {

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -42,13 +42,13 @@
 #include "VMSymbol.h"
 
 VMMethod::VMMethod(VMSymbol* signature, size_t bcCount, size_t numberOfConstants, size_t numLocals, size_t maxStackDepth) :
-        VMInvokable(signature), bcLength(bcCount), numberOfLocals(numLocals), maximumNumberOfStackElements(maxStackDepth), numberOfArguments(signature == nullptr ? 0 : Signature::GetNumberOfArguments(signature)), numberOfConstants(numberOfConstants) {
+        VMInvokable(signature), numberOfLocals(numLocals), maximumNumberOfStackElements(maxStackDepth), bcLength(bcCount), numberOfArguments(signature == nullptr ? 0 : Signature::GetNumberOfArguments(signature)), numberOfConstants(numberOfConstants) {
 #ifdef UNSAFE_FRAME_OPTIMIZATION
     cachedFrame = nullptr;
 #endif
 
     indexableFields = (gc_oop_t*)(&indexableFields + 2);
-    for (long i = 0; i < numberOfConstants; ++i) {
+    for (size_t i = 0; i < numberOfConstants; ++i) {
         indexableFields[i] = nilObject;
     }
     bytecodes = (uint8_t*)(&indexableFields + 2 + GetNumberOfIndexableFields());

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -56,7 +56,7 @@ VMMethod::VMMethod(VMSymbol* signature, size_t bcCount, size_t numberOfConstants
     write_barrier(this, signature);
 }
 
-VMMethod* VMMethod::Clone() const {
+VMMethod* VMMethod::CloneForMovingGC() const {
     VMMethod* clone = new (GetHeap<HEAP_CLS>(), GetObjectSize() - sizeof(VMMethod) ALLOC_MATURE) VMMethod(*this);
     memcpy(SHIFTED_PTR(clone, sizeof(VMObject)), SHIFTED_PTR(this,
                     sizeof(VMObject)), GetObjectSize() -

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -60,7 +60,12 @@ VMMethod* VMMethod::Clone() const {
                     sizeof(VMObject)), GetObjectSize() -
             sizeof(VMObject));
     clone->indexableFields = (gc_oop_t*)(&(clone->indexableFields) + 2);
-    clone->bytecodes = (uint8_t*)(&(clone->indexableFields) + 2 + GetNumberOfIndexableFields());
+
+
+    size_t numIndexableFields = GetNumberOfIndexableFields();
+    clone->bytecodes = (uint8_t*)(&(clone->indexableFields) + 2 + numIndexableFields);
+
+    // Use of GetNumberOfIndexableFields() is problematic here, because it may be invalid object while cloning/moving within GC
     return clone;
 }
 
@@ -72,7 +77,8 @@ void VMMethod::WalkObjects(walk_heap_fn walk) {
         cachedFrame = static_cast<VMFrame*>(walk(cachedFrame));
 #endif
 
-    long numIndexableFields = GetNumberOfIndexableFields();
+    int64_t numIndexableFields = GetNumberOfIndexableFields();
+
     for (long i = 0; i < numIndexableFields; ++i) {
         if (indexableFields[i] != nullptr) {
             indexableFields[i] = walk(indexableFields[i]);

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -100,7 +100,7 @@ public:
         return numberOfConstants;
     }
 
-    VMMethod* Clone() const override;
+    VMMethod* CloneForMovingGC() const override;
 
     inline  void SetIndexableField(long idx, vm_oop_t item) {
         store_ptr(indexableFields[idx], item);

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -112,6 +112,10 @@ public:
         indexableFields = (gc_oop_t*) INVALID_GC_POINTER;
     }
 
+    bool IsMarkedInvalid() const override {
+        return indexableFields == (gc_oop_t*) INVALID_GC_POINTER;
+    }
+
     StdString AsDebugString() const override;
 
 private:

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -62,7 +62,7 @@ public:
         return maximumNumberOfStackElements;
     }
 
-    inline long GetNumberOfArguments() const {
+    inline size_t GetNumberOfArguments() const {
         return numberOfArguments;
     }
 
@@ -96,7 +96,7 @@ public:
 
     void WalkObjects(walk_heap_fn) override;
 
-    inline  long GetNumberOfIndexableFields() const {
+    inline  size_t GetNumberOfIndexableFields() const {
         return numberOfConstants;
     }
 

--- a/src/vmobjects/VMObject.cpp
+++ b/src/vmobjects/VMObject.cpp
@@ -54,7 +54,7 @@ VMObject::VMObject(size_t numSubclassFields, size_t totalObjectSize) : totalObje
     nilInitializeFields();
 }
 
-VMObject* VMObject::Clone() const {
+VMObject* VMObject::CloneForMovingGC() const {
     VMObject* clone = new (GetHeap<HEAP_CLS>(), totalObjectSize - sizeof(VMObject) ALLOC_MATURE) VMObject(*this);
     memcpy(SHIFTED_PTR(clone, sizeof(VMObject)),
            SHIFTED_PTR(this,  sizeof(VMObject)), totalObjectSize - sizeof(VMObject));

--- a/src/vmobjects/VMObject.cpp
+++ b/src/vmobjects/VMObject.cpp
@@ -52,7 +52,7 @@ VMObject* VMObject::Clone() const {
     VMObject* clone = new (GetHeap<HEAP_CLS>(), objectSize - sizeof(VMObject) ALLOC_MATURE) VMObject(*this);
     memcpy(SHIFTED_PTR(clone, sizeof(VMObject)),
            SHIFTED_PTR(this,  sizeof(VMObject)), GetObjectSize() - sizeof(VMObject));
-    clone->hash = (size_t) &clone;
+    clone->hash = this->hash;
     return clone;
 }
 

--- a/src/vmobjects/VMObject.cpp
+++ b/src/vmobjects/VMObject.cpp
@@ -86,6 +86,15 @@ void VMObject::WalkObjects(walk_heap_fn walk) {
 
 void VMObject::MarkObjectAsInvalid() {
     clazz = (GCClass*) INVALID_GC_POINTER;
+    
+    long numFields = GetNumberOfFields();
+    for (long i = 0; i < numFields; ++i) {
+        FIELDS[i] = INVALID_GC_POINTER;
+    }
+}
+
+bool VMObject::IsMarkedInvalid() const {
+    return clazz == INVALID_GC_POINTER;
 }
 
 std::string VMObject::AsDebugString() const {

--- a/src/vmobjects/VMObject.cpp
+++ b/src/vmobjects/VMObject.cpp
@@ -80,7 +80,7 @@ void VMObject::WalkObjects(walk_heap_fn walk) {
     
     long numFields = GetNumberOfFields();
     for (long i = 0; i < numFields; ++i) {
-        FIELDS[i] = walk(_store_ptr(GetField(i)));
+        FIELDS[i] = walk(tmp_ptr(GetField(i)));
     }
 }
 

--- a/src/vmobjects/VMObject.cpp
+++ b/src/vmobjects/VMObject.cpp
@@ -23,6 +23,8 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  */
+
+#include <cassert>
 #include <cstddef>
 #include <cstring>
 #include <string>
@@ -31,6 +33,7 @@
 #include "../misc/defs.h"
 #include "../vm/Globals.h"
 #include "../vm/Universe.h"
+#include "AbstractObject.h"
 #include "ObjectFormats.h"
 #include "VMClass.h"
 #include "VMFrame.h"
@@ -78,7 +81,7 @@ void VMObject::Assert(bool value) const {
 
 void VMObject::WalkObjects(walk_heap_fn walk) {
     clazz = static_cast<GCClass*>(walk(clazz));
-    
+
     long numFields = GetNumberOfFields();
     for (long i = 0; i < numFields; ++i) {
         FIELDS[i] = walk(tmp_ptr(GetField(i)));
@@ -87,7 +90,7 @@ void VMObject::WalkObjects(walk_heap_fn walk) {
 
 void VMObject::MarkObjectAsInvalid() {
     clazz = (GCClass*) INVALID_GC_POINTER;
-    
+
     long numFields = GetNumberOfFields();
     for (long i = 0; i < numFields; ++i) {
         FIELDS[i] = INVALID_GC_POINTER;

--- a/src/vmobjects/VMObject.h
+++ b/src/vmobjects/VMObject.h
@@ -121,7 +121,7 @@ protected_testable:
     size_t objectSize;     // set by the heap at allocation time
     long   numberOfFields;
 
-    GCClass* clazz;
+    GCClass* clazz{nullptr};
 
     // Start of fields. All members beyond after clazz are indexable.
     // clazz has index -1.

--- a/src/vmobjects/VMObject.h
+++ b/src/vmobjects/VMObject.h
@@ -62,7 +62,7 @@ class VMObject: public AbstractVMObject {
 public:
     typedef GCObject Stored;
 
-    VMObject(size_t numberOfFields = 0);
+    explicit VMObject(size_t numberOfFields = 0);
     ~VMObject() override = default;
 
     int64_t GetHash() const override { return hash; }
@@ -90,7 +90,7 @@ public:
     inline void      SetObjectSize(size_t size) override;
 
            void      MarkObjectAsInvalid() override;
-           bool      IsMarkedInvalid() const override final;
+           bool      IsMarkedInvalid() const final;
 
            StdString AsDebugString() const override;
 
@@ -112,7 +112,7 @@ public:
     }
 
 protected:
-    inline long GetAdditionalSpaceConsumption() const;
+    inline size_t GetAdditionalSpaceConsumption() const;
 
     // VMObject essentials
     int64_t hash;
@@ -148,7 +148,7 @@ long VMObject::GetNumberOfFields() const {
 }
 
 //returns the Object's additional memory used (e.g. for Array fields)
-long VMObject::GetAdditionalSpaceConsumption() const {
+size_t VMObject::GetAdditionalSpaceConsumption() const {
     //The VM*-Object's additional memory used needs to be calculated.
     //It's      the total object size   MINUS   sizeof(VMObject) for basic
     //VMObject  MINUS   the number of fields times sizeof(VMObject*)

--- a/src/vmobjects/VMObject.h
+++ b/src/vmobjects/VMObject.h
@@ -61,8 +61,9 @@ class VMObject: public AbstractVMObject {
 
 public:
     typedef GCObject Stored;
-    
+
     VMObject(size_t numberOfFields = 0);
+    ~VMObject() override = default;
 
     int64_t GetHash() const override { return hash; }
     inline VMClass*  GetClass() const override;
@@ -70,27 +71,27 @@ public:
            VMSymbol* GetFieldName(long index) const override;
     inline long      GetNumberOfFields() const override;
                    void      SetNumberOfFields(long nof);
-    
+
     inline vm_oop_t GetField(size_t index) const {
         vm_oop_t result = load_ptr(FIELDS[index]);
         assert(IsValidObject(result));
         return result;
     }
-    
+
     inline void SetField(size_t index, vm_oop_t value) {
         assert(IsValidObject(value));
         store_ptr(FIELDS[index], value);
     }
-    
+
     virtual        void      Assert(bool value) const;
     void      WalkObjects(walk_heap_fn walk) override;
     VMObject* Clone() const override;
     inline size_t    GetObjectSize() const override;
     inline void      SetObjectSize(size_t size) override;
-    
+
            void      MarkObjectAsInvalid() override;
            bool      IsMarkedInvalid() const override final;
-    
+
            StdString AsDebugString() const override;
 
     /**
@@ -105,7 +106,7 @@ public:
     void* operator new(size_t numBytes, HEAP_CLS* heap, unsigned long additionalBytes = 0 ALLOC_OUTSIDE_NURSERY_DECL) {
         void* mem = AbstractVMObject::operator new(numBytes, heap, additionalBytes ALLOC_OUTSIDE_NURSERY(outsideNursery));
         assert(mem != INVALID_VM_POINTER);
-        
+
         ((VMObject*) mem)->objectSize = numBytes + PADDED_SIZE(additionalBytes);
         return mem;
     }
@@ -119,12 +120,12 @@ protected:
 protected_testable:
     size_t objectSize;     // set by the heap at allocation time
     long   numberOfFields;
-  
+
     GCClass* clazz;
 
     // Start of fields. All members beyond after clazz are indexable.
     // clazz has index -1.
-    
+
 private:
     static const size_t VMObjectNumberOfFields;
 };

--- a/src/vmobjects/VMObject.h
+++ b/src/vmobjects/VMObject.h
@@ -89,6 +89,7 @@ public:
     inline void      SetObjectSize(size_t size) override;
     
            void      MarkObjectAsInvalid() override;
+           bool      IsMarkedInvalid() const override final;
     
            StdString AsDebugString() const override;
 

--- a/src/vmobjects/VMObject.h
+++ b/src/vmobjects/VMObject.h
@@ -87,7 +87,7 @@ public:
 
     virtual        void      Assert(bool value) const;
     void      WalkObjects(walk_heap_fn walk) override;
-    VMObject* Clone() const override;
+    VMObject* CloneForMovingGC() const override;
     
     /** The total size of the object on the heap. */
     inline size_t GetObjectSize() const override {

--- a/src/vmobjects/VMObjectBase.h
+++ b/src/vmobjects/VMObjectBase.h
@@ -13,6 +13,8 @@ protected:
 public:
     inline size_t GetGCField() const;
     inline void SetGCField(size_t);
+    VMObjectBase() : VMOop() {}
+    ~VMObjectBase() override = default;
 };
 
 size_t VMObjectBase::GetGCField() const {

--- a/src/vmobjects/VMObjectBase.h
+++ b/src/vmobjects/VMObjectBase.h
@@ -1,15 +1,15 @@
 #pragma once
 
-#define MASK_OBJECT_IS_MARKED (1 << 0)
-#define MASK_OBJECT_IS_OLD (1 << 1)
-#define MASK_SEEN_BY_WRITE_BARRIER (1 << 2)
+#define MASK_OBJECT_IS_MARKED (1U << 0U)
+#define MASK_OBJECT_IS_OLD (1U << 1U)
+#define MASK_SEEN_BY_WRITE_BARRIER (1U << 2U)
 #define MASK_BITS_ALL (MASK_OBJECT_IS_MARKED | MASK_OBJECT_IS_OLD | MASK_SEEN_BY_WRITE_BARRIER)
 
 #include <cassert>
 
 class VMObjectBase : public VMOop {
 protected:
-    size_t gcfield;
+    size_t gcfield{0};
 public:
     inline size_t GetGCField() const;
     inline void SetGCField(size_t);

--- a/src/vmobjects/VMPrimitive.cpp
+++ b/src/vmobjects/VMPrimitive.cpp
@@ -43,7 +43,9 @@ VMPrimitive* VMPrimitive::GetEmptyPrimitive(VMSymbol* sig, bool classSide) {
     return prim;
 }
 
-VMPrimitive::VMPrimitive(VMSymbol* signature) : VMInvokable(signature), routine(nullptr), empty(false) {}
+VMPrimitive::VMPrimitive(VMSymbol* signature) : VMInvokable(signature), routine(nullptr), empty(false) {
+    write_barrier(this, signature);
+}
 
 VMPrimitive* VMPrimitive::Clone() const {
     VMPrimitive* prim = new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMPrimitive(*this);

--- a/src/vmobjects/VMPrimitive.cpp
+++ b/src/vmobjects/VMPrimitive.cpp
@@ -47,7 +47,7 @@ VMPrimitive::VMPrimitive(VMSymbol* signature) : VMInvokable(signature), routine(
     write_barrier(this, signature);
 }
 
-VMPrimitive* VMPrimitive::Clone() const {
+VMPrimitive* VMPrimitive::CloneForMovingGC() const {
     VMPrimitive* prim = new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMPrimitive(*this);
     return prim;
 }

--- a/src/vmobjects/VMPrimitive.cpp
+++ b/src/vmobjects/VMPrimitive.cpp
@@ -38,7 +38,7 @@
 #include "VMSymbol.h"
 
 VMPrimitive* VMPrimitive::GetEmptyPrimitive(VMSymbol* sig, bool classSide) {
-    VMPrimitive* prim = new (GetHeap<HEAP_CLS>()) VMPrimitive(sig);
+    VMPrimitive* prim = new (GetHeap<HEAP_CLS>(), 0) VMPrimitive(sig);
     prim->SetRoutine(new Routine<VMPrimitive>(prim, &VMPrimitive::EmptyRoutine, classSide), true);
     return prim;
 }

--- a/src/vmobjects/VMPrimitive.h
+++ b/src/vmobjects/VMPrimitive.h
@@ -26,9 +26,9 @@
  THE SOFTWARE.
  */
 
-#include "VMObject.h"
-#include "VMInvokable.h"
 #include "PrimitiveRoutine.h"
+#include "VMInvokable.h"
+#include "VMObject.h"
 
 class VMPrimitive: public VMInvokable {
 public:

--- a/src/vmobjects/VMPrimitive.h
+++ b/src/vmobjects/VMPrimitive.h
@@ -56,7 +56,7 @@ public:
     }
 
             void SetEmpty(bool value) {empty = value;};
-            VMPrimitive* Clone() const override;
+            VMPrimitive* CloneForMovingGC() const override;
 
     void Invoke(Interpreter* interp, VMFrame* frm) override {
         routine->Invoke(interp, frm);

--- a/src/vmobjects/VMPrimitive.h
+++ b/src/vmobjects/VMPrimitive.h
@@ -68,6 +68,10 @@ public:
         routine = (PrimitiveRoutine*) INVALID_GC_POINTER;
     }
 
+    bool IsMarkedInvalid() const override {
+        return routine == (PrimitiveRoutine*) INVALID_GC_POINTER;
+    }
+
     StdString AsDebugString() const override;
 
 private:

--- a/src/vmobjects/VMString.cpp
+++ b/src/vmobjects/VMString.cpp
@@ -39,10 +39,9 @@ extern GCClass* stringClass;
 //#define CHARS ((char*)&clazz+sizeof(VMObject*))
 
 VMString::VMString(const size_t length, const char* str) :
-        length(length),
+        AbstractVMObject(), length(length),
         // set the chars-pointer to point at the position of the first character
-        chars((char*) &chars + sizeof(char*)),
-        AbstractVMObject() {
+        chars((char*) &chars + sizeof(char*)) {
     for (size_t i = 0; i < length; i++) {
         chars[i] = str[i];
     }

--- a/src/vmobjects/VMString.cpp
+++ b/src/vmobjects/VMString.cpp
@@ -47,7 +47,7 @@ VMString::VMString(const size_t length, const char* str) :
     }
 }
 
-VMString* VMString::Clone() const {
+VMString* VMString::CloneForMovingGC() const {
     return new (GetHeap<HEAP_CLS>(), PADDED_SIZE(length) ALLOC_MATURE) VMString(length, chars);
 }
 

--- a/src/vmobjects/VMString.cpp
+++ b/src/vmobjects/VMString.cpp
@@ -55,8 +55,12 @@ VMString* VMString::Clone() const {
 void VMString::MarkObjectAsInvalid() {
     for (size_t i = 0; i < length; i++) {
         chars[i] = 'z';
-        i++;
     }
+    chars = (char*) INVALID_GC_POINTER;
+}
+
+bool VMString::IsMarkedInvalid() const {
+    return chars == (char*) INVALID_GC_POINTER;
 }
 
 void VMString::WalkObjects(walk_heap_fn) {

--- a/src/vmobjects/VMString.h
+++ b/src/vmobjects/VMString.h
@@ -54,6 +54,7 @@ public:
     void WalkObjects(walk_heap_fn) override;
     
     void MarkObjectAsInvalid() override;
+    bool IsMarkedInvalid() const override;
     
     StdString AsDebugString() const override;
 
@@ -61,7 +62,7 @@ protected_testable:
     //this could be replaced by the CHARS macro in VMString.cpp
     //in order to decrease the object size
     const size_t length;
-    char* const chars;
+    char* chars;
 protected:
     VMString(char* const adaptedCharsPointer, const size_t length) :
         // set the chars-pointer to point at the position of the first character

--- a/src/vmobjects/VMString.h
+++ b/src/vmobjects/VMString.h
@@ -31,17 +31,17 @@
 class VMString: public AbstractVMObject {
 public:
     typedef GCString Stored;
-    
+
     VMString(const size_t length, const char* str);
-    
+
     int64_t GetHash() const override {
-        int64_t hash = 5381;
+        uint64_t hash = 5381U;
 
         for (size_t i = 0; i < length; i++) {
-            hash = ((hash << 5) + hash) + chars[i];
+            hash = ((hash << 5U) + hash) + chars[i];
         }
-        
-        return hash;
+
+        return (int64_t) hash;
     }
 
     inline char* GetRawChars() const;
@@ -52,10 +52,10 @@ public:
     VMClass* GetClass() const override;
     size_t GetObjectSize() const override;
     void WalkObjects(walk_heap_fn) override;
-    
+
     void MarkObjectAsInvalid() override;
     bool IsMarkedInvalid() const override;
-    
+
     StdString AsDebugString() const override;
 
 protected_testable:
@@ -67,8 +67,7 @@ protected:
     VMString(char* const adaptedCharsPointer, const size_t length) :
         // set the chars-pointer to point at the position of the first character
         // as determined in the VMSymbol constructor
-        chars(adaptedCharsPointer),
-        length(length) {}; //constructor to use by VMSymbol
+        length(length), chars(adaptedCharsPointer) {}; //constructor to use by VMSymbol
 };
 
 char* VMString::GetRawChars() const {

--- a/src/vmobjects/VMString.h
+++ b/src/vmobjects/VMString.h
@@ -48,7 +48,7 @@ public:
     StdString GetStdString() const;
     size_t GetStringLength() const;
 
-    VMString* Clone() const override;
+    VMString* CloneForMovingGC() const override;
     VMClass* GetClass() const override;
     size_t GetObjectSize() const override;
     void WalkObjects(walk_heap_fn) override;

--- a/src/vmobjects/VMSymbol.cpp
+++ b/src/vmobjects/VMSymbol.cpp
@@ -32,7 +32,6 @@
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../vm/Globals.h"  // NOLINT (misc-include-cleaner)
-#include "AbstractObject.h"
 #include "ObjectFormats.h"
 #include "Signature.h"
 #include "VMClass.h"

--- a/src/vmobjects/VMSymbol.cpp
+++ b/src/vmobjects/VMSymbol.cpp
@@ -57,7 +57,7 @@ size_t VMSymbol::GetObjectSize() const {
     return size;
 }
 
-VMSymbol* VMSymbol::Clone() const {
+VMSymbol* VMSymbol::CloneForMovingGC() const {
     VMSymbol* result = new (GetHeap<HEAP_CLS>(), PADDED_SIZE(length) ALLOC_MATURE) VMSymbol(length, chars);
     return result;
 }

--- a/src/vmobjects/VMSymbol.h
+++ b/src/vmobjects/VMSymbol.h
@@ -28,22 +28,22 @@
 
 #include <iostream>
 
-#include "VMString.h"
 #include "VMObject.h"
+#include "VMString.h"
 
 class VMSymbol: public VMString {
 
 public:
     typedef GCSymbol Stored;
-    
+
     VMSymbol(const size_t length, const char* const str);
     StdString GetPlainString() const;
     size_t GetObjectSize() const override;
     VMSymbol* Clone() const override;
     VMClass* GetClass() const override;
-    
+
     StdString AsDebugString() const override;
-    
+
 private:
     const int numberOfArgumentsOfSignature;
     const GCClass* cachedClass_invokable[3];

--- a/src/vmobjects/VMSymbol.h
+++ b/src/vmobjects/VMSymbol.h
@@ -39,7 +39,7 @@ public:
     VMSymbol(const size_t length, const char* const str);
     StdString GetPlainString() const;
     size_t GetObjectSize() const override;
-    VMSymbol* Clone() const override;
+    VMSymbol* CloneForMovingGC() const override;
     VMClass* GetClass() const override;
 
     StdString AsDebugString() const override;


### PR DESCRIPTION
This PR works on various issues around GC, trying to find leaks/incorrect bits etc.

There are a lot of bits here that change code to slowly get clang-tidy become useful, which also includes reducing undefined behavior etc.

The major changes are:
 - add a copying GC that's backed per-object by malloc: DebugCopyingGC
 - add `IsMarkedValid` for more aggressive assertion checking
 - add logging levels
 - refactor helpers to write pointers, to make more explicit what the GC-related invariants are
 - make sure object hash is stable across GCs
 - rework object creation to avoid undefined behavior (pass total object size into constructor)