### PR TITLE
Add inlining of #whileTrue:/#whileFalse:

### DIFF
--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 		0A335F6F1832D65100D7CFC8 /* Primitive.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Primitive.cpp; sourceTree = "<group>"; };
 		0A335F701832D65100D7CFC8 /* Primitive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Primitive.h; sourceTree = "<group>"; };
 		0A3FABE724F4670D002D4D69 /* BasicInterpreterTests.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; name = BasicInterpreterTests.h; path = unitTests/BasicInterpreterTests.h; sourceTree = "<group>"; };
+		0A5A7E8E2C5A37450011C783 /* StringUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StringUtil.h; sourceTree = "<group>"; };
 		0A67EA6719ACD37200830E3B /* unittests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = unittests; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A67EA7019ACD43A00830E3B /* CloneObjectsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CloneObjectsTest.cpp; path = unitTests/CloneObjectsTest.cpp; sourceTree = "<group>"; };
 		0A67EA7119ACD43A00830E3B /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = unitTests/main.cpp; sourceTree = "<group>"; };
@@ -557,6 +558,7 @@
 				0A707529297DF97700EB9F59 /* ParseInteger.cpp */,
 				0A1C98592C432E0E00735850 /* VectorUtil.h */,
 				0A1C986D2C4F1D3900735850 /* debug.cpp */,
+				0A5A7E8E2C5A37450011C783 /* StringUtil.h */,
 			);
 			path = misc;
 			sourceTree = "<group>";

--- a/src/compiler/BytecodeGenerator.h
+++ b/src/compiler/BytecodeGenerator.h
@@ -55,3 +55,11 @@ void EmitSEND(MethodGenerationContext& mgenc, VMSymbol* msg);
 void EmitSUPERSEND(MethodGenerationContext& mgenc, VMSymbol* msg);
 void EmitRETURNLOCAL(MethodGenerationContext& mgenc);
 void EmitRETURNNONLOCAL(MethodGenerationContext& mgenc);
+
+size_t EmitJumpOnBoolWithDummyOffset(MethodGenerationContext& mgenc, bool isIfTrue, bool needsPop);
+void EmitJumpBackwardWithOffset(MethodGenerationContext& mgenc, size_t jumpOffset);
+size_t Emit3WithDummy(MethodGenerationContext& mgenc, uint8_t bytecode, size_t stackEffect);
+
+void EmitPushFieldWithIndex(MethodGenerationContext& mgenc, uint8_t fieldIdx, uint8_t ctxLevel);
+void EmitPopFieldWithIndex(MethodGenerationContext& mgenc, uint8_t fieldIdx, uint8_t ctxLevel);
+

--- a/src/compiler/Disassembler.cpp
+++ b/src/compiler/Disassembler.cpp
@@ -264,15 +264,27 @@ void Disassembler::dumpMethod(uint8_t* bytecodes, size_t numberOfBytecodes, cons
                 }
                 break;
             }
-            case BC_JUMP_IF_FALSE:
-            case BC_JUMP_IF_TRUE:
-            case BC_JUMP: {
-                int target = 0;
-                target |= bytecodes[bc_idx + 1];
-                target |= bytecodes[bc_idx + 2] << 8;
-                target |= bytecodes[bc_idx + 3] << 16;
-                target |= bytecodes[bc_idx + 4] << 24;
-                DebugPrint("(target: %d)\n", target);
+            case BC_JUMP:
+            case BC_JUMP_ON_FALSE_POP:
+            case BC_JUMP_ON_TRUE_POP:
+            case BC_JUMP_ON_FALSE_TOP_NIL:
+            case BC_JUMP_ON_TRUE_TOP_NIL:
+            case BC_JUMP_BACKWARD:
+            case BC_JUMP2:
+            case BC_JUMP2_ON_FALSE_POP:
+            case BC_JUMP2_ON_TRUE_POP:
+            case BC_JUMP2_ON_FALSE_TOP_NIL:
+            case BC_JUMP2_ON_TRUE_TOP_NIL:
+            case BC_JUMP2_BACKWARD: {
+                uint16_t offset = ComputeOffset(bytecodes[bc_idx + 1], bytecodes[bc_idx + 2]);
+                
+                int32_t target;
+                if (bytecode == BC_JUMP_BACKWARD || bytecode == BC_JUMP2_BACKWARD) {
+                    target = ((int32_t) bc_idx) - offset;
+                } else {
+                    target = ((int32_t) bc_idx) + offset;
+                }
+                DebugPrint("(jump offset: %d -> jump target: %d)\n", offset, target);
                 break;
             }
             default: {
@@ -520,15 +532,27 @@ void Disassembler::DumpBytecode(VMFrame* frame, VMMethod* method, long bc_idx) {
             indentc--; ikind='<'; //visual
             break;
         }
-        case BC_JUMP_IF_FALSE:
-        case BC_JUMP_IF_TRUE:
-        case BC_JUMP: {
-            int target = 0;
-            target |= method->GetBytecode(bc_idx + 1);
-            target |= method->GetBytecode(bc_idx + 2) << 8;
-            target |= method->GetBytecode(bc_idx + 3) << 16;
-            target |= method->GetBytecode(bc_idx + 4) << 24;
-            DebugPrint("(target: %d)\n", target);
+        case BC_JUMP:
+        case BC_JUMP_ON_FALSE_POP:
+        case BC_JUMP_ON_TRUE_POP:
+        case BC_JUMP_ON_FALSE_TOP_NIL:
+        case BC_JUMP_ON_TRUE_TOP_NIL:
+        case BC_JUMP_BACKWARD:
+        case BC_JUMP2:
+        case BC_JUMP2_ON_FALSE_POP:
+        case BC_JUMP2_ON_TRUE_POP:
+        case BC_JUMP2_ON_FALSE_TOP_NIL:
+        case BC_JUMP2_ON_TRUE_TOP_NIL:
+        case BC_JUMP2_BACKWARD: {
+            uint16_t offset = ComputeOffset(method->GetBytecode(bc_idx + 1), method->GetBytecode(bc_idx + 2));
+            
+            int32_t target;
+            if (bc == BC_JUMP_BACKWARD || bc == BC_JUMP2_BACKWARD) {
+                target = ((int32_t) bc_idx) - offset;
+            } else {
+                target = ((int32_t) bc_idx) + offset;
+            }
+            DebugPrint("(jump offset: %d -> jump target: %d)", offset, target);
             break;
         }
         default:

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -28,15 +28,20 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <string>
+#include <tuple>
 #include <vector>
 
+#include "../interpreter/bytecodes.h"
 #include "../misc/VectorUtil.h"
+#include "../vm/Globals.h"
 #include "../vm/Universe.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMMethod.h"
 #include "../vmobjects/VMPrimitive.h"
 #include "../vmobjects/VMSymbol.h"
+#include "BytecodeGenerator.h"
 #include "ClassGenerationContext.h"
 #include "LexicalScope.h"
 #include "MethodGenerationContext.h"
@@ -46,14 +51,17 @@
 MethodGenerationContext::MethodGenerationContext(ClassGenerationContext& holder, MethodGenerationContext* outer) :
         holderGenc(holder), outerGenc(outer),
         blockMethod(outer != nullptr), signature(nullptr), primitive(false), finished(false),
-        currentStackDepth(0), maxStackDepth(0), maxContextLevel(outer == nullptr ? 0 : outer->GetMaxContextLevel() + 1) { }
+        currentStackDepth(0), maxStackDepth(0), maxContextLevel(outer == nullptr ? 0 : outer->GetMaxContextLevel() + 1) {
+            last4Bytecodes = {BC_INVALID, BC_INVALID, BC_INVALID, BC_INVALID};
+            isCurrentlyInliningABlock = false;
+}
 
 VMMethod* MethodGenerationContext::Assemble() {
     // create a method instance with the given number of bytecodes and literals
     size_t numLiterals = literals.size();
     size_t numLocals = locals.size();
     VMMethod* meth = GetUniverse()->NewMethod(signature, bytecode.size(),
-            numLiterals, numLocals, maxStackDepth, lexicalScope);
+            numLiterals, numLocals, maxStackDepth, lexicalScope, inlinedLoops);
 
     // copy literals into the method
     for (size_t i = 0; i < numLiterals; i++) {
@@ -206,13 +214,191 @@ void MethodGenerationContext::AddBytecode(uint8_t bc, size_t stackEffect) {
     maxStackDepth = max(maxStackDepth, currentStackDepth);
 
     bytecode.push_back(bc);
+
+    last4Bytecodes[0] = last4Bytecodes[1];
+    last4Bytecodes[1] = last4Bytecodes[2];
+    last4Bytecodes[2] = last4Bytecodes[3];
+    last4Bytecodes[3] = bc;
 }
 
 void MethodGenerationContext::AddBytecodeArgument(uint8_t bc) {
     bytecode.push_back(bc);
 }
 
+size_t MethodGenerationContext::AddBytecodeArgumentAndGetIndex(uint8_t bc) {
+    size_t index = bytecode.size();
+    AddBytecodeArgument(bc);
+    return index;
+}
+
+bool MethodGenerationContext::lastBytecodeIs(size_t indexFromEnd, uint8_t bytecode) {
+    assert(indexFromEnd >= 0 && indexFromEnd < 4);
+    uint8_t actual = last4Bytecodes[3 - indexFromEnd];
+    return actual == bytecode;
+}
+
+void MethodGenerationContext::removeLastBytecodes(size_t numBytecodes) {
+    assert(numBytecodes > 0 && numBytecodes <= 4);
+    size_t bytesToRemove = 0;
+
+    for (size_t idxFromEnd = 0; idxFromEnd < numBytecodes; idxFromEnd += 1) {
+        bytesToRemove += Bytecode::GetBytecodeLength(last4Bytecodes[3 - idxFromEnd]);
+    }
+
+    bytecode.erase(bytecode.end() - bytesToRemove, bytecode.end());
+}
+
+bool MethodGenerationContext::hasTwoLiteralBlockArguments() {
+    if (!lastBytecodeIs(0, BC_PUSH_BLOCK)) {
+        return false;
+    }
+
+    return lastBytecodeIs(1, BC_PUSH_BLOCK);
+}
+
+std::tuple<vm_oop_t, vm_oop_t> MethodGenerationContext::extractBlockMethodsAndRemoveBytecodes() {
+    uint8_t block1LitIdx = bytecode.at(bytecode.size() - 3);
+    uint8_t block2LitIdx = bytecode.at(bytecode.size() - 1);
+
+    // grab the blocks' methods for inlining
+    vm_oop_t toBeInlined1 = literals.at(block1LitIdx);
+    vm_oop_t toBeInlined2 = literals.at(block2LitIdx);
+
+    removeLastBytecodes(2);
+
+    return {toBeInlined1, toBeInlined2};
+}
+
+bool MethodGenerationContext::InlineWhile(Parser& parser, bool isWhileTrue) {
+    if (!hasTwoLiteralBlockArguments()) {
+        return false;
+    }
+
+    assert(Bytecode::GetBytecodeLength(BC_PUSH_BLOCK) == 2);
+
+    std::tuple<vm_oop_t, vm_oop_t> methods = extractBlockMethodsAndRemoveBytecodes();
+    VMMethod* condMethod = static_cast<VMMethod*>(std::get<0>(methods));
+    VMMethod* bodyMethod = static_cast<VMMethod*>(std::get<1>(methods));
+
+    size_t loopBeginIdx = OffsetOfNextInstruction();
+
+    isCurrentlyInliningABlock = true;
+    condMethod->InlineInto(*this);
+
+    size_t jumpOffsetIdxToSkipLoopBody = EmitJumpOnBoolWithDummyOffset(*this, isWhileTrue, true);
+
+    bodyMethod->InlineInto(*this);
+
+    completeJumpsAndEmitReturningNil(parser, loopBeginIdx, jumpOffsetIdxToSkipLoopBody);
+
+    isCurrentlyInliningABlock = false;
+
+    return true;
+}
+
 void MethodGenerationContext::CompleteLexicalScope() {
     lexicalScope = new LexicalScope(outerGenc == nullptr ? nullptr : outerGenc->lexicalScope,
                                     arguments, locals);
+}
+
+void MethodGenerationContext::MergeIntoScope(LexicalScope& scopeToBeInlined) {
+    assert(scopeToBeInlined.GetNumberOfArguments() == 1);
+    size_t numLocals = scopeToBeInlined.GetNumberOfLocals();
+    if (numLocals > 0) {
+        inlineLocals(scopeToBeInlined);
+    }
+}
+
+void MethodGenerationContext::inlineLocals(LexicalScope& scopeToBeInlined) {
+    for (const Variable& local : scopeToBeInlined.locals) {
+        Variable freshCopy = local.CopyForInlining(this->locals.size());
+        if (freshCopy.IsValid()) {
+            // freshCopy can be invalid, because we don't need the $blockSelf
+            std::string qualifiedName = local.MakeQualifiedName();
+            assert(!Contains(this->locals, qualifiedName));
+            lexicalScope->AddInlinedLocal(freshCopy);
+            this->locals.push_back(freshCopy);
+        }
+    }
+}
+
+uint8_t MethodGenerationContext::GetInlinedLocalIdx(const Variable* var) const {
+    assert(locals.size() < UINT8_MAX);
+    uint8_t index = locals.size();
+
+    while (index > 0) {
+        index -= 1;
+        if (locals[index].IsSame(*var)) {
+            return index;
+        }
+    }
+
+    char msg[200];
+    std::string qualifiedName = var->MakeQualifiedName();
+    snprintf(msg, 200, "Unexpected issue trying to find an inlined variable. %s could not be found.", qualifiedName.data());
+    Universe::ErrorExit(msg);
+}
+
+void MethodGenerationContext::checkJumpOffset(size_t jumpOffset, uint8_t bytecode) {
+    if (jumpOffset < 0 || jumpOffset > 0xFFFF) {
+        char msg[100];
+        snprintf(msg, 100, "The jumpOffset for the %s bytecode is out of range: %zu\n", Bytecode::GetBytecodeName(bytecode), jumpOffset);
+        Universe::ErrorExit(msg);
+    }
+}
+
+void MethodGenerationContext::EmitBackwardsJumpOffsetToTarget(size_t loopBeginIdx) {
+    size_t addressOfJump = OffsetOfNextInstruction();
+
+    // we are going to jump backward and want a positive value
+    // thus we subtract target_address from address_of_jump
+    size_t jumpOffset = addressOfJump - loopBeginIdx;
+
+    checkJumpOffset(jumpOffset, BC_JUMP_BACKWARD);
+
+    size_t backwardJumpIdx = OffsetOfNextInstruction();
+
+    EmitJumpBackwardWithOffset(*this, jumpOffset);
+    inlinedLoops.push_back(BackJump(loopBeginIdx, backwardJumpIdx));
+}
+
+void MethodGenerationContext::completeJumpsAndEmitReturningNil(Parser& parser, size_t loopBeginIdx, size_t jumpOffsetIdxToSkipLoopBody) {
+    resetLastBytecodeBuffer();
+    EmitPOP(*this);
+
+    EmitBackwardsJumpOffsetToTarget(loopBeginIdx);
+
+    PatchJumpOffsetToPointToNextInstruction(jumpOffsetIdxToSkipLoopBody);
+    EmitPUSHCONSTANT(*this, load_ptr(nilObject));
+    resetLastBytecodeBuffer();
+}
+
+void MethodGenerationContext::PatchJumpOffsetToPointToNextInstruction(size_t indexOfOffset) {
+    size_t instructionStart = indexOfOffset - 1;
+    uint8_t bytecode = this->bytecode[instructionStart];
+    assert(IsJumpBytecode(bytecode));
+
+    size_t jumpOffset = OffsetOfNextInstruction() - instructionStart;
+    checkJumpOffset(jumpOffset, bytecode);
+
+    if (jumpOffset <= 0xFF) {
+        this->bytecode[indexOfOffset] = jumpOffset;
+        this->bytecode[indexOfOffset + 1] = 0;
+    } else {
+        // need to use the JUMP2* version of the bytecode
+        if (bytecode < FIRST_DOUBLE_BYTE_JUMP_BYTECODE) {
+            // still need to bump this one up to
+            this->bytecode[instructionStart] += NUM_SINGLE_BYTE_JUMP_BYTECODES;
+        }
+        assert(IsJumpBytecode(this->bytecode[instructionStart]));
+        this->bytecode[indexOfOffset] = jumpOffset & 0xFF;
+        this->bytecode[indexOfOffset + 1] = jumpOffset >> 8;
+    }
+}
+
+void MethodGenerationContext::resetLastBytecodeBuffer() {
+    last4Bytecodes[0] = BC_INVALID;
+    last4Bytecodes[1] = BC_INVALID;
+    last4Bytecodes[2] = BC_INVALID;
+    last4Bytecodes[3] = BC_INVALID;
 }

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -124,6 +124,8 @@ private:
     bool hasTwoLiteralBlockArguments();
     bool lastBytecodeIs(size_t indexFromEnd, uint8_t bytecode);
     std::tuple<vm_oop_t, vm_oop_t> extractBlockMethodsAndRemoveBytecodes();
+    vm_oop_t getLastBlockMethodAndFreeLiteral(uint8_t blockLiteralIdx);
+
     void completeJumpsAndEmitReturningNil(Parser& parser, size_t loopBeginIdx, size_t jumpOffsetIdxToSkipLoopBody);
     void inlineLocals(LexicalScope& scopeToBeInlined);
     void checkJumpOffset(size_t jumpOffset, uint8_t bytecode);

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -26,6 +26,7 @@
  THE SOFTWARE.
  */
 
+#include <array>
 #include <vector>
 
 #include "../misc/defs.h"
@@ -52,7 +53,7 @@ public:
     uint8_t GetFieldIndex(VMSymbol* field);
 
     void SetSignature(VMSymbol* sig);
-    
+
     void AddArgument(std::string& arg, const SourceCoordinate& coord);
     void AddLocal(std::string& local, const SourceCoordinate& coord);
     bool AddArgumentIfAbsent(std::string& arg, const SourceCoordinate& coord);
@@ -96,6 +97,7 @@ public:
     size_t GetNumberOfArguments();
     void AddBytecode(uint8_t bc, size_t stackEffect);
     void AddBytecodeArgument(uint8_t bc);
+    size_t AddBytecodeArgumentAndGetIndex(uint8_t bc);
 
     bool HasBytecodes();
 
@@ -103,9 +105,30 @@ public:
         return bytecode;
     }
 
+    bool InlineWhile(Parser& parser, bool isWhileTrue);
+
+    inline size_t OffsetOfNextInstruction() {
+        return bytecode.size();
+    }
+
     void CompleteLexicalScope();
+    void MergeIntoScope(LexicalScope& scopeToBeInlined);
+
+    uint8_t GetInlinedLocalIdx(const Variable* var) const;
+
+    void EmitBackwardsJumpOffsetToTarget(size_t loopBeginIdx);
+    void PatchJumpOffsetToPointToNextInstruction(size_t indexOfOffset);
 
 private:
+    void removeLastBytecodes(size_t numBytecodes);
+    bool hasTwoLiteralBlockArguments();
+    bool lastBytecodeIs(size_t indexFromEnd, uint8_t bytecode);
+    std::tuple<vm_oop_t, vm_oop_t> extractBlockMethodsAndRemoveBytecodes();
+    void completeJumpsAndEmitReturningNil(Parser& parser, size_t loopBeginIdx, size_t jumpOffsetIdxToSkipLoopBody);
+    void inlineLocals(LexicalScope& scopeToBeInlined);
+    void checkJumpOffset(size_t jumpOffset, uint8_t bytecode);
+    void resetLastBytecodeBuffer();
+
     ClassGenerationContext& holderGenc;
     MethodGenerationContext* const outerGenc;
 
@@ -123,4 +146,10 @@ private:
 
     size_t currentStackDepth;
     size_t maxStackDepth;
+
+    std::array<uint8_t, 4> last4Bytecodes;
+
+    std::vector<BackJump> inlinedLoops;
+
+    bool isCurrentlyInliningABlock;
 };

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -608,11 +608,21 @@ bool Parser::binaryOperand(MethodGenerationContext& mgenc) {
 
 void Parser::keywordMessage(MethodGenerationContext& mgenc, bool super) {
     StdString kw = keyword();
+    int numParts = 1;
 
     formula(mgenc);
     while (sym == Keyword) {
         kw.append(keyword());
+        numParts += 1;
         formula(mgenc);
+    }
+
+    if (!super) {
+        if (numParts == 1 && (
+            (kw == "whileTrue:" && mgenc.InlineWhile(*this, true)) ||
+            (kw == "whileFalse:" && mgenc.InlineWhile(*this, false)))) {
+            return;
+        }
     }
 
     VMSymbol* msg = SymbolFor(kw);

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include "../misc/ParseInteger.h"
+#include "../misc/StringUtil.h"
 #include "../misc/defs.h"
 #include "../vm/Globals.h"
 #include "../vm/Print.h"
@@ -834,15 +835,7 @@ void Parser::blockArguments(MethodGenerationContext& mgenc) {
     } while (sym == Colon);
 }
 
-static bool replace(StdString& str, const char* pattern, StdString& replacement) {
-    size_t pos = str.find(pattern);
-    if (pos == std::string::npos) {
-        return false;
-    }
 
-    str.replace(pos, strlen(pattern), replacement);
-    return true;
-}
 
 __attribute__((noreturn)) void Parser::parseError(const char* msg, Symbol expected) {
     StdString expectedStr(symnames[expected]);
@@ -860,15 +853,15 @@ __attribute__((noreturn)) void Parser::parseError(const char* msg, StdString exp
         foundStr = symnames[sym];
     }
 
-    replace(msgWithMeta, "%(file)s", fname);
+    ReplacePattern(msgWithMeta, "%(file)s", fname);
 
     StdString line = std::to_string(lexer.GetCurrentLineNumber());
-    replace(msgWithMeta, "%(line)d", line);
+    ReplacePattern(msgWithMeta, "%(line)d", line);
 
     StdString column = std::to_string(lexer.GetCurrentColumn());
-    replace(msgWithMeta, "%(column)d", column);
-    replace(msgWithMeta, "%(expected)s", expected);
-    replace(msgWithMeta, "%(found)s", foundStr);
+    ReplacePattern(msgWithMeta, "%(column)d", column);
+    ReplacePattern(msgWithMeta, "%(expected)s", expected);
+    ReplacePattern(msgWithMeta, "%(found)s", foundStr);
 
     ErrorPrint(msgWithMeta);
     GetUniverse()->Quit(ERR_FAIL);

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -28,10 +28,10 @@
 #include <cstdint>
 #include <string>
 
+#include "../interpreter/bytecodes.h" // NOLINT// NOLINT(misc-include-cleaner) it's required to make the types complete
 #include "../compiler/Disassembler.h"
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
-#include "../vm/Globals.h"
 #include "../vm/IsValidObject.h"
 #include "../vm/Universe.h"
 #include "../vmobjects/IntegerBox.h"
@@ -159,7 +159,7 @@ void Interpreter::triggerDoesNotUnderstand(VMSymbol* signature) {
         argumentsArray->SetIndexableField(i, o);
     }
     vm_oop_t arguments[] = {signature, argumentsArray};
-    
+
     GetFrame()->Pop(); // pop the receiver
 
     //check if current frame is big enough for this unplanned Send
@@ -302,13 +302,13 @@ void Interpreter::doSend(long bytecodeIndex) {
     int numOfArgs = Signature::GetNumberOfArguments(signature);
 
     vm_oop_t receiver = GetFrame()->GetStackElement(numOfArgs-1);
-    
+
     assert(IsValidObject(receiver));
     // make sure it is really a class
     assert(dynamic_cast<VMClass*>(CLASS_OF(receiver)) != nullptr);
-    
+
     VMClass* receiverClass = CLASS_OF(receiver);
-    
+
     assert(IsValidObject(receiverClass));
 
 #ifdef LOG_RECEIVER_TYPES
@@ -363,7 +363,7 @@ void Interpreter::doReturnNonLocal() {
         vm_oop_t arguments[] = {block};
 
         popFrame();
-        
+
         // Pop old arguments from stack
         VMMethod* method = GetFrame()->GetMethod();
         long numberOfArgs = method->GetNumberOfArguments();
@@ -413,7 +413,7 @@ void Interpreter::doJump(long bytecodeIndex) {
 
 void Interpreter::WalkGlobals(walk_heap_fn walk) {
     method = load_ptr(static_cast<GCMethod*>(walk(tmp_ptr(method))));
-    
+
     // Get the current frame and mark it.
     // Since marking is done recursively, this automatically
     // marks the whole stack

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -28,8 +28,8 @@
 #include <cstdint>
 #include <string>
 
-#include "../interpreter/bytecodes.h" // NOLINT// NOLINT(misc-include-cleaner) it's required to make the types complete
 #include "../compiler/Disassembler.h"
+#include "../interpreter/bytecodes.h" // NOLINT(misc-include-cleaner) it's required for InterpreterLoop.h
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../vm/IsValidObject.h"

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -388,29 +388,6 @@ void Interpreter::doReturnNonLocal() {
     popFrameAndPushResult(result);
 }
 
-void Interpreter::doJumpIfFalse(long bytecodeIndex) {
-    vm_oop_t value = GetFrame()->Pop();
-    if (value == load_ptr(falseObject))
-        doJump(bytecodeIndex);
-}
-
-void Interpreter::doJumpIfTrue(long bytecodeIndex) {
-    vm_oop_t value = GetFrame()->Pop();
-    if (value == load_ptr(trueObject))
-        doJump(bytecodeIndex);
-}
-
-void Interpreter::doJump(long bytecodeIndex) {
-    long target = 0;
-    target |= method->GetBytecode(bytecodeIndex + 1);
-    target |= method->GetBytecode(bytecodeIndex + 2) << 8;
-    target |= method->GetBytecode(bytecodeIndex + 3) << 16;
-    target |= method->GetBytecode(bytecodeIndex + 4) << 24;
-
-    // do the jump
-    bytecodeIndexGlobal = target;
-}
-
 void Interpreter::WalkGlobals(walk_heap_fn walk) {
     method = load_ptr(static_cast<GCMethod*>(walk(tmp_ptr(method))));
 

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -106,9 +106,6 @@ private:
     void doSuperSend(long bytecodeIndex);
     void doReturnLocal();
     void doReturnNonLocal();
-    void doJumpIfFalse(long bytecodeIndex);
-    void doJumpIfTrue(long bytecodeIndex);
-    void doJump(long bytecodeIndex);
 };
 
 inline VMFrame* Interpreter::GetFrame() const {

--- a/src/interpreter/InterpreterLoop.h
+++ b/src/interpreter/InterpreterLoop.h
@@ -4,7 +4,7 @@ vm_oop_t Start() {
     // initialization
     method = GetMethod();
     currentBytecodes = GetBytecodes();
-    
+
     void* loopTargets[] = {
         &&LABEL_BC_HALT,
         &&LABEL_BC_DUP,
@@ -41,21 +41,33 @@ vm_oop_t Start() {
         &&LABEL_BC_SUPER_SEND,
         &&LABEL_BC_RETURN_LOCAL,
         &&LABEL_BC_RETURN_NON_LOCAL,
+        &&LABEL_BC_JUMP,
+        &&LABEL_BC_JUMP_ON_FALSE_POP,
+        &&LABEL_BC_JUMP_ON_TRUE_POP,
+        &&LABEL_BC_JUMP_ON_FALSE_TOP_NIL,
+        &&LABEL_BC_JUMP_ON_TRUE_TOP_NIL,
+        &&LABEL_BC_JUMP_BACKWARD,
+        &&LABEL_BC_JUMP2,
+        &&LABEL_BC_JUMP2_ON_FALSE_POP,
+        &&LABEL_BC_JUMP2_ON_TRUE_POP,
+        &&LABEL_BC_JUMP2_ON_FALSE_TOP_NIL,
+        &&LABEL_BC_JUMP2_ON_TRUE_TOP_NIL,
+        &&LABEL_BC_JUMP2_BACKWARD
     };
-    
+
     goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]];
-    
+
     //
     // THIS IS THE former interpretation loop
 LABEL_BC_HALT:
     PROLOGUE(1);
     return GetFrame()->GetStackElement(0); // handle the halt bytecode
-    
+
 LABEL_BC_DUP:
     PROLOGUE(1);
     doDup();
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_LOCAL:
     PROLOGUE(3);
     doPushLocal(bytecodeIndexGlobal - 3);
@@ -65,17 +77,17 @@ LABEL_BC_PUSH_LOCAL_0:
     PROLOGUE(1);
     doPushLocalWithIndex(0);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_LOCAL_1:
     PROLOGUE(1);
     doPushLocalWithIndex(1);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_LOCAL_2:
     PROLOGUE(1);
     doPushLocalWithIndex(2);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_ARGUMENT:
     PROLOGUE(3);
     doPushArgument(bytecodeIndexGlobal - 3);
@@ -96,7 +108,7 @@ LABEL_BC_PUSH_ARG_1:
         GetFrame()->Push(argument);
     }
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_ARG_2:
     PROLOGUE(1);
     {
@@ -104,7 +116,7 @@ LABEL_BC_PUSH_ARG_2:
         GetFrame()->Push(argument);
     }
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_FIELD:
     PROLOGUE(2);
     doPushField(bytecodeIndexGlobal - 2);
@@ -119,17 +131,17 @@ LABEL_BC_PUSH_FIELD_1:
     PROLOGUE(1);
     doPushFieldWithIndex(1);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_BLOCK:
     PROLOGUE(2);
     doPushBlock(bytecodeIndexGlobal - 2);
     DISPATCH_GC();
-    
+
 LABEL_BC_PUSH_CONSTANT:
     PROLOGUE(2);
     doPushConstant(bytecodeIndexGlobal - 2);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_CONSTANT_0:
     PROLOGUE(1);
     {
@@ -137,7 +149,7 @@ LABEL_BC_PUSH_CONSTANT_0:
         GetFrame()->Push(constant);
     }
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_CONSTANT_1:
     PROLOGUE(1);
     {
@@ -145,7 +157,7 @@ LABEL_BC_PUSH_CONSTANT_1:
         GetFrame()->Push(constant);
     }
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_CONSTANT_2:
     PROLOGUE(1);
     {
@@ -158,27 +170,27 @@ LABEL_BC_PUSH_0:
     PROLOGUE(1);
     GetFrame()->Push(NEW_INT(0));
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_1:
     PROLOGUE(1);
     GetFrame()->Push(NEW_INT(1));
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_NIL:
     PROLOGUE(1);
     GetFrame()->Push(load_ptr(nilObject));
     DISPATCH_NOGC();
-    
+
 LABEL_BC_PUSH_GLOBAL:
     PROLOGUE(2);
     doPushGlobal(bytecodeIndexGlobal - 2);
     DISPATCH_GC();
-    
+
 LABEL_BC_POP:
     PROLOGUE(1);
     doPop();
     DISPATCH_NOGC();
-    
+
 LABEL_BC_POP_LOCAL:
     PROLOGUE(3);
     doPopLocal(bytecodeIndexGlobal - 3);
@@ -188,22 +200,22 @@ LABEL_BC_POP_LOCAL_0:
     PROLOGUE(1);
     doPopLocalWithIndex(0);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_POP_LOCAL_1:
     PROLOGUE(1);
     doPopLocalWithIndex(1);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_POP_LOCAL_2:
     PROLOGUE(1);
     doPopLocalWithIndex(2);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_POP_ARGUMENT:
     PROLOGUE(3);
     doPopArgument(bytecodeIndexGlobal - 3);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_POP_FIELD:
     PROLOGUE(2);
     doPopField(bytecodeIndexGlobal - 2);
@@ -213,34 +225,174 @@ LABEL_BC_POP_FIELD_0:
     PROLOGUE(1);
     doPopFieldWithIndex(0);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_POP_FIELD_1:
     PROLOGUE(1);
     doPopFieldWithIndex(1);
     DISPATCH_NOGC();
-    
+
 LABEL_BC_SEND:
     PROLOGUE(2);
     doSend(bytecodeIndexGlobal - 2);
     DISPATCH_GC();
-    
+
 LABEL_BC_SUPER_SEND:
     PROLOGUE(2);
     doSuperSend(bytecodeIndexGlobal - 2);
     DISPATCH_GC();
-    
+
 LABEL_BC_RETURN_LOCAL:
     PROLOGUE(1);
     doReturnLocal();
     DISPATCH_NOGC();
-    
+
 LABEL_BC_RETURN_NON_LOCAL:
     PROLOGUE(1);
     doReturnNonLocal();
     DISPATCH_NOGC();
+
+LABEL_BC_JUMP:
+    {
+        uint8_t offset = currentBytecodes[bytecodeIndexGlobal + 1];
+        bytecodeIndexGlobal += offset;
+    }
     DISPATCH_NOGC();
+
+LABEL_BC_JUMP_ON_FALSE_POP:
+    {
+        vm_oop_t val = GetFrame()->Top();
+        if (val == load_ptr(falseObject)) {
+            uint8_t offset = currentBytecodes[bytecodeIndexGlobal + 1];
+            bytecodeIndexGlobal += offset;
+        } else {
+            bytecodeIndexGlobal += 3;
+        }
+        GetFrame()->PopVoid();
+    }
     DISPATCH_NOGC();
+
+LABEL_BC_JUMP_ON_TRUE_POP:
+    {
+        vm_oop_t val = GetFrame()->Top();
+        if (val == load_ptr(trueObject)) {
+            uint8_t offset = currentBytecodes[bytecodeIndexGlobal + 1];
+            bytecodeIndexGlobal += offset;
+        } else {
+            bytecodeIndexGlobal += 3;
+        }
+        GetFrame()->PopVoid();
+    }
     DISPATCH_NOGC();
+
+LABEL_BC_JUMP_ON_FALSE_TOP_NIL:
+    {
+        vm_oop_t val = GetFrame()->Top();
+        if (val == load_ptr(falseObject)) {
+            uint8_t offset = currentBytecodes[bytecodeIndexGlobal + 1];
+            bytecodeIndexGlobal += offset;
+            GetFrame()->SetTop(nilObject);
+        } else {
+            GetFrame()->PopVoid();
+            bytecodeIndexGlobal += 3;
+        }
+    }
+    DISPATCH_NOGC();
+
+LABEL_BC_JUMP_ON_TRUE_TOP_NIL:
+    {
+        vm_oop_t val = GetFrame()->Top();
+        if (val == load_ptr(trueObject)) {
+            uint8_t offset = currentBytecodes[bytecodeIndexGlobal + 1];
+            bytecodeIndexGlobal += offset;
+            GetFrame()->SetTop(nilObject);
+        } else {
+            GetFrame()->PopVoid();
+            bytecodeIndexGlobal += 3;
+        }
+    }
+    DISPATCH_NOGC();
+
+LABEL_BC_JUMP_BACKWARD:
+    {
+        uint8_t offset = currentBytecodes[bytecodeIndexGlobal + 1];
+        bytecodeIndexGlobal -= offset;
+    }
+    DISPATCH_NOGC();
+
+LABEL_BC_JUMP2:
+    {
+        uint16_t offset = ComputeOffset(currentBytecodes[bytecodeIndexGlobal + 1],
+                                        currentBytecodes[bytecodeIndexGlobal + 2]);
+        bytecodeIndexGlobal += offset;
+    }
+    DISPATCH_NOGC();
+
+LABEL_BC_JUMP2_ON_FALSE_POP:
+    {
+        vm_oop_t val = GetFrame()->Top();
+        if (val == load_ptr(falseObject)) {
+            uint16_t offset = ComputeOffset(currentBytecodes[bytecodeIndexGlobal + 1],
+                                            currentBytecodes[bytecodeIndexGlobal + 2]);
+            bytecodeIndexGlobal += offset;
+        } else {
+            bytecodeIndexGlobal += 3;
+        }
+        GetFrame()->PopVoid();
+    }
+    DISPATCH_NOGC();
+
+LABEL_BC_JUMP2_ON_TRUE_POP:
+    {
+        vm_oop_t val = GetFrame()->Top();
+        if (val == load_ptr(trueObject)) {
+            uint16_t offset = ComputeOffset(currentBytecodes[bytecodeIndexGlobal + 1],
+                                            currentBytecodes[bytecodeIndexGlobal + 2]);
+            bytecodeIndexGlobal += offset;
+        } else {
+            bytecodeIndexGlobal += 3;
+        }
+        GetFrame()->PopVoid();
+    }
+    DISPATCH_NOGC();
+
+LABEL_BC_JUMP2_ON_FALSE_TOP_NIL:
+    {
+        vm_oop_t val = GetFrame()->Top();
+        if (val == load_ptr(falseObject)) {
+            uint16_t offset = ComputeOffset(currentBytecodes[bytecodeIndexGlobal + 1],
+                                            currentBytecodes[bytecodeIndexGlobal + 2]);
+            bytecodeIndexGlobal += offset;
+            GetFrame()->SetTop(nilObject);
+        } else {
+            GetFrame()->PopVoid();
+            bytecodeIndexGlobal += 3;
+        }
+    }
+    DISPATCH_NOGC();
+
+LABEL_BC_JUMP2_ON_TRUE_TOP_NIL:
+    {
+        vm_oop_t val = GetFrame()->Top();
+        if (val == load_ptr(trueObject)) {
+            uint16_t offset = ComputeOffset(currentBytecodes[bytecodeIndexGlobal + 1],
+                                            currentBytecodes[bytecodeIndexGlobal + 2]);
+            bytecodeIndexGlobal += offset;
+            GetFrame()->SetTop(nilObject);
+        } else {
+            GetFrame()->PopVoid();
+            bytecodeIndexGlobal += 3;
+        }
+    }
+    DISPATCH_NOGC();
+
+LABEL_BC_JUMP2_BACKWARD:
+    {
+        uint16_t offset = ComputeOffset(currentBytecodes[bytecodeIndexGlobal + 1],
+                                        currentBytecodes[bytecodeIndexGlobal + 2]);
+        bytecodeIndexGlobal -= offset;
+    }
+    DISPATCH_NOGC();
+
 
 #ifndef HACK_INLINE_START
 }

--- a/src/interpreter/InterpreterLoop.h
+++ b/src/interpreter/InterpreterLoop.h
@@ -41,9 +41,6 @@ vm_oop_t Start() {
         &&LABEL_BC_SUPER_SEND,
         &&LABEL_BC_RETURN_LOCAL,
         &&LABEL_BC_RETURN_NON_LOCAL,
-        &&LABEL_BC_JUMP_IF_FALSE,
-        &&LABEL_BC_JUMP_IF_TRUE,
-        &&LABEL_BC_JUMP
     };
     
     goto *loopTargets[currentBytecodes[bytecodeIndexGlobal]];
@@ -241,20 +238,8 @@ LABEL_BC_RETURN_NON_LOCAL:
     PROLOGUE(1);
     doReturnNonLocal();
     DISPATCH_NOGC();
-    
-LABEL_BC_JUMP_IF_FALSE:
-    PROLOGUE(5);
-    doJumpIfFalse(bytecodeIndexGlobal - 5);
     DISPATCH_NOGC();
-    
-LABEL_BC_JUMP_IF_TRUE:
-    PROLOGUE(5);
-    doJumpIfTrue(bytecodeIndexGlobal - 5);
     DISPATCH_NOGC();
-    
-LABEL_BC_JUMP:
-    PROLOGUE(5);
-    doJump(bytecodeIndexGlobal - 5);
     DISPATCH_NOGC();
 
 #ifndef HACK_INLINE_START

--- a/src/interpreter/bytecodes.cpp
+++ b/src/interpreter/bytecodes.cpp
@@ -26,6 +26,7 @@
  THE SOFTWARE.
  */
 
+#include <cassert>
 #include <cstdint>
 
 const uint8_t Bytecode::bytecodeLengths[] = {
@@ -64,9 +65,20 @@ const uint8_t Bytecode::bytecodeLengths[] = {
         2, // BC_SUPER_SEND
         1, // BC_RETURN_LOCAL
         1, // BC_RETURN_NON_LOCAL
-        5, // JUMP_IF_FALSE
-        5, // JUMP_IF_TRUE
-        5  // JUMP
+
+        3, // BC_JUMP
+        3, // BC_JUMP_ON_TRUE_TOP_NIL
+        3, // BC_JUMP_ON_FALSE_TOP_NIL
+        3, // BC_JUMP_ON_TRUE_POP
+        3, // BC_JUMP_ON_FALSE_POP
+        3, // BC_JUMP_BACKWARDS
+
+        3, // BC_JUMP2
+        3, // BC_JUMP2_ON_TRUE_TOP_NIL
+        3, // BC_JUMP2_ON_FALSE_TOP_NIL
+        3, // BC_JUMP2_ON_TRUE_POP
+        3, // BC_JUMP2_ON_FALSE_POP
+        3, // BC_JUMP2_BACKWARDS
         };
 
 const char* Bytecode::bytecodeNames[] = {
@@ -78,8 +90,8 @@ const char* Bytecode::bytecodeNames[] = {
     "PUSH_LOCAL_2    ",
     "PUSH_ARGUMENT   ",
     "PUSH_SELF       ",
-    "PUSH_ARG_0      ",
     "PUSH_ARG_1      ",
+    "PUSH_ARG_2      ",
     "PUSH_FIELD      ",
     "PUSH_FIELD_0    ",
     "PUSH_FIELD_1    ",
@@ -105,7 +117,31 @@ const char* Bytecode::bytecodeNames[] = {
     "SUPER_SEND      ",
     "RETURN_LOCAL    ",
     "RETURN_NON_LOCAL",
-    "JUMP_IF_FALSE   ",
-    "JUMP_IF_TRUE    ",
-    "JUMP            "
+    "BC_JUMP         ",
+    "BC_JUMP_ON_TRUE_TOP_NIL",
+    "BC_JUMP_ON_FALSE_TOP_NIL",
+    "BC_JUMP_ON_TRUE_POP",
+    "BC_JUMP_ON_FALSE_POP",
+    "BC_JUMP_BACKWARDS",
+
+    "BC_JUMP2         ",
+    "BC_JUMP2_ON_TRUE_TOP_NIL",
+    "BC_JUMP2_ON_FALSE_TOP_NIL",
+    "BC_JUMP2_ON_TRUE_POP",
+    "BC_JUMP2_ON_FALSE_POP",
+    "BC_JUMP2_BACKWARDS",
 };
+
+bool IsJumpBytecode(uint8_t bc) {
+    assert(BC_JUMP < BC_JUMP2_BACKWARD);
+    assert((BC_JUMP2_BACKWARD - BC_JUMP) == 11);
+
+    return BC_JUMP <= bc && bc <= BC_JUMP2_BACKWARD;
+}
+
+bool Bytecode::BytecodeDefinitionsAreConsistent() {
+    bool namesAndLengthMatch = (sizeof(Bytecode::bytecodeNames) / sizeof(char*))  == (sizeof(Bytecode::bytecodeLengths) / sizeof(uint8_t));
+    bool lastBytecodeLinesUp = _LAST_BYTECODE == (sizeof(Bytecode::bytecodeLengths) - 1); // -1 because null terminated
+
+    return namesAndLengthMatch && lastBytecodeLinesUp;
+}

--- a/src/interpreter/bytecodes.h
+++ b/src/interpreter/bytecodes.h
@@ -26,6 +26,8 @@
  THE SOFTWARE.
  */
 
+#include <cassert>
+
 #include "../misc/defs.h"
 
 // bytecode constants used by SOM++
@@ -65,11 +67,43 @@
 #define BC_SUPER_SEND        32
 #define BC_RETURN_LOCAL      33
 #define BC_RETURN_NON_LOCAL  34
-#define BC_JUMP_IF_FALSE     35
-#define BC_JUMP_IF_TRUE      36
-#define BC_JUMP              37
+#define BC_JUMP                   35
+#define BC_JUMP_ON_FALSE_POP      36
+#define BC_JUMP_ON_TRUE_POP       37
+#define BC_JUMP_ON_FALSE_TOP_NIL  38
+#define BC_JUMP_ON_TRUE_TOP_NIL   39
+#define BC_JUMP_BACKWARD          40
+#define BC_JUMP2                  41
+#define BC_JUMP2_ON_FALSE_POP     42
+#define BC_JUMP2_ON_TRUE_POP      43
+#define BC_JUMP2_ON_FALSE_TOP_NIL 44
+#define BC_JUMP2_ON_TRUE_TOP_NIL  45
+#define BC_JUMP2_BACKWARD         46
 
-// bytecode lengths
+#define _LAST_BYTECODE BC_JUMP2_BACKWARD
+
+#define BC_INVALID           255
+
+// TODO: port support for these bytecodes
+//       they were already named in ported code, and it seemed nicer to just already include that code
+#define BC_INC_FIELD         254
+#define BC_INC_FIELD_PUSH    253
+#define BC_INC               252
+#define BC_DEC               251
+#define BC_SEND_N            250
+#define BC_SEND_3            249
+#define BC_SEND_2            248
+#define BC_SEND_1            247
+#define BC_RETURN_FIELD_0    246
+#define BC_RETURN_FIELD_1    245
+#define BC_RETURN_FIELD_2    244
+#define BC_RETURN_SELF       243
+
+
+// properties of the bytecodes
+
+#define FIRST_DOUBLE_BYTE_JUMP_BYTECODE         BC_JUMP2
+#define NUM_SINGLE_BYTE_JUMP_BYTECODES          ((BC_JUMP_BACKWARD - BC_JUMP) + 1)
 
 class Bytecode {
 
@@ -82,9 +116,18 @@ public:
         return bytecodeLengths[bc]; // Return the length of the given bytecode
     }
 
+    static bool BytecodeDefinitionsAreConsistent();
+
 private:
 
     static const uint8_t bytecodeLengths[];
 
     static const char* bytecodeNames[];
 };
+
+inline uint16_t ComputeOffset(uint8_t byte1, uint8_t byte2) {
+    return ((uint16_t) byte1) | (((uint16_t) byte2) << 8);
+}
+
+bool IsJumpBytecode(uint8_t bc);
+

--- a/src/misc/StringUtil.h
+++ b/src/misc/StringUtil.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+inline bool ReplacePattern(std::string& str, const char* pattern, const char* replacement) {
+    size_t pos = str.find(pattern);
+    if (pos == std::string::npos) {
+        return false;
+    }
+
+    str.replace(pos, strlen(pattern), replacement);
+    return true;
+}
+
+inline bool ReplacePattern(std::string& str, const char* pattern, StdString& replacement) {
+    size_t pos = str.find(pattern);
+    if (pos == std::string::npos) {
+        return false;
+    }
+
+    str.replace(pos, strlen(pattern), replacement);
+    return true;
+}

--- a/src/unitTests/BytecodeGenerationTest.cpp
+++ b/src/unitTests/BytecodeGenerationTest.cpp
@@ -11,6 +11,8 @@
 #include "../compiler/Disassembler.h"
 #include "../compiler/MethodGenerationContext.h"
 #include "../compiler/Parser.h"
+#include "../misc/StringUtil.h"
+#include "../misc/debug.h"
 #include "../interpreter/bytecodes.h"
 #include "../vm/Symbols.h"
 #include "BytecodeGenerationTest.h"
@@ -504,6 +506,129 @@ void BytecodeGenerationTest::check(std::vector<uint8_t> actual, std::vector<uint
                                  expected.size(), actual.size());
 }
 
+
+
+void BytecodeGenerationTest::testWhileInlining(const char* selector, uint8_t jumpBytecode) {
+    std::string source = R"""(   test: arg = (
+                                      #start.
+                                      [ true ] SELECTOR [ arg ].
+                                      #end
+                                  ) )""";
+    bool wasReplaced = ReplacePattern(source, "SELECTOR", selector);
+    assert(wasReplaced);
+
+    auto bytecodes = methodToBytecode(source.data());
+    check(bytecodes, {
+        BC_PUSH_CONSTANT_0, BC_POP,
+        BC_PUSH_CONSTANT_1,
+        jumpBytecode, 8, 0,
+        BC_PUSH_ARG_1,
+        BC_POP,
+        BC_JUMP_BACKWARD, 6, 0,
+        BC_PUSH_NIL,
+        BC_POP,
+        BC_PUSH_CONSTANT_2,
+        BC_POP,
+        BC_PUSH_SELF,
+        BC_RETURN_LOCAL
+    });
+}
+
+/** This test checks whether the jumps in the while loop are correct after it got inlined. */
+void BytecodeGenerationTest::testInliningWhileLoopsWithExpandingBranches() {
+    DebugPrint("\nTODO: testInliningWhileLoopsWithExpandingBranches is currently ignored, because we do not yet support inlining if #ifTrue:\n");
+    return;
+
+    auto bytecodes = methodToBytecode(R"""(
+        test = (
+          #const0. #const1. #const2.
+          0 ifTrue: [
+            [ #const3. #const4. #const5 ]
+               whileTrue: [
+                 #const6. #const7. #const8 ]
+          ].
+          ^ #end
+        )  )""");
+
+    check(bytecodes, {
+        BC_PUSH_CONSTANT_0, BC_POP,
+        BC_PUSH_CONSTANT_1, BC_POP,
+        BC_PUSH_CONSTANT_2, BC_POP,
+        BC_PUSH_0,
+
+        // jump offset, to jump to the pop BC after the if/right before the push #end
+        BC_JUMP_ON_FALSE_TOP_NIL, 27, 0,
+        BC_PUSH_CONSTANT, 3, BC_POP,
+        BC_PUSH_CONSTANT, 4, BC_POP,
+        BC_PUSH_CONSTANT, 5, BC_POP,
+
+        // jump offset, jump to push_nil as result of whileTrue
+        BC_JUMP_ON_FALSE_POP, 15,
+        BC_PUSH_CONSTANT, 6, BC_POP,
+        BC_PUSH_CONSTANT, 7, BC_POP,
+        BC_PUSH_CONSTANT, 8, BC_POP,
+
+        // jump offset, jump back to the first PUSH_CONST inside if body, pushing #const3
+        BC_PUSH_NIL,
+        BC_POP,
+
+        BC_PUSH_CONSTANT, 9,
+        BC_RETURN_LOCAL
+    });
+}
+
+void BytecodeGenerationTest::testInliningWhileLoopsWithContractingBranches() {
+    DebugPrint("\nTODO: testInliningWhileLoopsWithContractingBranches is currently ignored, because we do not yet support inlining if #ifTrue:\n");
+
+    //def test_inlining_while_loop_with_contracting_branches(mgenc):
+    //    """
+    //    This test checks whether the jumps in the while loop are correct after it got inlined.
+    //    The challenge here is
+    //    """
+    //    bytecodes = method_to_bytecodes(
+    //        mgenc,
+    //        """
+    //        test = (
+    //          0 ifTrue: [
+    //            [ ^ 1 ]
+    //               whileTrue: [
+    //                 ^ 0 ]
+    //          ].
+    //          ^ #end
+    //        )
+    //        """,
+    //    )
+    //
+    //    assert len(bytecodes) == 19
+    //    check(
+    //        bytecodes,
+    //        [
+    //            Bytecodes.push_0,
+    //            BC(
+    //                Bytecodes.jump_on_false_top_nil,
+    //                15,
+    //                note="jump offset to jump to the pop after the if, before pushing #end",
+    //            ),
+    //            Bytecodes.push_1,
+    //            Bytecodes.return_local,
+    //            BC(
+    //                Bytecodes.jump_on_false_pop,
+    //                9,
+    //                note="jump offset, jump to push_nil as result of whileTrue",
+    //            ),
+    //            Bytecodes.push_0,
+    //            Bytecodes.return_local,
+    //            Bytecodes.pop,
+    //            BC(
+    //                Bytecodes.jump_backward,
+    //                8,
+    //                note="jump offset, to the push_1 of the condition",
+    //            ),
+    //            Bytecodes.push_nil,
+    //            Bytecodes.pop,
+    //        ],
+    //    )
+};
 
 
 /*
@@ -1144,153 +1269,6 @@ void BytecodeGenerationTest::check(std::vector<uint8_t> actual, std::vector<uint
      )
 
 
- @pytest.mark.parametrize(
-     "selector,jump_bytecode",
-     [
-         ("whileTrue:", Bytecodes.jump_on_false_pop),
-         ("whileFalse:", Bytecodes.jump_on_true_pop),
-     ],
- )
- def test_while_inlining(mgenc, selector, jump_bytecode):
-     bytecodes = method_to_bytecodes(
-         mgenc,
-         """
-         test: arg = (
-             #start.
-             [ true ] SELECTOR [ arg ].
-             #end
-         )""".replace(
-             "SELECTOR", selector
-         ),
-     )
-
-     assert len(bytecodes) == 19
-     check(
-         bytecodes,
-         [
-             (2, Bytecodes.push_constant),
-             jump_bytecode,
-             Bytecodes.push_argument,
-             Bytecodes.pop,
-             BC(Bytecodes.jump_backward, 9),
-             Bytecodes.push_nil,
-             Bytecodes.pop,
-         ],
-     )
-
-
- def test_inlining_while_loop_with_expanding_branches(mgenc):
-     """
-     This test checks whether the jumps in the while loop are correct after it got inlined.
-     The challenge here is
-     """
-     bytecodes = method_to_bytecodes(
-         mgenc,
-         """
-         test = (
-           #const0. #const1. #const2.
-           0 ifTrue: [
-             [ #const3. #const4. #const5 ]
-                whileTrue: [
-                  #const6. #const7. #const8 ]
-           ].
-           ^ #end
-         )
-         """,
-     )
-
-     assert len(bytecodes) == 38
-     check(
-         bytecodes,
-         [
-             Bytecodes.push_constant_0,
-             Bytecodes.pop,
-             Bytecodes.push_constant_1,
-             Bytecodes.pop,
-             Bytecodes.push_constant_2,
-             Bytecodes.pop,
-             Bytecodes.push_0,
-             BC(
-                 Bytecodes.jump_on_false_top_nil,
-                 27,
-                 note="jump offset, to jump to the pop BC after the if/right before the push #end",
-             ),
-             Bytecodes.push_constant,
-             Bytecodes.pop,
-             Bytecodes.push_constant,
-             Bytecodes.pop,
-             Bytecodes.push_constant,
-             BC(
-                 Bytecodes.jump_on_false_pop,
-                 15,
-                 note="jump offset, jump to push_nil as result of whileTrue",
-             ),
-             Bytecodes.push_constant,
-             Bytecodes.pop,
-             Bytecodes.push_constant,
-             Bytecodes.pop,
-             Bytecodes.push_constant,
-             Bytecodes.pop,
-             BC(
-                 Bytecodes.jump_backward,
-                 20,
-                 note="jump offset, jump back to the first push constant "
-                 + "in the condition, pushing const3",
-             ),
-             Bytecodes.push_nil,
-             Bytecodes.pop,
-         ],
-     )
-
-
- def test_inlining_while_loop_with_contracting_branches(mgenc):
-     """
-     This test checks whether the jumps in the while loop are correct after it got inlined.
-     The challenge here is
-     """
-     bytecodes = method_to_bytecodes(
-         mgenc,
-         """
-         test = (
-           0 ifTrue: [
-             [ ^ 1 ]
-                whileTrue: [
-                  ^ 0 ]
-           ].
-           ^ #end
-         )
-         """,
-     )
-
-     assert len(bytecodes) == 19
-     check(
-         bytecodes,
-         [
-             Bytecodes.push_0,
-             BC(
-                 Bytecodes.jump_on_false_top_nil,
-                 15,
-                 note="jump offset to jump to the pop after the if, before pushing #end",
-             ),
-             Bytecodes.push_1,
-             Bytecodes.return_local,
-             BC(
-                 Bytecodes.jump_on_false_pop,
-                 9,
-                 note="jump offset, jump to push_nil as result of whileTrue",
-             ),
-             Bytecodes.push_0,
-             Bytecodes.return_local,
-             Bytecodes.pop,
-             BC(
-                 Bytecodes.jump_backward,
-                 8,
-                 note="jump offset, to the push_1 of the condition",
-             ),
-             Bytecodes.push_nil,
-             Bytecodes.pop,
-         ],
-     )
 
 
  @pytest.mark.parametrize(

--- a/src/unitTests/BytecodeGenerationTest.h
+++ b/src/unitTests/BytecodeGenerationTest.h
@@ -42,6 +42,8 @@ class BytecodeGenerationTest: public CPPUNIT_NS::TestCase {
     CPPUNIT_TEST(testInliningWhileLoopsWithExpandingBranches);
     CPPUNIT_TEST(testInliningWhileLoopsWithContractingBranches);
 
+    CPPUNIT_TEST(testJumpQueuesOrdering);
+
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -115,6 +117,8 @@ private:
 
     void testInliningWhileLoopsWithExpandingBranches();
     void testInliningWhileLoopsWithContractingBranches();
+
+    void testJumpQueuesOrdering();
 
     void dump(MethodGenerationContext* mgenc);
     

--- a/src/unitTests/BytecodeGenerationTest.h
+++ b/src/unitTests/BytecodeGenerationTest.h
@@ -4,6 +4,7 @@
 
 #include "../compiler/ClassGenerationContext.h"
 #include "../compiler/MethodGenerationContext.h"
+#include "../interpreter/bytecodes.h"
 
 class BytecodeGenerationTest: public CPPUNIT_NS::TestCase {
 
@@ -35,7 +36,12 @@ class BytecodeGenerationTest: public CPPUNIT_NS::TestCase {
     CPPUNIT_TEST(testBlockPushFieldOpt);
     CPPUNIT_TEST(testPopLocalOpt);
     CPPUNIT_TEST(testPopFieldOpt);
-    
+
+    CPPUNIT_TEST(testWhileInliningWhileTrue);
+    CPPUNIT_TEST(testWhileInliningWhileFalse);
+    CPPUNIT_TEST(testInliningWhileLoopsWithExpandingBranches);
+    CPPUNIT_TEST(testInliningWhileLoopsWithContractingBranches);
+
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -96,7 +102,20 @@ private:
     void testBlockPushFieldOpt();
     void testPopLocalOpt();
     void testPopFieldOpt();
-    
+
+    void testWhileInliningWhileTrue() {
+        testWhileInlining("whileTrue:", BC_JUMP_ON_FALSE_POP);
+    }
+
+    void testWhileInliningWhileFalse() {
+        testWhileInlining("whileFalse:", BC_JUMP_ON_TRUE_POP);
+    }
+
+    void testWhileInlining(const char* selector, uint8_t jumpBytecode);
+
+    void testInliningWhileLoopsWithExpandingBranches();
+    void testInliningWhileLoopsWithContractingBranches();
+
     void dump(MethodGenerationContext* mgenc);
     
     void check(std::vector<uint8_t> actual, std::vector<uint8_t> expected);

--- a/src/unitTests/CloneObjectsTest.cpp
+++ b/src/unitTests/CloneObjectsTest.cpp
@@ -7,6 +7,7 @@
 
 #include <cppunit/TestAssert.h>
 #include <cstdint>
+#include <vector>
 
 #include "../compiler/LexicalScope.h"
 #include "../memory/Heap.h"
@@ -128,7 +129,9 @@ void CloneObjectsTest::testCloneArray() {
 
 void CloneObjectsTest::testCloneBlock() {
     VMSymbol* methodSymbol = NewSymbol("someMethod");
-    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}));
+
+    vector<BackJump> inlinedLoops;
+    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}),  inlinedLoops);
     VMBlock* orig = GetUniverse()->NewBlock(method,
             GetUniverse()->GetInterpreter()->GetFrame(),
             method->GetNumberOfArguments());
@@ -167,7 +170,10 @@ void CloneObjectsTest::testCloneEvaluationPrimitive() {
 
 void CloneObjectsTest::testCloneFrame() {
     VMSymbol* methodSymbol = NewSymbol("frameMethod");
-    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}));
+
+    vector<BackJump> inlinedLoops;
+    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}), inlinedLoops);
+
     VMFrame* orig = GetUniverse()->NewFrame(nullptr, method);
     VMFrame* context = orig->CloneForMovingGC();
     orig->SetContext(context);
@@ -188,7 +194,9 @@ void CloneObjectsTest::testCloneFrame() {
 
 void CloneObjectsTest::testCloneMethod() {
     VMSymbol* methodSymbol = NewSymbol("myMethod");
-    VMMethod* orig = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}));
+
+    vector<BackJump> inlinedLoops;
+    VMMethod* orig = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}), inlinedLoops);
     VMMethod* clone = orig->CloneForMovingGC();
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);

--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -147,7 +147,10 @@ void WalkObjectsTest::testWalkPrimitive() {
 void WalkObjectsTest::testWalkFrame() {
     walkedObjects.clear();
     VMSymbol* methodSymbol = NewSymbol("frameMethod");
-    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}));
+
+    vector<BackJump> inlinedLoops;
+    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}), inlinedLoops);
+
     VMFrame* frame = GetUniverse()->NewFrame(nullptr, method);
     frame->SetPreviousFrame(frame->CloneForMovingGC());
     frame->SetContext(frame->CloneForMovingGC());
@@ -195,7 +198,10 @@ void WalkObjectsTest::testWalkMethod() {
 
 
     VMSymbol* methodSymbol = NewSymbol("myMethod");
-    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, scope);
+
+    vector<BackJump> inlinedLoops;
+    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, scope, inlinedLoops);
+
     method->SetHolder(load_ptr(symbolClass));
     method->WalkObjects(collectMembers);
 
@@ -210,7 +216,10 @@ void WalkObjectsTest::testWalkMethod() {
 void WalkObjectsTest::testWalkBlock() {
     walkedObjects.clear();
     VMSymbol* methodSymbol = NewSymbol("someMethod");
-    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}));
+
+    vector<BackJump> inlinedLoops;
+    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}), inlinedLoops);
+
     VMBlock* block = GetUniverse()->NewBlock(method,
             GetUniverse()->GetInterpreter()->GetFrame(),
             method->GetNumberOfArguments());

--- a/src/unitTests/WriteBarrierTest.cpp
+++ b/src/unitTests/WriteBarrierTest.cpp
@@ -67,7 +67,10 @@ void WriteBarrierTest::testWriteBlock() {
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
 
     VMSymbol* methodSymbol = NewSymbol("someMethod");
-    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}));
+
+    vector<BackJump> inlinedLoops;
+    VMMethod* method = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}), inlinedLoops);
+
     VMBlock* block = GetUniverse()->NewBlock(method,
             GetUniverse()->GetInterpreter()->GetFrame(),
             method->GetNumberOfArguments());

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -137,7 +137,7 @@ void obtain_vtables_of_known_classes(VMSymbol* className) {
     VMInteger* i  = new (GetHeap<HEAP_CLS>(), 0) VMInteger(0);
     vt_integer    = get_vtable(i);
 
-    VMMethod* mth = new (GetHeap<HEAP_CLS>(), 0) VMMethod(nullptr, 0, 0, 0, 0, nullptr);
+    VMMethod* mth = new (GetHeap<HEAP_CLS>(), 0) VMMethod(nullptr, 0, 0, 0, 0, nullptr, nullptr);
     vt_method     = get_vtable(mth);
     vt_object     = get_vtable(load_ptr(nilObject));
 

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -76,7 +76,7 @@ public:
     VMBlock* NewBlock(VMMethod*, VMFrame*, long);
     VMClass* NewClass(VMClass*) const;
     VMFrame* NewFrame(VMFrame*, VMMethod*) const;
-    VMMethod* NewMethod(VMSymbol*, size_t numberOfBytecodes, size_t numberOfConstants, size_t numLocals, size_t maxStackDepth, LexicalScope*) const;
+    VMMethod* NewMethod(VMSymbol*, size_t numberOfBytecodes, size_t numberOfConstants, size_t numLocals, size_t maxStackDepth, LexicalScope*, vector<BackJump>& inlinedLoops) const;
     VMObject* NewInstance(VMClass*) const;
     VMObject* NewInstanceWithoutFields() const;
     VMInteger* NewInteger(int64_t) const;

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -59,6 +59,19 @@ public:
         return result;
     }
 
+    inline void PopVoid() {
+        stack_ptr--;
+    }
+
+    inline vm_oop_t Top() {
+        vm_oop_t result = load_ptr(*stack_ptr);
+        return result;
+    }
+
+    inline void SetTop(gc_oop_t val) {
+        *stack_ptr = val;
+    }
+
     inline void Push(vm_oop_t obj) {
         assert(RemainingStackSize() > 0);
         ++stack_ptr;

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -547,13 +547,13 @@ void VMMethod::AdaptAfterOuterInlined(uint8_t removedCtxLevel, MethodGenerationC
 }
 
 bool operator<(const Jump& a, const Jump& b) {
-  return a.originalJumpTargetIdx < b.originalJumpTargetIdx;
+  return a.originalJumpTargetIdx > b.originalJumpTargetIdx;
 }
 
 bool operator<(const BackJump& a, const BackJump& b) {
-  return a.loopBeginIdx < b.loopBeginIdx;
+  return a.loopBeginIdx > b.loopBeginIdx;
 }
 
 bool operator<(const BackJumpPatch& a, const BackJumpPatch& b) {
-  return a.backwardsJumpIdx < b.backwardsJumpIdx;
+  return a.backwardsJumpIdx > b.backwardsJumpIdx;
 }

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -24,12 +24,19 @@
  THE SOFTWARE.
  */
 
+#include <cassert>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
+#include <queue>
 #include <string>
 
+#include "../compiler/BytecodeGenerator.h"
 #include "../compiler/LexicalScope.h"
+#include "../compiler/MethodGenerationContext.h"
+#include "../compiler/Variable.h"
 #include "../interpreter/Interpreter.h"
+#include "../interpreter/bytecodes.h"
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../vm/Globals.h"
@@ -42,8 +49,8 @@
 #include "VMObject.h"
 #include "VMSymbol.h"
 
-VMMethod::VMMethod(VMSymbol* signature, size_t bcCount, size_t numberOfConstants, size_t numLocals, size_t maxStackDepth, LexicalScope* lexicalScope) :
-        VMInvokable(signature), numberOfLocals(numLocals), maximumNumberOfStackElements(maxStackDepth), bcLength(bcCount), numberOfArguments(signature == nullptr ? 0 : Signature::GetNumberOfArguments(signature)), numberOfConstants(numberOfConstants), lexicalScope(lexicalScope) {
+VMMethod::VMMethod(VMSymbol* signature, size_t bcCount, size_t numberOfConstants, size_t numLocals, size_t maxStackDepth, LexicalScope* lexicalScope, BackJump* inlinedLoops) :
+        VMInvokable(signature), numberOfLocals(numLocals), maximumNumberOfStackElements(maxStackDepth), bcLength(bcCount), numberOfArguments(signature == nullptr ? 0 : Signature::GetNumberOfArguments(signature)), numberOfConstants(numberOfConstants), lexicalScope(lexicalScope), inlinedLoops(inlinedLoops) {
 #ifdef UNSAFE_FRAME_OPTIMIZATION
     cachedFrame = nullptr;
 #endif
@@ -136,4 +143,417 @@ std::string VMMethod::AsDebugString() const {
         holder_str = holder->GetName()->GetStdString();
     }
     return "Method(" + holder_str + ">>#" + GetSignature()->GetStdString() + ")";
+}
+
+void VMMethod::InlineInto(MethodGenerationContext& mgenc) {
+    mgenc.MergeIntoScope(*lexicalScope);
+    inlineInto(mgenc);
+}
+
+std::priority_queue<BackJump> VMMethod::createBackJumpHeap() {
+    std::priority_queue<BackJump> loops;
+    if (inlinedLoops != nullptr) {
+        size_t i = 0;
+        while (inlinedLoops[i].IsValid()) {
+            loops.emplace(inlinedLoops[i]);
+            i += 1;
+        }
+    }
+    return loops;
+}
+
+void VMMethod::inlineInto(MethodGenerationContext& mgenc) {
+    std::priority_queue<Jump> jumps; // priority queue sorted by originalJumpTargetIdx
+    std::priority_queue<BackJump> backJumps = createBackJumpHeap();
+    std::priority_queue<BackJumpPatch> backJumpsToPatch;
+
+    size_t i = 0;
+    const size_t numBytecodes = GetNumberOfBytecodes();
+    while (i < numBytecodes) {
+        prepareBackJumpToCurrentAddress(backJumps, backJumpsToPatch, i, mgenc);
+        patchJumpToCurrentAddress(i, jumps, mgenc);
+
+        const uint8_t bytecode = bytecodes[i];
+        const uint8_t bcLength = Bytecode::GetBytecodeLength(bytecode);
+
+        switch (bytecode) {
+            case BC_DUP:
+                Emit1(mgenc, bytecode, 1);
+                break;
+            case BC_PUSH_FIELD:
+            case BC_PUSH_FIELD_0:
+            case BC_PUSH_FIELD_1:
+            case BC_POP_FIELD:
+            case BC_POP_FIELD_0:
+            case BC_POP_FIELD_1: {
+                uint8_t idx = 0;
+                if (bytecode == BC_PUSH_FIELD || bytecode == BC_POP_FIELD) {
+                    idx = bytecodes[i + 1];
+                } else {
+                    switch (bytecode) {
+                        case BC_PUSH_FIELD_0: { idx = 0; break; }
+                        case BC_PUSH_FIELD_1: { idx = 1; break; }
+                        case BC_POP_FIELD_0:  { idx = 0; break; }
+                        case BC_POP_FIELD_1:  { idx = 1; break; }
+                    }
+                }
+
+                if (bytecode == BC_PUSH_FIELD || bytecode == BC_PUSH_FIELD_0 || bytecode == BC_PUSH_FIELD_1) {
+                    EmitPushFieldWithIndex(mgenc, idx, 0 /* dummy, self is looked up dynamically at the moment. */);
+                } else {
+                    EmitPopFieldWithIndex(mgenc, idx, 0 /* dummy, self is looked up dynamically at the moment. */);
+                }
+                break;
+            }
+
+            case BC_POP_ARGUMENT: {
+                const uint8_t idx = bytecodes[i + 1];
+                const uint8_t ctxLevel = bytecodes[i + 2];
+                assert(ctxLevel > 0);
+
+                assert(bytecode == BC_POP_ARGUMENT);
+                EmitPOPARGUMENT(mgenc, idx, ctxLevel - 1);
+                break;
+            }
+            case BC_PUSH_ARGUMENT: {
+                const uint8_t idx = bytecodes[i + 1];
+                const uint8_t ctxLevel = bytecodes[i + 2];
+                assert(ctxLevel > 0);
+
+                EmitPUSHARGUMENT(mgenc, idx, ctxLevel - 1);
+                break;
+            }
+            case BC_INC_FIELD:
+            case BC_INC_FIELD_PUSH: {
+                const uint8_t idx = bytecodes[i + 1];
+                const uint8_t ctxLevel = bytecodes[i + 2];
+                assert(ctxLevel > 0);
+                Emit3(mgenc, bytecode, idx, ctxLevel - 1, 1);
+                break;
+            }
+            case BC_PUSH_LOCAL:
+            case BC_POP_LOCAL: {
+                uint8_t idx = bytecodes[i + 1];
+                uint8_t ctxLevel = bytecodes[i + 2];
+
+                if (ctxLevel == 0) {
+                    // these have been inlined into the outer context already
+                    // so, we need to look up the right one
+                    const Variable* const var = lexicalScope->GetLocal(idx, 0);
+                    idx = mgenc.GetInlinedLocalIdx(var);
+                } else {
+                    ctxLevel -= 1;
+                }
+
+                if (bytecode == BC_PUSH_LOCAL) {
+                    Emit3(mgenc, bytecode, idx, ctxLevel, 1);
+                } else {
+                    Emit3(mgenc, bytecode, idx, ctxLevel, -1);
+                }
+                break;
+            }
+
+            case BC_PUSH_LOCAL_0:
+            case BC_PUSH_LOCAL_1:
+            case BC_PUSH_LOCAL_2: {
+                uint8_t idx = bytecode - BC_PUSH_LOCAL_0;
+                auto* oldVar = lexicalScope->GetLocal(idx, 0);
+                uint8_t newIdx = mgenc.GetInlinedLocalIdx(oldVar);
+                EmitPUSHLOCAL(mgenc, newIdx, 0);
+                break;
+            }
+
+            case BC_POP_LOCAL_0:
+            case BC_POP_LOCAL_1:
+            case BC_POP_LOCAL_2: {
+                uint8_t idx = bytecode - BC_POP_LOCAL_0;
+                auto* oldVar = lexicalScope->GetLocal(idx, 0);
+                uint8_t newIdx = mgenc.GetInlinedLocalIdx(oldVar);
+                EmitPOPLOCAL(mgenc, newIdx, 0);
+                break;
+            }
+
+            case BC_PUSH_BLOCK: {
+                VMMethod* blockMethod = (VMMethod*) GetConstant(i);
+                blockMethod->AdaptAfterOuterInlined(1, mgenc);
+                EmitPUSHBLOCK(mgenc, blockMethod);
+                break;
+            }
+            case BC_PUSH_CONSTANT: {
+                vm_oop_t literal = GetConstant(i);
+                EmitPUSHCONSTANT(mgenc, literal);
+                break;
+            }
+            case BC_PUSH_CONSTANT_0:
+            case BC_PUSH_CONSTANT_1:
+            case BC_PUSH_CONSTANT_2: {
+                const uint8_t literalIdx = bytecode - BC_PUSH_CONSTANT_0;
+                vm_oop_t literal = GetIndexableField(literalIdx);
+                EmitPUSHCONSTANT(mgenc, literal);
+                break;
+            }
+            case BC_PUSH_0:
+            case BC_PUSH_1:
+            case BC_PUSH_NIL: {
+                Emit1(mgenc, bytecode, 1);
+                break;
+            }
+            case BC_POP: {
+                // TODO: PySOM simply does Emit1
+                //   not sure whether EmitPOP might cause issues if we try to do optimizations here again
+                EmitPOP(mgenc);
+                break;
+            }
+            case BC_INC:
+            case BC_DEC: {
+                Emit1(mgenc, bytecode, 0);
+                break;
+            }
+            case BC_PUSH_GLOBAL: {
+                VMSymbol* const sym = (VMSymbol*) GetConstant(i);
+                EmitPUSHGLOBAL(mgenc, sym);
+                break;
+            }
+            case BC_SEND:
+            case BC_SEND_1:
+            case BC_SEND_2:
+            case BC_SEND_3:
+            case BC_SEND_N: {
+                VMSymbol* const sym = (VMSymbol*) GetConstant(i);
+                EmitSEND(mgenc, sym);
+                break;
+            }
+            case BC_SUPER_SEND: {
+                VMSymbol* const sym = (VMSymbol*) GetConstant(i);
+                EmitSUPERSEND(mgenc, sym);
+                break;
+            }
+            case BC_RETURN_LOCAL: {
+                // NO OP, doesn't need to be translated
+                break;
+            }
+            case BC_RETURN_NON_LOCAL: {
+                const uint8_t newCtxLevel = bytecodes[i + 1] - 1;
+                if (newCtxLevel == 0) {
+                    EmitRETURNLOCAL(mgenc);
+                } else {
+                    assert(newCtxLevel == mgenc.GetMaxContextLevel());
+                    EmitRETURNNONLOCAL(mgenc);
+                }
+                break;
+            }
+            case BC_JUMP:
+            case BC_JUMP_ON_TRUE_TOP_NIL:
+            case BC_JUMP_ON_FALSE_TOP_NIL:
+            case BC_JUMP2:
+            case BC_JUMP2_ON_TRUE_TOP_NIL:
+            case BC_JUMP2_ON_FALSE_TOP_NIL: {
+                // emit the jump, but instead of the offset, emit a dummy
+                const size_t idx = Emit3WithDummy(mgenc, bytecode, 0);
+                const size_t offset = ComputeOffset(bytecodes[i + 1], bytecodes[i + 2]);
+
+                jumps.emplace(Jump(i + offset, bytecode, idx));
+                break;
+            }
+            case BC_JUMP_ON_TRUE_POP:
+            case BC_JUMP_ON_FALSE_POP:
+            case BC_JUMP2_ON_TRUE_POP:
+            case BC_JUMP2_ON_FALSE_POP: {
+                // emit the jump, but instead of the offset, emit a dummy
+                const size_t idx = Emit3WithDummy(mgenc, bytecode, -1);
+                const size_t offset = ComputeOffset(bytecodes[i + 1], bytecodes[i + 2]);
+                jumps.emplace(Jump(i + offset, bytecode, idx));
+                break;
+            }
+            case BC_JUMP_BACKWARD:
+            case BC_JUMP2_BACKWARD: {
+                const size_t loopBeginIdx = backJumpsToPatch.top().loopBeginIdx;
+                assert(backJumpsToPatch.top().backwardsJumpIdx == i
+                       && "the jump should match with the jump instructions");
+
+                backJumpsToPatch.pop();
+                mgenc.EmitBackwardsJumpOffsetToTarget(loopBeginIdx);
+                break;
+            }
+
+            case BC_HALT:
+            case BC_PUSH_SELF:
+            case BC_PUSH_ARG_1:
+            case BC_PUSH_ARG_2:
+            case BC_RETURN_SELF:
+            case BC_RETURN_FIELD_0:
+            case BC_RETURN_FIELD_1:
+            case BC_RETURN_FIELD_2: {
+                char msg[120];
+                snprintf(msg, 120, "inlineInto: Found %s bytecode, but it's not expected in a block method", Bytecode::GetBytecodeName(bytecode));
+                Universe::ErrorExit(msg);
+                break;
+            }
+            default: {
+                char msg[120];
+                snprintf(msg, 120, "inlineInto: Found %s bytecode, but inlining of it is not yet supported.", Bytecode::GetBytecodeName(bytecode));
+                Universe::ErrorExit(msg);
+                break;
+            }
+        }
+
+        i += bcLength;
+    }
+
+    assert(jumps.empty());
+}
+
+void VMMethod::patchJumpToCurrentAddress(size_t i, std::priority_queue<Jump>& jumps, MethodGenerationContext& mgenc) {
+    while (!jumps.empty() && jumps.top().originalJumpTargetIdx <= i) {
+        Jump jump = jumps.top();
+        jumps.pop();
+
+        assert(jump.originalJumpTargetIdx == i && "we use the less or equal, but actually expect it to be strictly equal");
+        mgenc.PatchJumpOffsetToPointToNextInstruction(jump.idx);
+    }
+}
+
+void VMMethod::prepareBackJumpToCurrentAddress(std::priority_queue<BackJump>& backJumps, std::priority_queue<BackJumpPatch>& backJumpsToPatch, size_t i, MethodGenerationContext& mgenc) {
+    while (!backJumps.empty() && backJumps.top().loopBeginIdx <= i) {
+        BackJump jump = backJumps.top();
+        backJumps.pop();
+
+        assert(jump.loopBeginIdx == i && "we use the less or equal, but actually expect it to be strictly equal");
+        backJumpsToPatch.emplace(BackJumpPatch(jump.backwardJumpIdx, mgenc.OffsetOfNextInstruction()));
+    }
+}
+
+void VMMethod::AdaptAfterOuterInlined(uint8_t removedCtxLevel, MethodGenerationContext& mgencWithInlined) {
+    size_t i = 0;
+    long numBytecodes = GetNumberOfBytecodes();
+
+    while (i < numBytecodes) {
+        uint8_t bytecode = bytecodes[i];
+        size_t bcLength = Bytecode::GetBytecodeLength(bytecode);
+
+        switch (bytecode) {
+            case BC_DUP:
+            case BC_PUSH_CONSTANT:
+            case BC_PUSH_CONSTANT_0:
+            case BC_PUSH_CONSTANT_1:
+            case BC_PUSH_CONSTANT_2:
+            case BC_PUSH_0:
+            case BC_PUSH_1:
+            case BC_PUSH_NIL:
+            case BC_PUSH_GLOBAL: // BC_PUSH_GLOBAL doesn't encode context
+            case BC_PUSH_FIELD:
+            case BC_POP_FIELD:
+            case BC_POP:
+            case BC_SEND:
+            case BC_SEND_1:
+            case BC_SEND_2:
+            case BC_SEND_3:
+            case BC_SUPER_SEND:
+            case BC_RETURN_LOCAL:
+            case BC_RETURN_NON_LOCAL:
+            case BC_INC:
+            case BC_DEC:
+            case BC_JUMP:
+            case BC_JUMP_ON_TRUE_TOP_NIL:
+            case BC_JUMP_ON_TRUE_POP:
+            case BC_JUMP_ON_FALSE_TOP_NIL:
+            case BC_JUMP_ON_FALSE_POP:
+            case BC_JUMP_BACKWARD:
+            case BC_JUMP2:
+            case BC_JUMP2_ON_TRUE_TOP_NIL:
+            case BC_JUMP2_ON_TRUE_POP:
+            case BC_JUMP2_ON_FALSE_TOP_NIL:
+            case BC_JUMP2_ON_FALSE_POP:
+            case BC_JUMP2_BACKWARD: {
+                // these bytecodes do not use context and don't need to be adapted
+                break;
+            }
+
+            case BC_PUSH_ARGUMENT:
+            case BC_POP_ARGUMENT:
+            case BC_INC_FIELD_PUSH:
+            case BC_INC_FIELD: {
+                uint8_t ctxLevel = bytecodes[i + 2];
+                if (ctxLevel > removedCtxLevel) {
+                    bytecodes[i + 2] = ctxLevel - 1;
+                }
+                break;
+            }
+
+            case BC_PUSH_BLOCK: {
+                VMMethod* blockMethod = static_cast<VMMethod*>(GetConstant(i));
+                blockMethod->AdaptAfterOuterInlined(removedCtxLevel + 1, mgencWithInlined);
+                break;
+            }
+
+            case BC_PUSH_LOCAL:
+            case BC_POP_LOCAL: {
+                uint8_t ctxLevel = bytecodes[i + 2];
+                if (ctxLevel == removedCtxLevel) {
+                    uint8_t idx = bytecodes[i + 1];
+
+                    // locals have been inlined into the outer context already
+                    // so, we need to look up the right one and fix up the index
+                    // at this point, the lexical scope has not been changed
+                    // so, we should still be able to find the right one
+                    auto* oldVar = lexicalScope->GetLocal(idx, ctxLevel);
+                    uint8_t newIdx = mgencWithInlined.GetInlinedLocalIdx(oldVar);
+                    bytecodes[i + 1] = newIdx;
+                } else if (ctxLevel > removedCtxLevel) {
+                    bytecodes[i + 2] = ctxLevel - 1;
+                }
+                break;
+            }
+
+            case BC_PUSH_SELF:
+            case BC_PUSH_ARG_1:
+            case BC_PUSH_ARG_2:
+            case BC_PUSH_LOCAL_0:
+            case BC_PUSH_LOCAL_1:
+            case BC_PUSH_LOCAL_2:
+            case BC_PUSH_FIELD_0:
+            case BC_PUSH_FIELD_1:
+            case BC_POP_LOCAL_0:
+            case BC_POP_LOCAL_1:
+            case BC_POP_LOCAL_2: 
+            case BC_POP_FIELD_0:
+            case BC_POP_FIELD_1: {
+                break;
+            }
+
+            case BC_HALT:
+            case BC_RETURN_SELF:
+            case BC_RETURN_FIELD_0:
+            case BC_RETURN_FIELD_1:
+            case BC_RETURN_FIELD_2: {
+                char msg[120];
+                snprintf(msg, 120, "AdaptAfterOuterInlined: Found %s bytecode, but it's not expected in a block method", Bytecode::GetBytecodeName(bytecode));
+                Universe::ErrorExit(msg);
+            }
+
+            default: {
+                char msg[120];
+                snprintf(msg, 120, "Found %s bytecode, but AdaptAfterOuterInlined does not yet support it.", Bytecode::GetBytecodeName(bytecode));
+                Universe::ErrorExit(msg);
+            }
+        }
+
+        i += bcLength;
+    }
+
+    if (removedCtxLevel == 1) {
+        lexicalScope->DropInlinedScope();
+    }
+}
+
+bool operator<(const Jump& a, const Jump& b) {
+  return a.originalJumpTargetIdx < b.originalJumpTargetIdx;
+}
+
+bool operator<(const BackJump& a, const BackJump& b) {
+  return a.loopBeginIdx < b.loopBeginIdx;
+}
+
+bool operator<(const BackJumpPatch& a, const BackJumpPatch& b) {
+  return a.backwardsJumpIdx < b.backwardsJumpIdx;
 }


### PR DESCRIPTION
This PR uses the infrastructure introduced previously in #32 to implement bytecode-level inlining in the same style as in TruffleSOM and PySOM.

One improvement here is that we remove blocks from the literals, too, which leads in the tests to use more use of the specialized bytecodes.

Generally, the new introduced bytecodes for jumps have all the same length, and exist in two variants, one that only uses one byte, i.e., shorted jumps, and the other that uses both.

This also introduces keeping track of the last 4 bytecodes, which is useful for other optimizations later on, too.