### PR TITLE
Inline #ifTrue:, #ifFalse:, #ifTrue:ifFalse:, #ifFalse:ifTrue:, #||, #or:, #&&, #and:

### DIFF
--- a/src/compiler/BytecodeGenerator.cpp
+++ b/src/compiler/BytecodeGenerator.cpp
@@ -278,6 +278,13 @@ size_t EmitJumpOnBoolWithDummyOffset(MethodGenerationContext& mgenc,
     return idx;
 }
 
+size_t EmitJumpWithDumyOffset(MethodGenerationContext& mgenc) {
+    Emit1(mgenc, BC_JUMP, 0);
+    size_t idx = mgenc.AddBytecodeArgumentAndGetIndex(0);
+    mgenc.AddBytecodeArgument(0);
+    return idx;
+}
+
 void EmitJumpBackwardWithOffset(MethodGenerationContext& mgenc,
                                 size_t jumpOffset) {
     uint8_t jumpBytecode =

--- a/src/compiler/BytecodeGenerator.h
+++ b/src/compiler/BytecodeGenerator.h
@@ -60,6 +60,7 @@ void EmitRETURNNONLOCAL(MethodGenerationContext& mgenc);
 
 size_t EmitJumpOnBoolWithDummyOffset(MethodGenerationContext& mgenc,
                                      bool isIfTrue, bool needsPop);
+size_t EmitJumpWithDumyOffset(MethodGenerationContext& mgenc);
 void EmitJumpBackwardWithOffset(MethodGenerationContext& mgenc,
                                 size_t jumpOffset);
 size_t Emit3WithDummy(MethodGenerationContext& mgenc, uint8_t bytecode,

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -259,6 +259,10 @@ void MethodGenerationContext::removeLastBytecodes(size_t numBytecodes) {
     bytecode.erase(bytecode.end() - bytesToRemove, bytecode.end());
 }
 
+bool MethodGenerationContext::hasOneLiteralBlockArgument() {
+    return lastBytecodeIs(0, BC_PUSH_BLOCK);
+}
+
 bool MethodGenerationContext::hasTwoLiteralBlockArguments() {
     if (!lastBytecodeIs(0, BC_PUSH_BLOCK)) {
         return false;
@@ -280,6 +284,16 @@ vm_oop_t MethodGenerationContext::getLastBlockMethodAndFreeLiteral(
     return block;
 }
 
+vm_oop_t MethodGenerationContext::extractBlockMethodAndRemoveBytecode() {
+    uint8_t blockLitIdx = bytecode.at(bytecode.size() - 1);
+
+    vm_oop_t toBeInlined = getLastBlockMethodAndFreeLiteral(blockLitIdx);
+
+    removeLastBytecodes(1);
+
+    return toBeInlined;
+}
+
 std::tuple<vm_oop_t, vm_oop_t>
 MethodGenerationContext::extractBlockMethodsAndRemoveBytecodes() {
     uint8_t block1LitIdx = bytecode.at(bytecode.size() - 3);
@@ -292,6 +306,33 @@ MethodGenerationContext::extractBlockMethodsAndRemoveBytecodes() {
     removeLastBytecodes(2);
 
     return {toBeInlined1, toBeInlined2};
+}
+
+bool MethodGenerationContext::InlineIfTrueOrIfFalse(bool isIfTrue) {
+    // HACK: We do assume that the receiver on the stack is a boolean,
+    // HACK: similar to the IfTrueIfFalseNode.
+    // HACK: We don't support anything but booleans at the moment.
+    assert(Bytecode::GetBytecodeLength(BC_PUSH_BLOCK) == 2);
+    if (!hasOneLiteralBlockArgument()) {
+        return false;
+    }
+
+    VMMethod* toBeInlined =
+        static_cast<VMMethod*>(extractBlockMethodAndRemoveBytecode());
+
+    size_t jumpOffsetIdxToSkipBody =
+        EmitJumpOnBoolWithDummyOffset(*this, isIfTrue, false);
+
+    isCurrentlyInliningABlock = true;
+
+    toBeInlined->InlineInto(*this);
+    PatchJumpOffsetToPointToNextInstruction(jumpOffsetIdxToSkipBody);
+
+    // with the jumping, it's best to prevent any subsequent optimizations here
+    // otherwise we may not have the correct jump target
+    resetLastBytecodeBuffer();
+
+    return true;
 }
 
 bool MethodGenerationContext::InlineWhile(Parser& parser, bool isWhileTrue) {

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -96,6 +96,7 @@ public:
     bool InlineWhile(Parser& parser, bool isWhileTrue);
     bool InlineIfTrueOrIfFalse(bool isIfTrue);
     bool InlineIfTrueFalse(bool isIfTrue);
+    bool InlineAndOr(bool isOr);
 
     inline size_t OffsetOfNextInstruction() { return bytecode.size(); }
 

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -94,6 +94,7 @@ public:
     std::vector<uint8_t> GetBytecodes() { return bytecode; }
 
     bool InlineWhile(Parser& parser, bool isWhileTrue);
+    bool InlineIfTrueOrIfFalse(bool isIfTrue);
 
     inline size_t OffsetOfNextInstruction() { return bytecode.size(); }
 
@@ -107,9 +108,12 @@ public:
 
 private:
     void removeLastBytecodes(size_t numBytecodes);
+    bool hasOneLiteralBlockArgument();
     bool hasTwoLiteralBlockArguments();
     bool lastBytecodeIs(size_t indexFromEnd, uint8_t bytecode);
     std::tuple<vm_oop_t, vm_oop_t> extractBlockMethodsAndRemoveBytecodes();
+    vm_oop_t extractBlockMethodAndRemoveBytecode();
+
     vm_oop_t getLastBlockMethodAndFreeLiteral(uint8_t blockLiteralIdx);
 
     void completeJumpsAndEmitReturningNil(Parser& parser, size_t loopBeginIdx,

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -95,6 +95,7 @@ public:
 
     bool InlineWhile(Parser& parser, bool isWhileTrue);
     bool InlineIfTrueOrIfFalse(bool isIfTrue);
+    bool InlineIfTrueFalse(bool isIfTrue);
 
     inline size_t OffsetOfNextInstruction() { return bytecode.size(); }
 

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -634,6 +634,12 @@ void Parser::keywordMessage(MethodGenerationContext& mgenc, bool super) {
              (kw == "whileFalse:" && mgenc.InlineWhile(*this, false)))) {
             return;
         }
+
+        if (numParts == 2 &&
+            ((kw == "ifTrue:ifFalse:" && mgenc.InlineIfTrueFalse(true)) ||
+             (kw == "ifFalse:ifTrue:" && mgenc.InlineIfTrueFalse(false)))) {
+            return;
+        }
     }
 
     VMSymbol* msg = SymbolFor(kw);

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -628,7 +628,9 @@ void Parser::keywordMessage(MethodGenerationContext& mgenc, bool super) {
 
     if (!super) {
         if (numParts == 1 &&
-            ((kw == "whileTrue:" && mgenc.InlineWhile(*this, true)) ||
+            ((kw == "ifTrue:" && mgenc.InlineIfTrueOrIfFalse(true)) ||
+             (kw == "ifFalse:" && mgenc.InlineIfTrueOrIfFalse(false)) ||
+             (kw == "whileTrue:" && mgenc.InlineWhile(*this, true)) ||
              (kw == "whileFalse:" && mgenc.InlineWhile(*this, false)))) {
             return;
         }

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -593,9 +593,15 @@ void Parser::unaryMessage(MethodGenerationContext& mgenc, bool super) {
 }
 
 void Parser::binaryMessage(MethodGenerationContext& mgenc, bool super) {
+    std::string msgSelector(text);
     VMSymbol* msg = binarySelector();
 
     binaryOperand(mgenc);
+
+    if (!super && (msgSelector == "||" && mgenc.InlineAndOr(true)) ||
+        (msgSelector == "&&" && mgenc.InlineAndOr(false))) {
+        return;
+    }
 
     if (super) {
         EmitSUPERSEND(mgenc, msg);
@@ -631,7 +637,9 @@ void Parser::keywordMessage(MethodGenerationContext& mgenc, bool super) {
             ((kw == "ifTrue:" && mgenc.InlineIfTrueOrIfFalse(true)) ||
              (kw == "ifFalse:" && mgenc.InlineIfTrueOrIfFalse(false)) ||
              (kw == "whileTrue:" && mgenc.InlineWhile(*this, true)) ||
-             (kw == "whileFalse:" && mgenc.InlineWhile(*this, false)))) {
+             (kw == "whileFalse:" && mgenc.InlineWhile(*this, false)) ||
+             (kw == "or:" && mgenc.InlineAndOr(true)) ||
+             (kw == "and:" && mgenc.InlineAndOr(false)))) {
             return;
         }
 

--- a/src/interpreter/bytecodes.cpp
+++ b/src/interpreter/bytecodes.cpp
@@ -82,31 +82,53 @@ const uint8_t Bytecode::bytecodeLengths[] = {
 };
 
 const char* Bytecode::bytecodeNames[] = {
-    "HALT            ",          "DUP             ",
-    "PUSH_LOCAL      ",          "PUSH_LOCAL_0    ",
-    "PUSH_LOCAL_1    ",          "PUSH_LOCAL_2    ",
-    "PUSH_ARGUMENT   ",          "PUSH_SELF       ",
-    "PUSH_ARG_1      ",          "PUSH_ARG_2      ",
-    "PUSH_FIELD      ",          "PUSH_FIELD_0    ",
-    "PUSH_FIELD_1    ",          "PUSH_BLOCK      ",
-    "PUSH_CONSTANT   ",          "PUSH_CONSTANT_0 ",
-    "PUSH_CONSTANT_1 ",          "PUSH_CONSTANT_2 ",
-    "PUSH_0          ",          "PUSH_1          ",
-    "PUSH_NIL        ",          "PUSH_GLOBAL     ",
-    "POP             ",          "POP_LOCAL       ",
-    "POP_LOCAL_0     ",          "POP_LOCAL_1     ",
-    "POP_LOCAL_2     ",          "POP_ARGUMENT    ",
-    "POP_FIELD       ",          "POP_FIELD_0     ",
-    "POP_FIELD_1     ",          "SEND            ",
-    "SUPER_SEND      ",          "RETURN_LOCAL    ",
-    "RETURN_NON_LOCAL",          "BC_JUMP         ",
-    "BC_JUMP_ON_TRUE_TOP_NIL",   "BC_JUMP_ON_FALSE_TOP_NIL",
-    "BC_JUMP_ON_TRUE_POP",       "BC_JUMP_ON_FALSE_POP",
-    "BC_JUMP_BACKWARD",
-
-    "BC_JUMP2         ",         "BC_JUMP2_ON_TRUE_TOP_NIL",
-    "BC_JUMP2_ON_FALSE_TOP_NIL", "BC_JUMP2_ON_TRUE_POP",
-    "BC_JUMP2_ON_FALSE_POP",     "BC_JUMP2_BACKWARD",
+    "HALT            ",           // 0
+    "DUP             ",           // 1
+    "PUSH_LOCAL      ",           // 2
+    "PUSH_LOCAL_0    ",           // 3
+    "PUSH_LOCAL_1    ",           // 4
+    "PUSH_LOCAL_2    ",           // 5
+    "PUSH_ARGUMENT   ",           // 6
+    "PUSH_SELF       ",           // 7
+    "PUSH_ARG_1      ",           // 8
+    "PUSH_ARG_2      ",           // 9
+    "PUSH_FIELD      ",           // 10
+    "PUSH_FIELD_0    ",           // 11
+    "PUSH_FIELD_1    ",           // 12
+    "PUSH_BLOCK      ",           // 13
+    "PUSH_CONSTANT   ",           // 14
+    "PUSH_CONSTANT_0 ",           // 15
+    "PUSH_CONSTANT_1 ",           // 16
+    "PUSH_CONSTANT_2 ",           // 17
+    "PUSH_0          ",           // 18
+    "PUSH_1          ",           // 19
+    "PUSH_NIL        ",           // 20
+    "PUSH_GLOBAL     ",           // 21
+    "POP             ",           // 22
+    "POP_LOCAL       ",           // 23
+    "POP_LOCAL_0     ",           // 24
+    "POP_LOCAL_1     ",           // 25
+    "POP_LOCAL_2     ",           // 26
+    "POP_ARGUMENT    ",           // 27
+    "POP_FIELD       ",           // 28
+    "POP_FIELD_0     ",           // 29
+    "POP_FIELD_1     ",           // 30
+    "SEND            ",           // 31
+    "SUPER_SEND      ",           // 32
+    "RETURN_LOCAL    ",           // 33
+    "RETURN_NON_LOCAL",           // 34
+    "BC_JUMP         ",           // 35
+    "BC_JUMP_ON_FALSE_POP",       // 36
+    "BC_JUMP_ON_TRUE_POP",        // 37
+    "BC_JUMP_ON_FALSE_TOP_NIL",   // 38
+    "BC_JUMP_ON_TRUE_TOP_NIL",    // 39
+    "BC_JUMP_BACKWARD",           // 40
+    "BC_JUMP2         ",          // 41
+    "BC_JUMP2_ON_FALSE_POP",      // 42
+    "BC_JUMP2_ON_TRUE_POP",       // 43
+    "BC_JUMP2_ON_FALSE_TOP_NIL",  // 44
+    "BC_JUMP2_ON_TRUE_TOP_NIL",   // 45
+    "BC_JUMP2_BACKWARD",          // 46
 };
 
 bool IsJumpBytecode(uint8_t bc) {

--- a/src/unitTests/BytecodeGenerationTest.cpp
+++ b/src/unitTests/BytecodeGenerationTest.cpp
@@ -613,6 +613,48 @@ void BytecodeGenerationTest::ifTrueWithSomethingAndLiteralReturn(
     tearDown();
 }
 
+void BytecodeGenerationTest::testIfTrueIfFalseArg() {
+    auto bytecodes = methodToBytecode(R"""( test: arg1 with: arg2 = (
+            #start.
+            self method ifTrue: [ arg1 ] ifFalse: [ arg2 ].
+            #end
+        ) )""");
+
+    check(bytecodes,
+          {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_SELF, BC(BC_SEND, 1),
+           BC(BC_JUMP_ON_FALSE_POP, 7, 0), BC_PUSH_ARG_1, BC(BC_JUMP, 4, 0),
+           BC_PUSH_ARG_2, BC_POP, BC_PUSH_CONSTANT_2, BC_POP, BC_PUSH_SELF,
+           BC_RETURN_LOCAL});
+}
+
+void BytecodeGenerationTest::testIfTrueIfFalseNlrArg1() {
+    auto bytecodes = methodToBytecode(R"""( test: arg1 with: arg2 = (
+            #start.
+            self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ].
+            #end
+        ) )""");
+
+    check(bytecodes,
+          {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_SELF, BC(BC_SEND, 1),
+           BC(BC_JUMP_ON_FALSE_POP, 8, 0), BC_PUSH_ARG_1, BC_RETURN_LOCAL,
+           BC(BC_JUMP, 4, 0), BC_PUSH_ARG_2, BC_POP, BC_PUSH_CONSTANT_2, BC_POP,
+           BC_PUSH_SELF, BC_RETURN_LOCAL});
+}
+
+void BytecodeGenerationTest::testIfTrueIfFalseNlrArg2() {
+    auto bytecodes = methodToBytecode(R"""( test: arg1 with: arg2 = (
+            #start.
+            self method ifTrue: [ arg1 ] ifFalse: [ ^ arg2 ].
+            #end
+        ) )""");
+
+    check(bytecodes,
+          {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_SELF, BC(BC_SEND, 1),
+           BC(BC_JUMP_ON_FALSE_POP, 7, 0), BC_PUSH_ARG_1, BC(BC_JUMP, 5, 0),
+           BC_PUSH_ARG_2, BC_RETURN_LOCAL, BC_POP, BC_PUSH_CONSTANT_2, BC_POP,
+           BC_PUSH_SELF, BC_RETURN_LOCAL});
+}
+
 /*
  @pytest.mark.parametrize(
      "operator,bytecode",
@@ -987,79 +1029,6 @@ void BytecodeGenerationTest::ifTrueWithSomethingAndLiteralReturn(
          ],
      )
 
-
- def test_if_true_if_false_arg(mgenc):
-     bytecodes = method_to_bytecodes(
-         mgenc,
-         """
-         test: arg1 with: arg2 = (
-             #start.
-             self method ifTrue: [ arg1 ] ifFalse: [ arg2 ].
-             #end
-         )""",
-     )
-
-     assert len(bytecodes) == 23
-     check(
-         bytecodes,
-         [
-             (7, BC(Bytecodes.jump_on_false_pop, 9)),
-             BC(Bytecodes.push_argument, 1, 0),
-             BC(Bytecodes.jump, 6),
-             BC(Bytecodes.push_argument, 2, 0),
-             Bytecodes.pop,
-         ],
-     )
-
-
- def test_if_true_if_false_nlr_arg1(mgenc):
-     bytecodes = method_to_bytecodes(
-         mgenc,
-         """
-         test: arg1 with: arg2 = (
-             #start.
-             self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ].
-             #end
-         )""",
-     )
-
-     assert len(bytecodes) == 24
-     check(
-         bytecodes,
-         [
-             (7, BC(Bytecodes.jump_on_false_pop, 10)),
-             BC(Bytecodes.push_argument, 1, 0),
-             Bytecodes.return_local,
-             BC(Bytecodes.jump, 6),
-             BC(Bytecodes.push_argument, 2, 0),
-             Bytecodes.pop,
-         ],
-     )
-
-
- def test_if_true_if_false_nlr_arg2(mgenc):
-     bytecodes = method_to_bytecodes(
-         mgenc,
-         """
-         test: arg1 with: arg2 = (
-             #start.
-             self method ifTrue: [ arg1 ] ifFalse: [ ^ arg2 ].
-             #end
-         )""",
-     )
-
-     assert len(bytecodes) == 24
-     check(
-         bytecodes,
-         [
-             (7, BC(Bytecodes.jump_on_false_pop, 9)),
-             BC(Bytecodes.push_argument, 1, 0),
-             BC(Bytecodes.jump, 7),
-             BC(Bytecodes.push_argument, 2, 0),
-             Bytecodes.return_local,
-             Bytecodes.pop,
-         ],
-     )
 
 
  @pytest.mark.parametrize(

--- a/src/unitTests/BytecodeGenerationTest.cpp
+++ b/src/unitTests/BytecodeGenerationTest.cpp
@@ -116,10 +116,26 @@ void BytecodeGenerationTest::testIfPushConstantSame() {
                                         #a. #b. #c. #d.
                                         true ifFalse: [ #a. #b. #c. #d. ]
                                       ) )""");
-    check(bytecodes, {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_CONSTANT_1, BC_POP,
-                      BC_PUSH_CONSTANT_2, BC_POP, BC(BC_PUSH_CONSTANT, 3),
-                      BC_POP, BC(BC_PUSH_CONSTANT, 4), BC(BC_PUSH_BLOCK, 5),
-                      BC(BC_SEND, 6), BC_POP, BC_PUSH_SELF, BC_RETURN_LOCAL});
+    check(bytecodes, {BC_PUSH_CONSTANT_0,
+                      BC_POP,
+                      BC_PUSH_CONSTANT_1,
+                      BC_POP,
+                      BC_PUSH_CONSTANT_2,
+                      BC_POP,
+                      BC(BC_PUSH_CONSTANT, 3),
+                      BC_POP,
+                      BC(BC_PUSH_CONSTANT, 4),
+                      BC(BC_JUMP_ON_TRUE_TOP_NIL, 11, 0),
+                      BC_PUSH_CONSTANT_0,
+                      BC_POP,
+                      BC_PUSH_CONSTANT_1,
+                      BC_POP,
+                      BC_PUSH_CONSTANT_2,
+                      BC_POP,
+                      BC(BC_PUSH_CONSTANT, 3),
+                      BC_POP,
+                      BC_PUSH_SELF,
+                      BC_RETURN_LOCAL});
 }
 
 void BytecodeGenerationTest::testIfPushConstantDifferent() {
@@ -128,10 +144,26 @@ void BytecodeGenerationTest::testIfPushConstantDifferent() {
                                         #a. #b. #c. #d.
                                         true ifFalse: [ #e. #f. #g. #h. ]
                                       ) )""");
-    check(bytecodes, {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_CONSTANT_1, BC_POP,
-                      BC_PUSH_CONSTANT_2, BC_POP, BC(BC_PUSH_CONSTANT, 3),
-                      BC_POP, BC(BC_PUSH_CONSTANT, 4), BC(BC_PUSH_BLOCK, 5),
-                      BC(BC_SEND, 6), BC_POP, BC_PUSH_SELF, BC_RETURN_LOCAL});
+    check(bytecodes, {BC_PUSH_CONSTANT_0,
+                      BC_POP,
+                      BC_PUSH_CONSTANT_1,
+                      BC_POP,
+                      BC_PUSH_CONSTANT_2,
+                      BC_POP,
+                      BC(BC_PUSH_CONSTANT, 3),
+                      BC_POP,
+                      BC(BC_PUSH_CONSTANT, 4),
+                      BC(BC_JUMP_ON_TRUE_TOP_NIL, 14, 0),
+                      BC(BC_PUSH_CONSTANT, 5),
+                      BC_POP,
+                      BC(BC_PUSH_CONSTANT, 6),
+                      BC_POP,
+                      BC(BC_PUSH_CONSTANT, 7),
+                      BC_POP,
+                      BC(BC_PUSH_CONSTANT, 8),
+                      BC_POP,
+                      BC_PUSH_SELF,
+                      BC_RETURN_LOCAL});
 }
 
 void BytecodeGenerationTest::testExplicitReturnSelf() {
@@ -401,6 +433,9 @@ void BytecodeGenerationTest::check(std::vector<uint8_t> actual,
         i += 1;
         bci += bcLength;
     }
+    if (expected.size() != i || actual.size() != bci) {
+        dump(_mgenc);
+    }
 
     CPPUNIT_ASSERT_EQUAL_MESSAGE("All expected bytecodes covered",
                                  expected.size(), i);
@@ -429,11 +464,6 @@ void BytecodeGenerationTest::testWhileInlining(const char* selector,
 /** This test checks whether the jumps in the while loop are correct after it
  * got inlined. */
 void BytecodeGenerationTest::testInliningWhileLoopsWithExpandingBranches() {
-    DebugPrint(
-        "\nTODO: testInliningWhileLoopsWithExpandingBranches is currently "
-        "ignored, because we do not yet support inlining if #ifTrue:\n");
-    return;
-
     auto bytecodes = methodToBytecode(R"""(
         test = (
           #const0. #const1. #const2.
@@ -452,88 +482,138 @@ void BytecodeGenerationTest::testInliningWhileLoopsWithExpandingBranches() {
            // jump offset, to jump to the pop BC after the if/right before the
            // push #end
            BC(BC_JUMP_ON_FALSE_TOP_NIL, 27, 0), BC(BC_PUSH_CONSTANT, 3), BC_POP,
-           BC(BC_PUSH_CONSTANT, 4), BC_POP, BC(BC_PUSH_CONSTANT, 5), BC_POP,
+           BC(BC_PUSH_CONSTANT, 4), BC_POP, BC(BC_PUSH_CONSTANT, 5),
 
            // jump offset, jump to push_nil as result of whileTrue
-           BC(BC_JUMP_ON_FALSE_POP, 15), BC(BC_PUSH_CONSTANT, 6), BC_POP,
+           BC(BC_JUMP_ON_FALSE_POP, 15, 0), BC(BC_PUSH_CONSTANT, 6), BC_POP,
            BC(BC_PUSH_CONSTANT, 7), BC_POP, BC(BC_PUSH_CONSTANT, 8), BC_POP,
 
            // jump offset, jump back to the first PUSH_CONST inside if body,
            // pushing #const3
-           BC_PUSH_NIL, BC_POP,
+           BC(BC_JUMP_BACKWARD, 20, 0), BC_PUSH_NIL, BC_POP,
 
            BC(BC_PUSH_CONSTANT, 9), BC_RETURN_LOCAL});
 }
 
 void BytecodeGenerationTest::testInliningWhileLoopsWithContractingBranches() {
-    DebugPrint(
-        "\nTODO: testInliningWhileLoopsWithContractingBranches is currently "
-        "ignored, because we do not yet support inlining if #ifTrue:\n");
+    auto bytecodes = methodToBytecode(R"""(
+                        test = (
+                        0 ifTrue: [
+                            [ ^ 1 ]
+                                whileTrue: [
+                                ^ 0 ]
+                        ].
+                        ^ #end
+                        ) )""");
 
-    // def test_inlining_while_loop_with_contracting_branches(mgenc):
-    //     """
-    //     This test checks whether the jumps in the while loop are correct
-    //     after it got inlined. The challenge here is
-    //     """
-    //     bytecodes = method_to_bytecodes(
-    //         mgenc,
-    //         """
-    //         test = (
-    //           0 ifTrue: [
-    //             [ ^ 1 ]
-    //                whileTrue: [
-    //                  ^ 0 ]
-    //           ].
-    //           ^ #end
-    //         )
-    //         """,
-    //     )
-    //
-    //     assert len(bytecodes) == 19
-    //     check(
-    //         bytecodes,
-    //         [
-    //             Bytecodes.push_0,
-    //             BC(
-    //                 Bytecodes.jump_on_false_top_nil,
-    //                 15,
-    //                 note="jump offset to jump to the pop after the if, before
-    //                 pushing #end",
-    //             ),
-    //             Bytecodes.push_1,
-    //             Bytecodes.return_local,
-    //             BC(
-    //                 Bytecodes.jump_on_false_pop,
-    //                 9,
-    //                 note="jump offset, jump to push_nil as result of
-    //                 whileTrue",
-    //             ),
-    //             Bytecodes.push_0,
-    //             Bytecodes.return_local,
-    //             Bytecodes.pop,
-    //             BC(
-    //                 Bytecodes.jump_backward,
-    //                 8,
-    //                 note="jump offset, to the push_1 of the condition",
-    //             ),
-    //             Bytecodes.push_nil,
-    //             Bytecodes.pop,
-    //         ],
-    //     )
+    check(bytecodes,
+          {BC_PUSH_0,
+           // jump offset to jump to the pop after the if, before pushing #end
+           BC(BC_JUMP_ON_FALSE_TOP_NIL, 15, 0), BC_PUSH_1, BC_RETURN_LOCAL,
+           // jump offset, jump to push_nil as result of whileTrue
+           BC(BC_JUMP_ON_FALSE_POP, 9, 0), BC_PUSH_0, BC_RETURN_LOCAL, BC_POP,
+           // jump offset, to the push_1 of the condition
+           BC(BC_JUMP_BACKWARD, 8, 0), BC_PUSH_NIL, BC_POP, BC_PUSH_CONSTANT_0,
+           BC_RETURN_LOCAL});
 };
 
+void BytecodeGenerationTest::testIfInlineAndConstantBcLength() {
+    auto bytecodes = methodToBytecode(R"""(
+                                test = (
+                                  #a. #b. #c.
+                                  true ifTrue: [
+                                    true ifFalse: [ #e. #f. #g ] ]
+                                ) )""");
+
+    CPPUNIT_ASSERT_EQUAL((uint8_t)BC_JUMP_ON_TRUE_TOP_NIL, bytecodes.at(13));
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(
+        "jump offset, should point to correct bytecode and not be affected by "
+        "changing length of bytecodes in the block",
+        (uint8_t)11, bytecodes.at(14));
+}
+
+void BytecodeGenerationTest::testIfTrueWithLiteralReturn() {
+    ifTrueWithLiteralReturn("0", BC_PUSH_0);
+    ifTrueWithLiteralReturn("1", BC_PUSH_1);
+    ifTrueWithLiteralReturn("-10", BC_PUSH_CONSTANT_1);
+    ifTrueWithLiteralReturn("3333", BC_PUSH_CONSTANT_1);
+    ifTrueWithLiteralReturn("'str'", BC_PUSH_CONSTANT_1);
+    ifTrueWithLiteralReturn("#sym", BC_PUSH_CONSTANT_1);
+    ifTrueWithLiteralReturn("1.1", BC_PUSH_CONSTANT_1);
+    ifTrueWithLiteralReturn("-2342.234", BC_PUSH_CONSTANT_1);
+    ifTrueWithLiteralReturn("true", BC_PUSH_CONSTANT_1);
+    ifTrueWithLiteralReturn("false", BC_PUSH_CONSTANT_1);
+    ifTrueWithLiteralReturn("nil", BC_PUSH_NIL);
+    ifTrueWithLiteralReturn("SomeGlobal", BC(BC_PUSH_GLOBAL, 1));
+    ifTrueWithLiteralReturn("[]", BC(BC_PUSH_BLOCK, 1));
+    ifTrueWithLiteralReturn("[ self ]", BC(BC_PUSH_BLOCK, 1));
+}
+
+void BytecodeGenerationTest::ifTrueWithLiteralReturn(std::string literal,
+                                                     BC bytecode) {
+    std::string source = R"""(      test = (
+                                        self method ifTrue: [ LITERAL ].
+                                    ) )""";
+    bool wasReplaced = ReplacePattern(source, "LITERAL", literal);
+    assert(wasReplaced);
+
+    auto bytecodes = methodToBytecode(source.data());
+
+    bool twoByte2 = bytecode.bytecode == BC_PUSH_GLOBAL ||
+                    bytecode.bytecode == BC_PUSH_BLOCK;
+
+    check(bytecodes,
+          {BC_PUSH_SELF, BC(BC_SEND, 0),
+           BC(BC_JUMP_ON_FALSE_TOP_NIL, twoByte2 ? 5 : 4, 0), bytecode, BC_POP,
+           BC_PUSH_SELF, BC_RETURN_LOCAL});
+
+    tearDown();
+}
+
+void BytecodeGenerationTest::testIfTrueWithSomethingAndLiteralReturn() {
+    ifTrueWithSomethingAndLiteralReturn("0", BC_PUSH_0);
+    ifTrueWithSomethingAndLiteralReturn("1", BC_PUSH_1);
+    ifTrueWithSomethingAndLiteralReturn("-10", BC_PUSH_CONSTANT_2);
+    ifTrueWithSomethingAndLiteralReturn("3333", BC_PUSH_CONSTANT_2);
+    ifTrueWithSomethingAndLiteralReturn("'str'", BC_PUSH_CONSTANT_2);
+    ifTrueWithSomethingAndLiteralReturn("#sym", BC_PUSH_CONSTANT_2);
+    ifTrueWithSomethingAndLiteralReturn("1.1", BC_PUSH_CONSTANT_2);
+    ifTrueWithSomethingAndLiteralReturn("-2342.234", BC_PUSH_CONSTANT_2);
+    ifTrueWithSomethingAndLiteralReturn("true", BC_PUSH_CONSTANT_2);
+    ifTrueWithSomethingAndLiteralReturn("false", BC_PUSH_CONSTANT_2);
+    ifTrueWithSomethingAndLiteralReturn("nil", BC_PUSH_NIL);
+    ifTrueWithSomethingAndLiteralReturn("SomeGlobal", BC(BC_PUSH_GLOBAL, 2));
+    ifTrueWithSomethingAndLiteralReturn("[]", BC(BC_PUSH_BLOCK, 2));
+    ifTrueWithSomethingAndLiteralReturn("[ self ]", BC(BC_PUSH_BLOCK, 2));
+}
+
+void BytecodeGenerationTest::ifTrueWithSomethingAndLiteralReturn(
+    std::string literal, BC bytecode) {
+    // This test is different from the previous one, because the block
+    // method won't be recognized as being trivial
+
+    std::string source = R"""(      test = (
+                                        self method ifTrue: [ #fooBarNonTrivialBlock. LITERAL ].
+                                    ) )""";
+    bool wasReplaced = ReplacePattern(source, "LITERAL", literal);
+    assert(wasReplaced);
+
+    auto bytecodes = methodToBytecode(source.data());
+
+    bool twoByte2 = bytecode.bytecode == BC_PUSH_GLOBAL ||
+                    bytecode.bytecode == BC_PUSH_BLOCK;
+
+    check(
+        bytecodes,
+        {BC_PUSH_SELF, BC(BC_SEND, 0),
+         BC(BC_JUMP_ON_FALSE_TOP_NIL, twoByte2 ? 7 : 6, 0), BC_PUSH_CONSTANT_1,
+         BC_POP, bytecode, BC_POP, BC_PUSH_SELF, BC_RETURN_LOCAL});
+
+    tearDown();
+}
+
 /*
-
-
- class BC(object):
-     def __init__(self, bytecode, arg1=None, arg2=None, note=None):
-         self.bytecode = bytecode
-         self.arg1 = arg1
-         self.arg2 = arg2
-         self.note = note
-
-
-
  @pytest.mark.parametrize(
      "operator,bytecode",
      [
@@ -548,119 +628,6 @@ void BytecodeGenerationTest::testInliningWhileLoopsWithContractingBranches() {
      assert len(bytecodes) == 3
      check(bytecodes, [Bytecodes.push_1, bytecode, Bytecodes.return_self])
 
-
-
-
- def test_if_inline_and_constant_bc_length(mgenc):
-     bytecodes = method_to_bytecodes(
-         mgenc,
-         """
-         test = (
-           #a. #b. #c.
-           true ifTrue: [
-             true ifFalse: [ #e. #f. #g ] ]
-         )""",
-     )
-
-     assert Bytecodes.jump_on_true_top_nil == bytecodes[13]
-     assert bytecodes[14] == 11, (
-         "jump offset, should point to correct bytecode"
-         + " and not be affected by changing length of bytecodes in the block"
-     )
-
-
-
-
- @pytest.mark.parametrize(
-     "literal,bytecode",
-     [
-         ("0", Bytecodes.push_0),
-         ("1", Bytecodes.push_1),
-         ("-10", Bytecodes.push_constant_2),
-         ("3333", Bytecodes.push_constant_2),
-         ("'str'", Bytecodes.push_constant_2),
-         ("#sym", Bytecodes.push_constant_2),
-         ("1.1", Bytecodes.push_constant_2),
-         ("-2342.234", Bytecodes.push_constant_2),
-         ("true", Bytecodes.push_constant_2),
-         ("false", Bytecodes.push_constant_2),
-         ("nil", Bytecodes.push_nil),
-         ("SomeGlobal", Bytecodes.push_global),
-         ("[]", Bytecodes.push_block_no_ctx),
-         ("[ self ]", Bytecodes.push_block),
-     ],
- )
- def test_if_true_with_literal_return(mgenc, literal, bytecode):
-     source = """
-         test = (
-             self method ifTrue: [ LITERAL ].
-         )""".replace(
-         "LITERAL", literal
-     )
-     bytecodes = method_to_bytecodes(mgenc, source)
-
-     length = bytecode_length(bytecode)
-
-     assert len(bytecodes) == 10 + length
-     check(
-         bytecodes,
-         [
-             Bytecodes.push_argument,
-             Bytecodes.send_1,
-             Bytecodes.jump_on_false_top_nil,
-             bytecode,
-             Bytecodes.pop,
-             Bytecodes.return_self,
-         ],
-     )
-
-
- @pytest.mark.parametrize(
-     "literal,bytecode",
-     [
-         ("0", Bytecodes.push_0),
-         ("1", Bytecodes.push_1),
-         ("-10", Bytecodes.push_constant),
-         ("3333", Bytecodes.push_constant),
-         ("'str'", Bytecodes.push_constant),
-         ("#sym", Bytecodes.push_constant),
-         ("1.1", Bytecodes.push_constant),
-         ("-2342.234", Bytecodes.push_constant),
-         ("true", Bytecodes.push_constant),
-         ("false", Bytecodes.push_constant),
-         ("nil", Bytecodes.push_nil),
-         ("SomeGlobal", Bytecodes.push_global),
-         ("[]", Bytecodes.push_block_no_ctx),
-         ("[ self ]", Bytecodes.push_block),
-     ],
- )
- def test_if_true_with_something_and_literal_return(mgenc, literal, bytecode):
-     # This test is different from the previous one, because the block
-     # method won't be recognized as being trivial
-     source = """
-         test = (
-             self method ifTrue: [ #fooBarNonTrivialBlock. LITERAL ].
-         )""".replace(
-         "LITERAL", literal
-     )
-     bytecodes = method_to_bytecodes(mgenc, source)
-
-     length = bytecode_length(bytecode)
-
-     assert len(bytecodes) == 12 + length
-     check(
-         bytecodes,
-         [
-             Bytecodes.push_argument,
-             Bytecodes.send_1,
-             Bytecodes.jump_on_false_top_nil,
-             Bytecodes.push_constant_2,
-             Bytecodes.pop,
-             bytecode,
-             Bytecodes.pop,
-             Bytecodes.return_self,
-         ],
-     )
 
 
  @pytest.mark.parametrize(
@@ -1168,14 +1135,14 @@ void BytecodeGenerationTest::testInliningWhileLoopsWithContractingBranches() {
      [
          ("0", Bytecodes.push_0),
          ("1", Bytecodes.push_1),
-         ("-10", Bytecodes.push_constant_2),
-         ("3333", Bytecodes.push_constant_2),
-         ("'str'", Bytecodes.push_constant_2),
-         ("#sym", Bytecodes.push_constant_2),
-         ("1.1", Bytecodes.push_constant_2),
-         ("-2342.234", Bytecodes.push_constant_2),
+         ("-10", BC_PUSH_CONSTANT_2),
+         ("3333", BC_PUSH_CONSTANT_2),
+         ("'str'", BC_PUSH_CONSTANT_2),
+         ("#sym", BC_PUSH_CONSTANT_2),
+         ("1.1", BC_PUSH_CONSTANT_2),
+         ("-2342.234", BC_PUSH_CONSTANT_2),
          ("true", Bytecodes.push_constant_0),
-         ("false", Bytecodes.push_constant_2),
+         ("false", BC_PUSH_CONSTANT_2),
          ("nil", Bytecodes.push_nil),
          ("Nil", Bytecodes.push_global),
          ("UnknownGlobal", Bytecodes.push_global),
@@ -1342,7 +1309,7 @@ void BytecodeGenerationTest::testInliningWhileLoopsWithContractingBranches() {
              Bytecodes.push_constant_0,
              BC(Bytecodes.jump_on_false_pop, 7),
              # true branch
-             Bytecodes.push_constant_2,  # push the `#val`
+             BC_PUSH_CONSTANT_2,  # push the `#val`
              BC(Bytecodes.jump, 5),
              # false branch, jump_on_false target, push false
              Bytecodes.push_constant,
@@ -1365,7 +1332,7 @@ void BytecodeGenerationTest::testInliningWhileLoopsWithContractingBranches() {
              Bytecodes.push_constant_0,
              BC(Bytecodes.jump_on_true_pop, 7),
              # true branch
-             Bytecodes.push_constant_2,  # push the `#val`
+             BC_PUSH_CONSTANT_2,  # push the `#val`
              BC(Bytecodes.jump, 4),
              # false branch, jump_on_true target, push true
              Bytecodes.push_constant_0,
@@ -1389,7 +1356,7 @@ void BytecodeGenerationTest::testInliningWhileLoopsWithContractingBranches() {
              Bytecodes.push_field_0,
              BC(Bytecodes.jump, 4),
              # false branch, jump_on_true target, push true
-             Bytecodes.push_constant_2,
+             BC_PUSH_CONSTANT_2,
              # target of the jump in the true branch
              Bytecodes.return_self,
          ],

--- a/src/unitTests/BytecodeGenerationTest.h
+++ b/src/unitTests/BytecodeGenerationTest.h
@@ -63,6 +63,8 @@ class BytecodeGenerationTest : public CPPUNIT_NS::TestCase {
     CPPUNIT_TEST(testIfTrueIfFalseArg);
     CPPUNIT_TEST(testIfTrueIfFalseNlrArg1);
     CPPUNIT_TEST(testIfTrueIfFalseNlrArg2);
+    CPPUNIT_TEST(testInliningOfOr);
+    CPPUNIT_TEST(testInliningOfAnd);
 
     CPPUNIT_TEST(testJumpQueuesOrdering);
 
@@ -151,6 +153,12 @@ private:
     void testIfTrueIfFalseArg();
     void testIfTrueIfFalseNlrArg1();
     void testIfTrueIfFalseNlrArg2();
+
+    void testInliningOfOr();
+    void inliningOfOr(std::string selector);
+    void testInliningOfAnd();
+    void inliningOfAnd(std::string selector);
+
     void testJumpQueuesOrdering();
 
     void dump(MethodGenerationContext* mgenc);

--- a/src/unitTests/BytecodeGenerationTest.h
+++ b/src/unitTests/BytecodeGenerationTest.h
@@ -60,6 +60,9 @@ class BytecodeGenerationTest : public CPPUNIT_NS::TestCase {
     CPPUNIT_TEST(testIfInlineAndConstantBcLength);
     CPPUNIT_TEST(testIfTrueWithLiteralReturn);
     CPPUNIT_TEST(testIfTrueWithSomethingAndLiteralReturn);
+    CPPUNIT_TEST(testIfTrueIfFalseArg);
+    CPPUNIT_TEST(testIfTrueIfFalseNlrArg1);
+    CPPUNIT_TEST(testIfTrueIfFalseNlrArg2);
 
     CPPUNIT_TEST(testJumpQueuesOrdering);
 
@@ -145,6 +148,9 @@ private:
     void testIfTrueWithSomethingAndLiteralReturn();
     void ifTrueWithSomethingAndLiteralReturn(std::string literal, BC bytecode);
 
+    void testIfTrueIfFalseArg();
+    void testIfTrueIfFalseNlrArg1();
+    void testIfTrueIfFalseNlrArg2();
     void testJumpQueuesOrdering();
 
     void dump(MethodGenerationContext* mgenc);

--- a/src/unitTests/BytecodeGenerationTest.h
+++ b/src/unitTests/BytecodeGenerationTest.h
@@ -57,15 +57,18 @@ class BytecodeGenerationTest : public CPPUNIT_NS::TestCase {
     CPPUNIT_TEST(testWhileInliningWhileFalse);
     CPPUNIT_TEST(testInliningWhileLoopsWithExpandingBranches);
     CPPUNIT_TEST(testInliningWhileLoopsWithContractingBranches);
+    CPPUNIT_TEST(testIfInlineAndConstantBcLength);
+    CPPUNIT_TEST(testIfTrueWithLiteralReturn);
+    CPPUNIT_TEST(testIfTrueWithSomethingAndLiteralReturn);
 
     CPPUNIT_TEST(testJumpQueuesOrdering);
 
     CPPUNIT_TEST_SUITE_END();
 
 public:
-    inline void setUp(void) {}
+    inline void setUp() {}
 
-    inline void tearDown(void) {
+    inline void tearDown() {
         delete _cgenc;
         _cgenc = nullptr;
 
@@ -134,6 +137,13 @@ private:
 
     void testInliningWhileLoopsWithExpandingBranches();
     void testInliningWhileLoopsWithContractingBranches();
+    void testIfInlineAndConstantBcLength();
+
+    void testIfTrueWithLiteralReturn();
+    void ifTrueWithLiteralReturn(std::string literal, BC bytecode);
+
+    void testIfTrueWithSomethingAndLiteralReturn();
+    void ifTrueWithSomethingAndLiteralReturn(std::string literal, BC bytecode);
 
     void testJumpQueuesOrdering();
 

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -367,12 +367,11 @@ void VMMethod::inlineInto(MethodGenerationContext& mgenc) {
                 break;
             }
             case BC_RETURN_NON_LOCAL: {
-                const uint8_t newCtxLevel = bytecodes[i + 1] - 1;
-                if (newCtxLevel == 0) {
-                    EmitRETURNLOCAL(mgenc);
-                } else {
-                    assert(newCtxLevel == mgenc.GetMaxContextLevel());
+                if (mgenc.IsBlockMethod()) {
+                    assert(mgenc.GetMaxContextLevel() > 0);
                     EmitRETURNNONLOCAL(mgenc);
+                } else {
+                    EmitRETURNLOCAL(mgenc);
                 }
                 break;
             }


### PR DESCRIPTION
This PR adds the inlining for the various messages.

It reduces the median run time by 23% https://rebench.dev/SOMpp/compare/2dc14379c566f40d51791d0e6eca95d743952799..692cc6c47727a7fa76923daf92e0bb8c7d4be3b1