### PR TITLE
Enable LTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,11 @@ target_include_directories(SOM++ PRIVATE ${SRC_DIR})
 
 target_link_libraries(SOM++)
 
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  target_compile_options(SOM++ PRIVATE -O3 -flto)
+  target_link_options(SOM++ PRIVATE -flto)
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_executable(unittests "")
 


### PR DESCRIPTION
This PR enable link-time-based optimizations.
The -O3 is somewhat redundant with "Release", but I threw it in there just for good measures...

https://rebench.dev/SOMpp/compare/7490bff551ff58befee1b4586cf6c2af21975474..b493e7d08ece319387fd8895b245d7aec44dadcc
Change of Run time: median -12% (min. -26%, max. 9%)