### PR TITLE
Make primitives safer by not exposing the interpreter/frame if not needed

### DIFF
--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		0A3A3CB11A5D5475004CB03B /* PrimitiveLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F52032B0FA6624C00E75857 /* PrimitiveLoader.cpp */; };
 		0A3A3CB21A5D5476004CB03B /* PrimitiveContainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F5203290FA6624C00E75857 /* PrimitiveContainer.cpp */; };
 		0A3A3CB31A5D5476004CB03B /* PrimitiveLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F52032B0FA6624C00E75857 /* PrimitiveLoader.cpp */; };
+		0A5A7E912C5D45A00011C783 /* VMSafePrimitive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E902C5D45A00011C783 /* VMSafePrimitive.cpp */; };
+		0A5A7E922C5D45A00011C783 /* VMSafePrimitive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E902C5D45A00011C783 /* VMSafePrimitive.cpp */; };
 		0A67EA7519ACD43A00830E3B /* CloneObjectsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7019ACD43A00830E3B /* CloneObjectsTest.cpp */; };
 		0A67EA7619ACD43A00830E3B /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7119ACD43A00830E3B /* main.cpp */; };
 		0A67EA7819ACD43A00830E3B /* WalkObjectsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7319ACD43A00830E3B /* WalkObjectsTest.cpp */; };
@@ -220,6 +222,9 @@
 		0A335F701832D65100D7CFC8 /* Primitive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Primitive.h; sourceTree = "<group>"; };
 		0A3FABE724F4670D002D4D69 /* BasicInterpreterTests.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; name = BasicInterpreterTests.h; path = unitTests/BasicInterpreterTests.h; sourceTree = "<group>"; };
 		0A5A7E8E2C5A37450011C783 /* StringUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StringUtil.h; sourceTree = "<group>"; };
+		0A5A7E8F2C5D30390011C783 /* VMSafePrimitive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMSafePrimitive.h; sourceTree = "<group>"; };
+		0A5A7E902C5D45A00011C783 /* VMSafePrimitive.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VMSafePrimitive.cpp; sourceTree = "<group>"; };
+		0A5A7E932C5DA9A90011C783 /* Primitives.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Primitives.h; sourceTree = "<group>"; };
 		0A67EA6719ACD37200830E3B /* unittests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = unittests; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A67EA7019ACD43A00830E3B /* CloneObjectsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CloneObjectsTest.cpp; path = unitTests/CloneObjectsTest.cpp; sourceTree = "<group>"; };
 		0A67EA7119ACD43A00830E3B /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = unitTests/main.cpp; sourceTree = "<group>"; };
@@ -600,6 +605,7 @@
 				3F52032B0FA6624C00E75857 /* PrimitiveLoader.cpp */,
 				3F52032C0FA6624C00E75857 /* PrimitiveLoader.h */,
 				3F52032E0FA6624C00E75857 /* Routine.h */,
+				0A5A7E932C5DA9A90011C783 /* Primitives.h */,
 			);
 			path = primitivesCore;
 			sourceTree = "<group>";
@@ -663,6 +669,8 @@
 				3F5203560FA6624C00E75857 /* VMString.h */,
 				3F5203570FA6624C00E75857 /* VMSymbol.cpp */,
 				3F5203580FA6624C00E75857 /* VMSymbol.h */,
+				0A5A7E8F2C5D30390011C783 /* VMSafePrimitive.h */,
+				0A5A7E902C5D45A00011C783 /* VMSafePrimitive.cpp */,
 			);
 			path = vmobjects;
 			sourceTree = "<group>";
@@ -882,6 +890,7 @@
 				0A1886E71832BCDC00A2CBCA /* Heap.cpp in Sources */,
 				0A1886F71832BCF500A2CBCA /* Signature.cpp in Sources */,
 				0A1887351832C10E00A2CBCA /* MarkSweepCollector.cpp in Sources */,
+				0A5A7E912C5D45A00011C783 /* VMSafePrimitive.cpp in Sources */,
 				0A1886FB1832BCF500A2CBCA /* VMBlock.cpp in Sources */,
 				0A1887391832C12E00A2CBCA /* Timer.cpp in Sources */,
 				0A1887021832BCFA00A2CBCA /* VMMethod.cpp in Sources */,
@@ -973,6 +982,7 @@
 				0A67EA7C19ACD74800830E3B /* AbstractObject.cpp in Sources */,
 				0A67EA8E19ACD83200830E3B /* ClassGenerationContext.cpp in Sources */,
 				0A3A3CB31A5D5476004CB03B /* PrimitiveLoader.cpp in Sources */,
+				0A5A7E922C5D45A00011C783 /* VMSafePrimitive.cpp in Sources */,
 				0A67EA8219ACD74800830E3B /* VMDouble.cpp in Sources */,
 				0A67EA9A19ACD85E00830E3B /* Heap.cpp in Sources */,
 				0A67EA8119ACD74800830E3B /* VMClass.cpp in Sources */,
@@ -1034,8 +1044,8 @@
 					src,
 				);
 				OTHER_CFLAGS = (
-					"-DGC_TYPE=DEBUG_COPYING",
-					"-DUSE_TAGGING=false",
+					"-DGC_TYPE=COPYING",
+					"-DUSE_TAGGING=true",
 					"-DDEBUG",
 					"-DLOG_LEVEL=3",
 					"-Wextra",
@@ -1079,8 +1089,8 @@
 					src,
 				);
 				OTHER_CFLAGS = (
-					"-DGC_TYPE=DEBUG_COPYING",
-					"-DUSE_TAGGING=false",
+					"-DGC_TYPE=COPYING",
+					"-DUSE_TAGGING=true",
 					"-DDEBUG",
 					"-DLOG_LEVEL=3",
 					"-Wextra",

--- a/lint.sh
+++ b/lint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 clang-format-mp-18 -i --style=file --Werror src/*.cpp  src/**/*.cpp src/**/*.h
-clang-tidy-mp-18 --config-file=.clang-tidy src/**/*.cpp -- \
-  -I/opt/local/include/ -fdiagnostics-absolute-paths \
+clang-tidy-mp-18 --config-file=.clang-tidy src/**/*.cpp \
+  --fix \
+  -- -I/opt/local/include/ -fdiagnostics-absolute-paths \
   -DGC_TYPE=GENERATIONAL -DUSE_TAGGING=false -DCACHE_INTEGER=false -DUNITTESTS

--- a/src/memory/CopyingCollector.cpp
+++ b/src/memory/CopyingCollector.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 
@@ -44,7 +45,7 @@ static gc_oop_t copy_if_necessary(gc_oop_t oop) {
         obj->MarkObjectAsInvalid();
     }
 
-    obj->SetGCField((long)newObj);
+    obj->SetGCField((intptr_t)newObj);
     return tmp_ptr(newObj);
 }
 

--- a/src/primitives/Array.h
+++ b/src/primitives/Array.h
@@ -32,8 +32,5 @@
 class _Array : public PrimitiveContainer {
 public:
     _Array();
-    void New_(Interpreter*, VMFrame*);
-    void At_(Interpreter*, VMFrame*);
     void At_Put_(Interpreter*, VMFrame*);
-    void Length(Interpreter*, VMFrame*);
 };

--- a/src/primitives/Class.cpp
+++ b/src/primitives/Class.cpp
@@ -27,42 +27,41 @@
 #include "Class.h"
 
 #include "../primitivesCore/PrimitiveContainer.h"
-#include "../primitivesCore/Routine.h"
 #include "../vm/Universe.h"
+#include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMClass.h"
 #include "../vmobjects/VMFrame.h"
 #include "../vmobjects/VMSymbol.h"  // NOLINT(misc-include-cleaner) it's required to make the types complete
 
+static vm_oop_t clsNew(vm_oop_t rcvr) {
+    VMClass* self = static_cast<VMClass*>(rcvr);
+    return GetUniverse()->NewInstance(self);
+}
+
+static vm_oop_t clsName(vm_oop_t rcvr) {
+    VMClass* self = static_cast<VMClass*>(rcvr);
+    return self->GetName();
+}
+
+static vm_oop_t clsSuperclass(vm_oop_t rcvr) {
+    VMClass* self = static_cast<VMClass*>(rcvr);
+    return self->GetSuperClass();
+}
+
+static vm_oop_t clsMethods(vm_oop_t rcvr) {
+    VMClass* self = static_cast<VMClass*>(rcvr);
+    return self->GetInstanceInvokables();
+}
+
+static vm_oop_t clsFields(vm_oop_t rcvr) {
+    VMClass* self = static_cast<VMClass*>(rcvr);
+    return self->GetInstanceFields();
+}
+
 _Class::_Class() : PrimitiveContainer() {
-    SetPrimitive("new", new Routine<_Class>(this, &_Class::New, false));
-    SetPrimitive("name", new Routine<_Class>(this, &_Class::Name, false));
-    SetPrimitive("superclass",
-                 new Routine<_Class>(this, &_Class::Superclass, false));
-    SetPrimitive("fields", new Routine<_Class>(this, &_Class::Fields, false));
-    SetPrimitive("methods", new Routine<_Class>(this, &_Class::Methods, false));
-}
-
-void _Class::New(Interpreter*, VMFrame* frame) {
-    VMClass* self = static_cast<VMClass*>(frame->Pop());
-    frame->Push(GetUniverse()->NewInstance(self));
-}
-
-void _Class::Name(Interpreter*, VMFrame* frame) {
-    VMClass* self = static_cast<VMClass*>(frame->Pop());
-    frame->Push(self->GetName());
-}
-
-void _Class::Superclass(Interpreter*, VMFrame* frame) {
-    VMClass* self = static_cast<VMClass*>(frame->Pop());
-    frame->Push(self->GetSuperClass());
-}
-
-void _Class::Methods(Interpreter*, VMFrame* frame) {
-    VMClass* self = static_cast<VMClass*>(frame->Pop());
-    frame->Push(self->GetInstanceInvokables());
-}
-
-void _Class::Fields(Interpreter*, VMFrame* frame) {
-    VMClass* self = static_cast<VMClass*>(frame->Pop());
-    frame->Push(self->GetInstanceFields());
+    Add("new", &clsNew, false);
+    Add("name", &clsName, false);
+    Add("superclass", &clsSuperclass, false);
+    Add("fields", &clsFields, false);
+    Add("methods", &clsMethods, false);
 }

--- a/src/primitives/Class.h
+++ b/src/primitives/Class.h
@@ -32,10 +32,4 @@
 class _Class : public PrimitiveContainer {
 public:
     _Class();
-    void New(Interpreter*, VMFrame*);
-
-    void Name(Interpreter*, VMFrame*);
-    void Superclass(Interpreter*, VMFrame*);
-    void Fields(Interpreter*, VMFrame*);
-    void Methods(Interpreter*, VMFrame*);
 };

--- a/src/primitives/Double.h
+++ b/src/primitives/Double.h
@@ -32,25 +32,4 @@
 class _Double : public PrimitiveContainer {
 public:
     _Double();
-    void Plus(Interpreter*, VMFrame*);
-    void Minus(Interpreter*, VMFrame*);
-    void Star(Interpreter*, VMFrame*);
-    void Cos(Interpreter*, VMFrame*);
-    void Sin(Interpreter*, VMFrame*);
-    void Slashslash(Interpreter*, VMFrame*);
-    void Percent(Interpreter*, VMFrame*);
-    void And(Interpreter*, VMFrame*);
-    void Equal(Interpreter*, VMFrame*);
-    void Lowerthan(Interpreter*, VMFrame*);
-    void AsString(Interpreter*, VMFrame*);
-    void Sqrt(Interpreter*, VMFrame*);
-    void BitwiseXor(Interpreter*, VMFrame*);
-    void Round(Interpreter*, VMFrame*);
-    void AsInteger(Interpreter*, VMFrame*);
-
-    void PositiveInfinity(Interpreter*, VMFrame*);
-    void FromString(Interpreter*, VMFrame*);
-
-private:
-    double coerceDouble(vm_oop_t x);
 };

--- a/src/primitives/Integer.h
+++ b/src/primitives/Integer.h
@@ -31,33 +31,5 @@
 
 class _Integer : public PrimitiveContainer {
 public:
-    void Plus(Interpreter*, VMFrame*);
-    void Minus(Interpreter*, VMFrame*);
-    void Star(Interpreter*, VMFrame*);
-    void Rem(Interpreter*, VMFrame*);
-    void BitwiseAnd(Interpreter*, VMFrame*);
-    void BitwiseXor(Interpreter*, VMFrame*);
-    void LeftShift(Interpreter*, VMFrame*);
-    void UnsignedRightShift(Interpreter*, VMFrame*);
-    void Slash(Interpreter*, VMFrame*);
-    void Slashslash(Interpreter*, VMFrame*);
-    void Percent(Interpreter*, VMFrame*);
-    void And(Interpreter*, VMFrame*);
-    void Equal(Interpreter*, VMFrame*);
-    void EqualEqual(Interpreter*, VMFrame*);
-    void Lowerthan(Interpreter*, VMFrame*);
-    void AsString(Interpreter*, VMFrame*);
-    void AsDouble(Interpreter*, VMFrame*);
-    void As32BitSigned(Interpreter*, VMFrame*);
-    void As32BitUnsigned(Interpreter*, VMFrame*);
-    void Sqrt(Interpreter*, VMFrame*);
-    void AtRandom(Interpreter*, VMFrame*);
-
-    void FromString(Interpreter*, VMFrame*);
-
-    _Integer(void);
-
-private:
-    void resendAsDouble(Interpreter* interp, const char* op, vm_oop_t left,
-                        VMDouble* right);
+    _Integer();
 };

--- a/src/primitives/Method.cpp
+++ b/src/primitives/Method.cpp
@@ -11,22 +11,14 @@
 #include "../vmobjects/VMMethod.h"
 #include "../vmobjects/VMSymbol.h"  // NOLINT(misc-include-cleaner) it's required to make the types complete
 
-_Method::_Method() : PrimitiveContainer() {
-    SetPrimitive("signature",
-                 new Routine<_Method>(this, &_Method::Signature, false));
-    SetPrimitive("holder", new Routine<_Method>(this, &_Method::Holder, false));
-    SetPrimitive("invokeOn_with_",
-                 new Routine<_Method>(this, &_Method::InvokeOn_With_, false));
+static vm_oop_t mHolder(vm_oop_t rcvr) {
+    VMMethod* self = static_cast<VMMethod*>(rcvr);
+    return self->GetHolder();
 }
 
-void _Method::Holder(Interpreter*, VMFrame* frame) {
-    VMMethod* self = static_cast<VMMethod*>(frame->Pop());
-    frame->Push(self->GetHolder());
-}
-
-void _Method::Signature(Interpreter*, VMFrame* frame) {
-    VMMethod* self = static_cast<VMMethod*>(frame->Pop());
-    frame->Push(self->GetSignature());
+static vm_oop_t mSignature(vm_oop_t rcvr) {
+    VMMethod* self = static_cast<VMMethod*>(rcvr);
+    return self->GetSignature();
 }
 
 void _Method::InvokeOn_With_(Interpreter* interp, VMFrame* frame) {
@@ -43,4 +35,11 @@ void _Method::InvokeOn_With_(Interpreter* interp, VMFrame* frame) {
         frame->Push(arg);
     }
     mthd->Invoke(interp, frame);
+}
+
+_Method::_Method() : PrimitiveContainer() {
+    Add("signature", &mSignature, false);
+    Add("holder", &mHolder, false);
+    SetPrimitive("invokeOn_with_",
+                 new Routine<_Method>(this, &_Method::InvokeOn_With_, false));
 }

--- a/src/primitives/Method.h
+++ b/src/primitives/Method.h
@@ -7,7 +7,5 @@ class _Method : public PrimitiveContainer {
 public:
     _Method(void);
 
-    void Signature(Interpreter*, VMFrame*);
-    void Holder(Interpreter*, VMFrame*);
     void InvokeOn_With_(Interpreter*, VMFrame*);
 };

--- a/src/primitives/Object.h
+++ b/src/primitives/Object.h
@@ -32,20 +32,10 @@
 class _Object : public PrimitiveContainer {
 public:
     _Object();
-    void Equalequal(Interpreter*, VMFrame*);
-    void ObjectSize(Interpreter*, VMFrame*);
-    void Hashcode(Interpreter*, VMFrame*);
-    void Inspect(Interpreter*, VMFrame*);
-    void Halt(Interpreter*, VMFrame*);
-
     void Perform(Interpreter*, VMFrame*);
     void PerformWithArguments(Interpreter*, VMFrame*);
     void PerformInSuperclass(Interpreter*, VMFrame*);
     void PerformWithArgumentsInSuperclass(Interpreter*, VMFrame*);
 
-    void InstVarAt(Interpreter*, VMFrame*);
     void InstVarAtPut(Interpreter*, VMFrame*);
-    void InstVarNamed(Interpreter*, VMFrame*);
-
-    void Class(Interpreter*, VMFrame*);
 };

--- a/src/primitives/Primitive.cpp
+++ b/src/primitives/Primitive.cpp
@@ -10,24 +10,14 @@
 #include "../vmobjects/VMMethod.h"
 #include "../vmobjects/VMSymbol.h"  // NOLINT(misc-include-cleaner) it's required to make the types complete
 
-_Primitive::_Primitive() : PrimitiveContainer() {
-    SetPrimitive("signature",
-                 new Routine<_Primitive>(this, &_Primitive::Signature, false));
-    SetPrimitive("holder",
-                 new Routine<_Primitive>(this, &_Primitive::Holder, false));
-    SetPrimitive(
-        "invokeOn_with_",
-        new Routine<_Primitive>(this, &_Primitive::InvokeOn_With_, false));
+static vm_oop_t pHolder(vm_oop_t rcvr) {
+    VMInvokable* self = static_cast<VMInvokable*>(rcvr);
+    return self->GetHolder();
 }
 
-void _Primitive::Holder(Interpreter*, VMFrame* frame) {
-    VMInvokable* self = static_cast<VMInvokable*>(frame->Pop());
-    frame->Push(self->GetHolder());
-}
-
-void _Primitive::Signature(Interpreter*, VMFrame* frame) {
-    VMInvokable* self = static_cast<VMInvokable*>(frame->Pop());
-    frame->Push(self->GetSignature());
+static vm_oop_t pSignature(vm_oop_t rcvr) {
+    VMInvokable* self = static_cast<VMInvokable*>(rcvr);
+    return self->GetSignature();
 }
 
 void _Primitive::InvokeOn_With_(Interpreter* interp, VMFrame* frame) {
@@ -44,4 +34,12 @@ void _Primitive::InvokeOn_With_(Interpreter* interp, VMFrame* frame) {
         frame->Push(arg);
     }
     mthd->Invoke(interp, frame);
+}
+
+_Primitive::_Primitive() : PrimitiveContainer() {
+    Add("signature", &pSignature, false);
+    Add("holder", &pHolder, false);
+    SetPrimitive(
+        "invokeOn_with_",
+        new Routine<_Primitive>(this, &_Primitive::InvokeOn_With_, false));
 }

--- a/src/primitives/Primitive.h
+++ b/src/primitives/Primitive.h
@@ -7,7 +7,5 @@ class _Primitive : public PrimitiveContainer {
 public:
     _Primitive(void);
 
-    void Signature(Interpreter*, VMFrame*);
-    void Holder(Interpreter*, VMFrame*);
     void InvokeOn_With_(Interpreter*, VMFrame*);
 };

--- a/src/primitives/String.h
+++ b/src/primitives/String.h
@@ -32,14 +32,5 @@
 class _String : public PrimitiveContainer {
 public:
     _String();
-    void Concatenate_(Interpreter*, VMFrame*);
-    void AsSymbol(Interpreter*, VMFrame*);
-    void Hashcode(Interpreter*, VMFrame*);
-    void Length(Interpreter*, VMFrame*);
-    void Equal(Interpreter*, VMFrame*);
     void PrimSubstringFrom_to_(Interpreter*, VMFrame*);
-
-    void IsWhiteSpace(Interpreter*, VMFrame*);
-    void IsLetters(Interpreter*, VMFrame*);
-    void IsDigits(Interpreter*, VMFrame*);
 };

--- a/src/primitives/Symbol.cpp
+++ b/src/primitives/Symbol.cpp
@@ -29,19 +29,18 @@
 #include <string>
 
 #include "../primitivesCore/PrimitiveContainer.h"
-#include "../primitivesCore/Routine.h"
 #include "../vm/Universe.h"
+#include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMFrame.h"
 #include "../vmobjects/VMSymbol.h"
 
-void _Symbol::AsString(Interpreter*, VMFrame* frame) {
-    VMSymbol* sym = static_cast<VMSymbol*>(frame->Pop());
+static vm_oop_t symAsString(vm_oop_t rcvr) {
+    VMSymbol* sym = static_cast<VMSymbol*>(rcvr);
 
     std::string str = sym->GetStdString();
-    frame->Push(GetUniverse()->NewString(str));
+    return GetUniverse()->NewString(str);
 }
 
 _Symbol::_Symbol() : PrimitiveContainer() {
-    SetPrimitive("asString",
-                 new Routine<_Symbol>(this, &_Symbol::AsString, false));
+    Add("asString", &symAsString, false);
 }

--- a/src/primitives/Symbol.h
+++ b/src/primitives/Symbol.h
@@ -32,5 +32,4 @@
 class _Symbol : public PrimitiveContainer {
 public:
     _Symbol();
-    void AsString(Interpreter*, VMFrame*);
 };

--- a/src/primitives/System.h
+++ b/src/primitives/System.h
@@ -36,23 +36,6 @@ public:
     _System(void);
     virtual ~_System();
 
-    void Global_(Interpreter*, VMFrame*);
     void Global_put_(Interpreter*, VMFrame*);
-    void HasGlobal_(Interpreter*, VMFrame*);
-    void Load_(Interpreter*, VMFrame*);
-    void Exit_(Interpreter*, VMFrame*);
-    void PrintString_(Interpreter*, VMFrame*);
-    void PrintNewline(Interpreter*, VMFrame*);
-    void PrintNewline_(Interpreter*, VMFrame*);
-    void ErrorPrint_(Interpreter*, VMFrame*);
-    void ErrorPrintNewline_(Interpreter*, VMFrame*);
-    void Time(Interpreter*, VMFrame*);
-    void Ticks(Interpreter*, VMFrame*);
-    void FullGC(Interpreter*, VMFrame*);
-
-    void LoadFile_(Interpreter*, VMFrame*);
     void PrintStackTrace(Interpreter*, VMFrame*);
-
-private:
-    struct timeval start_time;
 };

--- a/src/primitivesCore/PrimitiveContainer.cpp
+++ b/src/primitivesCore/PrimitiveContainer.cpp
@@ -30,10 +30,23 @@
 #include <string>
 
 #include "../vmobjects/PrimitiveRoutine.h"
+#include "Primitives.h"
 
 void PrimitiveContainer::SetPrimitive(const char* name,
                                       PrimitiveRoutine* routine) {
     methods[std::string(name)] = routine;
+}
+
+void PrimitiveContainer::Add(const char* name,
+                             BinaryPrimitiveRoutine routine,
+                             bool classSide) {
+    binaryPrims[std::string(name)] = {routine, classSide};
+}
+
+void PrimitiveContainer::Add(const char* name,
+                             UnaryPrimitiveRoutine routine,
+                             bool classSide) {
+    unaryPrims[std::string(name)] = {routine, classSide};
 }
 
 PrimitiveRoutine* PrimitiveContainer::GetPrimitive(
@@ -42,4 +55,18 @@ PrimitiveRoutine* PrimitiveContainer::GetPrimitive(
         return methods[routineName];
     }
     return nullptr;
+}
+
+BinaryPrim PrimitiveContainer::GetSafeBinary(const std::string& routineName) {
+    if (binaryPrims.find(routineName) != binaryPrims.end()) {
+        return binaryPrims[routineName];
+    }
+    return BinaryPrim();
+}
+
+UnaryPrim PrimitiveContainer::GetSafeUnary(const std::string& routineName) {
+    if (unaryPrims.find(routineName) != unaryPrims.end()) {
+        return unaryPrims[routineName];
+    }
+    return UnaryPrim();
 }

--- a/src/primitivesCore/PrimitiveContainer.cpp
+++ b/src/primitivesCore/PrimitiveContainer.cpp
@@ -38,5 +38,8 @@ void PrimitiveContainer::SetPrimitive(const char* name,
 
 PrimitiveRoutine* PrimitiveContainer::GetPrimitive(
     const std::string& routineName) {
-    return methods[routineName];
+    if (methods.find(routineName) != methods.end()) {
+        return methods[routineName];
+    }
+    return nullptr;
 }

--- a/src/primitivesCore/PrimitiveContainer.h
+++ b/src/primitivesCore/PrimitiveContainer.h
@@ -30,6 +30,7 @@
 
 #include "../misc/defs.h"
 #include "../vmobjects/PrimitiveRoutine.h"
+#include "Primitives.h"
 
 /// Base class for all container objects holding SOM++ primitives.
 // Primitive container classes need to initialize a std::map<StdString,
@@ -50,6 +51,14 @@ public:
 
     PrimitiveRoutine* GetPrimitive(const std::string& routineName);
 
+    UnaryPrim GetSafeUnary(const std::string& routineName);
+    BinaryPrim GetSafeBinary(const std::string& routineName);
+
+    void Add(const char* name, UnaryPrimitiveRoutine, bool classSide);
+    void Add(const char* name, BinaryPrimitiveRoutine, bool classSide);
+
 private:
     std::map<std::string, PrimitiveRoutine*> methods{};
+    std::map<std::string, UnaryPrim> unaryPrims{};
+    std::map<std::string, BinaryPrim> binaryPrims{};
 };

--- a/src/primitivesCore/PrimitiveContainer.h
+++ b/src/primitivesCore/PrimitiveContainer.h
@@ -46,9 +46,9 @@ public:
     // class is defined in vmobjects/PrimitiveRoutine. Basically, the only
     // requirement for those objects is to implement:
     //   virtual void operator()(VMObject*, VMFrame*)
-    virtual void SetPrimitive(const char* name, PrimitiveRoutine* routine);
+    void SetPrimitive(const char* name, PrimitiveRoutine* routine);
 
-    virtual PrimitiveRoutine* GetPrimitive(const std::string& routineName);
+    PrimitiveRoutine* GetPrimitive(const std::string& routineName);
 
 private:
     std::map<std::string, PrimitiveRoutine*> methods{};

--- a/src/primitivesCore/PrimitiveLoader.cpp
+++ b/src/primitivesCore/PrimitiveLoader.cpp
@@ -43,6 +43,7 @@
 #include "../vm/Print.h"
 #include "../vmobjects/PrimitiveRoutine.h"
 #include "PrimitiveContainer.h"
+#include "Primitives.h"
 
 PrimitiveLoader PrimitiveLoader::loader;
 
@@ -83,6 +84,38 @@ PrimitiveRoutine* PrimitiveLoader::GetPrimitiveRoutine(const std::string& cname,
                                                        const std::string& mname,
                                                        bool isPrimitive) {
     return loader.getPrimitiveRoutine(cname, mname, isPrimitive);
+}
+
+UnaryPrim PrimitiveLoader::GetUnaryPrim(const std::string& cname,
+                                        const std::string& mname) {
+    return loader.getUnaryPrim(cname, mname);
+}
+
+UnaryPrim PrimitiveLoader::getUnaryPrim(const std::string& cname,
+                                        const std::string& mname) {
+    if (primitiveObjects.find(cname) == primitiveObjects.end()) {
+        ErrorPrint("Primitive object not found for name: " + cname + "\n");
+        return UnaryPrim();
+    }
+
+    PrimitiveContainer* primitive = primitiveObjects[cname];
+    return primitive->GetSafeUnary(mname);
+}
+
+BinaryPrim PrimitiveLoader::GetBinaryPrim(const std::string& cname,
+                                          const std::string& mname) {
+    return loader.getBinaryPrim(cname, mname);
+}
+
+BinaryPrim PrimitiveLoader::getBinaryPrim(const std::string& cname,
+                                          const std::string& mname) {
+    if (primitiveObjects.find(cname) == primitiveObjects.end()) {
+        ErrorPrint("Primitive object not found for name: " + cname + "\n");
+        return BinaryPrim();
+    }
+
+    PrimitiveContainer* primitive = primitiveObjects[cname];
+    return primitive->GetSafeBinary(mname);
 }
 
 PrimitiveRoutine* PrimitiveLoader::getPrimitiveRoutine(const std::string& cname,

--- a/src/primitivesCore/PrimitiveLoader.cpp
+++ b/src/primitivesCore/PrimitiveLoader.cpp
@@ -61,10 +61,8 @@ PrimitiveLoader::PrimitiveLoader() {
 }
 
 PrimitiveLoader::~PrimitiveLoader() {
-    map<std::string, PrimitiveContainer*>::iterator it =
-        primitiveObjects.begin();
-    for (; it != primitiveObjects.end(); ++it) {
-        delete it->second;
+    for (const auto& p : primitiveObjects) {
+        delete p.second;
     }
 }
 
@@ -74,7 +72,7 @@ void PrimitiveLoader::AddPrimitiveObject(const std::string& name,
 }
 
 bool PrimitiveLoader::supportsClass(const std::string& name) {
-    return primitiveObjects[name] != nullptr;
+    return primitiveObjects.find(name) != primitiveObjects.end();
 }
 
 bool PrimitiveLoader::SupportsClass(const std::string& name) {
@@ -90,11 +88,12 @@ PrimitiveRoutine* PrimitiveLoader::GetPrimitiveRoutine(const std::string& cname,
 PrimitiveRoutine* PrimitiveLoader::getPrimitiveRoutine(const std::string& cname,
                                                        const std::string& mname,
                                                        bool isPrimitive) {
-    PrimitiveContainer* primitive = primitiveObjects[cname];
-    if (!primitive) {
+    if (primitiveObjects.find(cname) == primitiveObjects.end()) {
         ErrorPrint("Primitive object not found for name: " + cname + "\n");
         return nullptr;
     }
+
+    PrimitiveContainer* primitive = primitiveObjects[cname];
     PrimitiveRoutine* result = primitive->GetPrimitive(mname);
     if (!result) {
         if (isPrimitive) {

--- a/src/primitivesCore/PrimitiveLoader.h
+++ b/src/primitivesCore/PrimitiveLoader.h
@@ -29,9 +29,11 @@
 #include <map>
 
 #include "../misc/defs.h"
+#include "Primitives.h"
 
 class PrimitiveContainer;
 class PrimitiveRoutine;
+class BinaryPrim;
 
 /// Core class for primitive loading.
 // In order to implement new primitive libraries, you can use this class.
@@ -52,11 +54,21 @@ public:
                                                  const std::string& mname,
                                                  bool isPrimitive);
 
+    static BinaryPrim GetBinaryPrim(const std::string& cname,
+                                    const std::string& mname);
+    static UnaryPrim GetUnaryPrim(const std::string& cname,
+                                  const std::string& mname);
+
 private:
     bool supportsClass(const std::string& name);
     PrimitiveRoutine* getPrimitiveRoutine(const std::string& cname,
                                           const std::string& mname,
                                           bool isPrimitive);
+
+    UnaryPrim getUnaryPrim(const std::string& cname, const std::string& mname);
+
+    BinaryPrim getBinaryPrim(const std::string& cname,
+                             const std::string& mname);
 
     std::map<StdString, PrimitiveContainer*> primitiveObjects{};
 

--- a/src/primitivesCore/Primitives.h
+++ b/src/primitivesCore/Primitives.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "../vmobjects/ObjectFormats.h"
+
+using UnaryPrimitiveRoutine = vm_oop_t(vm_oop_t);
+using BinaryPrimitiveRoutine = vm_oop_t(vm_oop_t, vm_oop_t);
+
+class UnaryPrim {
+public:
+    UnaryPrim(UnaryPrimitiveRoutine ptr, bool classSide)
+        : pointer(ptr), isClassSide(classSide) {}
+    explicit UnaryPrim() : pointer(nullptr), isClassSide(false) {}
+
+    bool IsValid() const { return pointer != nullptr; }
+
+    void MarkObjectAsInvalid() { pointer = nullptr; }
+
+    vm_oop_t (*pointer)(vm_oop_t);
+
+    bool isClassSide;
+};
+
+class BinaryPrim {
+public:
+    BinaryPrim(BinaryPrimitiveRoutine ptr, bool classSide)
+        : pointer(ptr), isClassSide(classSide) {}
+    explicit BinaryPrim() : pointer(nullptr), isClassSide(false) {}
+
+    bool IsValid() const { return pointer != nullptr; }
+
+    void MarkObjectAsInvalid() { pointer = nullptr; }
+
+    vm_oop_t (*pointer)(vm_oop_t, vm_oop_t);
+
+    bool isClassSide;
+};

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -113,7 +113,7 @@ bool IsVMSymbol(vm_oop_t obj) {
     return get_vtable(AS_OBJ(obj)) == vt_symbol;
 }
 
-void obtain_vtables_of_known_classes(VMSymbol* className) {
+void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
     // These objects are allocated on the heap. So, they will get GC'ed soon
     // enough.
     VMArray* arr = new (GetHeap<HEAP_CLS>(), 0) VMArray(0, 0);
@@ -142,11 +142,12 @@ void obtain_vtables_of_known_classes(VMSymbol* className) {
     vt_method = get_vtable(mth);
     vt_object = get_vtable(load_ptr(nilObject));
 
-    VMPrimitive* prm = new (GetHeap<HEAP_CLS>(), 0) VMPrimitive(className);
+    VMPrimitive* prm =
+        new (GetHeap<HEAP_CLS>(), 0) VMPrimitive(someValidSymbol);
     vt_primitive = get_vtable(prm);
 
     VMString* str =
         new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);
     vt_string = get_vtable(str);
-    vt_symbol = get_vtable(className);
+    vt_symbol = get_vtable(someValidSymbol);
 }

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -15,6 +15,7 @@
 #include "../vmobjects/VMInteger.h"
 #include "../vmobjects/VMMethod.h"
 #include "../vmobjects/VMObjectBase.h"  // NOLINT(misc-include-cleaner) needed for some GCs
+#include "../vmobjects/VMSafePrimitive.h"
 #include "../vmobjects/VMString.h"
 #include "../vmobjects/VMSymbol.h"
 #include "Globals.h"
@@ -29,6 +30,8 @@ void* vt_integer;
 void* vt_method;
 void* vt_object;
 void* vt_primitive;
+void* vt_safe_un_primitive;
+void* vt_safe_bin_primitive;
 void* vt_string;
 void* vt_symbol;
 
@@ -59,7 +62,8 @@ bool IsValidObject(vm_oop_t obj) {
     bool b = vt == vt_array || vt == vt_block || vt == vt_class ||
              vt == vt_double || vt == vt_eval_primitive || vt == vt_frame ||
              vt == vt_integer || vt == vt_method || vt == vt_object ||
-             vt == vt_primitive || vt == vt_string || vt == vt_symbol;
+             vt == vt_primitive || vt == vt_safe_un_primitive ||
+             vt == vt_safe_bin_primitive || vt == vt_string || vt == vt_symbol;
     if (!b) {
         assert(b && "Expected vtable to be one of the known ones.");
         return false;
@@ -95,6 +99,8 @@ void set_vt_to_null() {
     vt_method = nullptr;
     vt_object = nullptr;
     vt_primitive = nullptr;
+    vt_safe_un_primitive = nullptr;
+    vt_safe_bin_primitive = nullptr;
     vt_string = nullptr;
     vt_symbol = nullptr;
 }
@@ -145,6 +151,14 @@ void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
     VMPrimitive* prm =
         new (GetHeap<HEAP_CLS>(), 0) VMPrimitive(someValidSymbol);
     vt_primitive = get_vtable(prm);
+
+    VMSafeUnaryPrimitive* sbp1 = new (GetHeap<HEAP_CLS>(), 0)
+        VMSafeUnaryPrimitive(someValidSymbol, UnaryPrim());
+    vt_safe_un_primitive = get_vtable(sbp1);
+
+    VMSafeBinaryPrimitive* sbp2 = new (GetHeap<HEAP_CLS>(), 0)
+        VMSafeBinaryPrimitive(someValidSymbol, BinaryPrim());
+    vt_safe_bin_primitive = get_vtable(sbp2);
 
     VMString* str =
         new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -439,12 +439,11 @@ VMObject* Universe::InitializeGlobals() {
     // Fix up objectClass
     load_ptr(objectClass)->SetSuperClass(nil);
 
-    obtain_vtables_of_known_classes(nil->GetClass()->GetName());
-
 #if USE_TAGGING
     GlobalBox::updateIntegerBox(NewInteger(1));
 #endif
     InitializeSymbols();
+    obtain_vtables_of_known_classes(load_ptr(symbolSelf));
 
     LoadSystemClass(load_ptr(objectClass));
     LoadSystemClass(load_ptr(classClass));

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -86,6 +86,9 @@ class VMInvokable;
 class VMMethod;
 class VMObject;
 class VMPrimitive;
+class VMSafePrimitive;
+class VMSafeUnaryPrimitive;
+class VMSafeBinaryPrimitive;
 class VMString;
 class VMSymbol;
 
@@ -142,6 +145,9 @@ class GCInvokable      : public GCAbstractObject { public: typedef VMInvokable  
 class GCMethod         : public GCInvokable      { public: typedef VMMethod         Loaded; };
 class GCPrimitive      : public GCInvokable      { public: typedef VMPrimitive      Loaded; };
 class GCEvaluationPrimitive : public GCPrimitive { public: typedef VMEvaluationPrimitive Loaded; };
+class GCSafePrimitive  : public GCInvokable      { public: typedef VMSafePrimitive  Loaded; };
+class GCSafeUnaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeUnaryPrimitive  Loaded; };
+class GCSafeBinaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeBinaryPrimitive  Loaded; };
 class GCString         : public GCAbstractObject { public: typedef VMString         Loaded; };
 class GCSymbol         : public GCString         { public: typedef VMSymbol         Loaded; };
 // clang-format on

--- a/src/vmobjects/VMInvokable.h
+++ b/src/vmobjects/VMInvokable.h
@@ -48,6 +48,11 @@ public:
 
     void WalkObjects(walk_heap_fn) override;
 
+    void MarkObjectAsInvalid() override {
+        signature = (GCSymbol*)INVALID_GC_POINTER;
+        holder = (GCClass*)INVALID_GC_POINTER;
+    }
+
     make_testable(public);
 
     int64_t hash;

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -496,7 +496,7 @@ void VMMethod::prepareBackJumpToCurrentAddress(
 void VMMethod::AdaptAfterOuterInlined(
     uint8_t removedCtxLevel, MethodGenerationContext& mgencWithInlined) {
     size_t i = 0;
-    long numBytecodes = GetNumberOfBytecodes();
+    size_t numBytecodes = GetNumberOfBytecodes();
 
     while (i < numBytecodes) {
         uint8_t bytecode = bytecodes[i];

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -150,6 +150,7 @@ public:
     void Invoke(Interpreter* interp, VMFrame* frame) override;
 
     void MarkObjectAsInvalid() override {
+        VMInvokable::MarkObjectAsInvalid();
         indexableFields = (gc_oop_t*)INVALID_GC_POINTER;
     }
 

--- a/src/vmobjects/VMSafePrimitive.cpp
+++ b/src/vmobjects/VMSafePrimitive.cpp
@@ -1,0 +1,55 @@
+#include "VMSafePrimitive.h"
+
+#include <string>
+
+#include "../memory/Heap.h"
+#include "../misc/defs.h"
+#include "../primitivesCore/Primitives.h"
+#include "AbstractObject.h"
+#include "ObjectFormats.h"
+#include "VMClass.h"
+#include "VMFrame.h"
+#include "VMSymbol.h"
+
+VMSafePrimitive* VMSafePrimitive::GetSafeUnary(VMSymbol* sig, UnaryPrim prim) {
+    VMSafeUnaryPrimitive* p =
+        new (GetHeap<HEAP_CLS>(), 0) VMSafeUnaryPrimitive(sig, prim);
+    return p;
+}
+
+void VMSafeUnaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
+    vm_oop_t receiverObj = frame->Pop();
+
+    frame->Push(prim.pointer(receiverObj));
+}
+
+VMSafePrimitive* VMSafePrimitive::GetSafeBinary(VMSymbol* sig,
+                                                BinaryPrim prim) {
+    VMSafeBinaryPrimitive* p =
+        new (GetHeap<HEAP_CLS>(), 0) VMSafeBinaryPrimitive(sig, prim);
+    return p;
+}
+
+void VMSafeBinaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
+    vm_oop_t rightObj = frame->Pop();
+    vm_oop_t leftObj = frame->Pop();
+
+    frame->Push(prim.pointer(leftObj, rightObj));
+}
+
+std::string VMSafePrimitive::AsDebugString() const {
+    return "SafePrim(" + GetClass()->GetName()->GetStdString() + ">>#" +
+           GetSignature()->GetStdString() + ")";
+}
+
+AbstractVMObject* VMSafeUnaryPrimitive::CloneForMovingGC() const {
+    VMSafeUnaryPrimitive* prim =
+        new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMSafeUnaryPrimitive(*this);
+    return prim;
+}
+
+AbstractVMObject* VMSafeBinaryPrimitive::CloneForMovingGC() const {
+    VMSafeBinaryPrimitive* prim =
+        new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMSafeBinaryPrimitive(*this);
+    return prim;
+}

--- a/src/vmobjects/VMSafePrimitive.h
+++ b/src/vmobjects/VMSafePrimitive.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "../primitivesCore/PrimitiveContainer.h"
+
+class VMSafePrimitive : public VMInvokable {
+public:
+    typedef GCSafePrimitive Stored;
+
+    VMSafePrimitive(VMSymbol* sig) : VMInvokable(sig) {}
+
+    VMClass* GetClass() const override { return load_ptr(primitiveClass); }
+
+    inline size_t GetObjectSize() const override {
+        return sizeof(VMSafePrimitive);
+    }
+
+    bool IsPrimitive() const final { return true; };
+
+    static VMSafePrimitive* GetSafeBinary(VMSymbol* sig, BinaryPrim prim);
+    static VMSafePrimitive* GetSafeUnary(VMSymbol* sig, UnaryPrim prim);
+
+    std::string AsDebugString() const final;
+};
+
+class VMSafeUnaryPrimitive : public VMSafePrimitive {
+public:
+    typedef GCSafeUnaryPrimitive Stored;
+
+    VMSafeUnaryPrimitive(VMSymbol* sig, UnaryPrim prim)
+        : VMSafePrimitive(sig), prim(prim) {
+        write_barrier(this, sig);
+    }
+
+    VMClass* GetClass() const override { return load_ptr(primitiveClass); }
+
+    inline size_t GetObjectSize() const override {
+        return sizeof(VMSafeUnaryPrimitive);
+    }
+
+    void Invoke(Interpreter*, VMFrame*) override;
+
+    AbstractVMObject* CloneForMovingGC() const final;
+
+    void MarkObjectAsInvalid() final {
+        VMSafePrimitive::MarkObjectAsInvalid();
+        prim.MarkObjectAsInvalid();
+    }
+
+    bool IsMarkedInvalid() const final { return !prim.IsValid(); }
+
+private:
+    UnaryPrim prim;
+};
+
+class VMSafeBinaryPrimitive : public VMSafePrimitive {
+public:
+    typedef GCSafeBinaryPrimitive Stored;
+
+    VMSafeBinaryPrimitive(VMSymbol* sig, BinaryPrim prim)
+        : VMSafePrimitive(sig), prim(prim) {
+        write_barrier(this, sig);
+    }
+
+    VMClass* GetClass() const override { return load_ptr(primitiveClass); }
+
+    inline size_t GetObjectSize() const override {
+        return sizeof(VMSafeBinaryPrimitive);
+    }
+
+    void Invoke(Interpreter*, VMFrame*) override;
+
+    AbstractVMObject* CloneForMovingGC() const final;
+
+    void MarkObjectAsInvalid() final {
+        VMSafePrimitive::MarkObjectAsInvalid();
+        prim.MarkObjectAsInvalid();
+    }
+
+    bool IsMarkedInvalid() const final { return !prim.IsValid(); }
+
+private:
+    BinaryPrim prim;
+};


### PR DESCRIPTION
This simplifies primitive implementation, and also seems to avoid one extra indirection the current implementation had.

This is not a complete replacement of the previous approach however.

Remaining bits that should be done eventually:
 - add support for ternary prims
 - add an unsafe version of this and block handling, to unify the mechanism and remove the old one completely