### PR TITLE
Enable all Generational configurations, but run them on zullie1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,12 @@ variables:
   PYTHONUNBUFFERED: "true"
 
 before_script:
-  - git submodule update --init
+  - |+
+    git submodule update --init
+    if [ "$MACHINE" = "zullie1" ]; then
+      export PATH=/opt/local/bin:/Users/gitlab-runner/Library/Python/3.12/bin:$PATH
+      export MP='-mp'
+    fi
 
 build_and_test:
   stage: build-and-test
@@ -29,11 +34,13 @@ build_and_test:
         GC: [COPYING]
         INTEGERS: ["-DUSE_TAGGING=true"]
 
-      # Generational GC is broken it seems, use a configuration that mostly works
-      - MACHINE: [yuria, yuria2, yuria3]
+      - MACHINE: [zullie1]
         COMPILER: [clang]
         GC: [GENERATIONAL]
-        INTEGERS: ["-DUSE_TAGGING=false -DCACHE_INTEGER=false"]
+        INTEGERS:
+          - "-DUSE_TAGGING=true"
+          - "-DUSE_TAGGING=false -DCACHE_INTEGER=true"
+          - "-DUSE_TAGGING=false -DCACHE_INTEGER=false"
 
       # Mark-Sweep working, but not super exciting
       - MACHINE: [yuria, yuria2, yuria3]
@@ -47,7 +54,7 @@ build_and_test:
     - rm -rf debug && mkdir debug
 
     - if [ "$COMPILER" = "gcc" ];   then export CC=gcc-13;   export CXX=g++-13; fi
-    - if [ "$COMPILER" = "clang" ]; then export CC=clang-17; export CXX=clang++-17; fi
+    - if [ "$COMPILER" = "clang" ]; then export CC=clang$MP-17; export CXX=clang++$MP-17; fi
 
     # compose a name for this configuration
     - |+
@@ -64,13 +71,13 @@ build_and_test:
 
     - cd release
     - cmake .. $INTEGERS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Release
-    - make -j10
+    - make -j
     - mv SOM++ ../$NAME
     - cd ..
 
     - cd debug
     - cmake .. $INTEGERS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Debug
-    - make -j10
+    - make -j
     - ./SOM++ -cp ../Smalltalk ../TestSuite/TestHarness.som
     - ./unittests -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
     - cd ..
@@ -80,13 +87,19 @@ build_and_test:
       if [ "$COMPILER" = "clang" ]; then
         # this is to load balance the SomSom testing
         # only when compiling with Clang, and only on one machine for each integer configuration
-        if [ "$MACHINE $INTEGERS" = "yuria -DUSE_TAGGING=true" ] || [ "$MACHINE $INTEGERS" = "yuria2 -DUSE_TAGGING=false -DCACHE_INTEGER=true" ] || [ "$MACHINE $INTEGERS" = "yuria3 -DUSE_TAGGING=false -DCACHE_INTEGER=false" ]; then
+        if [ "$MACHINE $INTEGERS" = "zullie1 -DUSE_TAGGING=true" ] || [ "$MACHINE $INTEGERS" = "yuria2 -DUSE_TAGGING=false -DCACHE_INTEGER=true" ] || [ "$MACHINE $INTEGERS" = "yuria3 -DUSE_TAGGING=false -DCACHE_INTEGER=false" ]; then
           ./$NAME -cp Smalltalk:TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects core-lib/SomSom/tests/SomSomTests.som
         fi
       fi
 
     # run the benchmarks
-    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf all "e:${NAME}" "m:$MACHINE"
+    - |+
+      if [ "$MACHINE" = "zullie1" ]; then
+        M=''
+      else
+        M="m:$MACHINE"
+      fi
+      rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf all "e:${NAME}" $M
 
 complete_benchmarking:
   stage: benchmark-completion

--- a/rebench.conf
+++ b/rebench.conf
@@ -19,44 +19,44 @@ runs:
 benchmark_suites:
     macro:
         gauge_adapter: RebenchLog
-        command: &MACRO_CMD "-cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
+        command: "-H16MB -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
         iterations: 10
         benchmarks:
             - Richards:     {iterations: 5, extra_args:   1, machines: [yuria3]}
-            - DeltaBlue:    {extra_args:  50, machines: [yuria2]}
-            - NBody:        {extra_args: 500, machines: [yuria3]}
-            - JsonSmall:    {extra_args:   1, machines: [yuria ]}
-            - GraphSearch:  {extra_args:   4, machines: [yuria2]}
-            - PageRank:     {extra_args:  40, machines: [yuria3]}
+            - DeltaBlue:    {extra_args: 500, machines: [yuria2]}
+            - NBody:        {extra_args: 5000, machines: [yuria3]}
+            - JsonSmall:    {extra_args:  10, machines: [yuria ]}
+            - GraphSearch:  {extra_args:   7, machines: [yuria2]}
+            - PageRank:     {extra_args: 150, machines: [yuria3]}
 
     micro:
         gauge_adapter: RebenchLog
         command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures:Examples/Benchmarks/TestSuite Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
         iterations: 10
         benchmarks:
-            - Fannkuch:     {extra_args:  6, machines: [yuria ]}
+            - Fannkuch:     {extra_args:  7, machines: [yuria ]}
             - Fibonacci:    {extra_args:  3, machines: [yuria2]}
-            - Dispatch:     {extra_args:  2, machines: [yuria3]}
-            - Bounce:       {extra_args:  2, machines: [yuria ]}
-            - Loop:         {extra_args:  5, machines: [yuria2]}
+            - Dispatch:     {extra_args: 20, machines: [yuria3]}
+            - Bounce:       {extra_args: 10, machines: [yuria ]}
+            - Loop:         {extra_args: 50, machines: [yuria2]}
             - Permute:      {extra_args:  3, machines: [yuria3]}
-            - Queens:       {extra_args:  2, machines: [yuria ]}
+            - Queens:       {extra_args: 10, machines: [yuria ]}
             - List:         {extra_args:  2, machines: [yuria2]}
             - Recurse:      {extra_args:  3, machines: [yuria3]}
-            - Storage:      {extra_args:  1, machines: [yuria ]}
+            - Storage:      {extra_args:  8, machines: [yuria ]}
             - Sieve:        {extra_args:  4, machines: [yuria2]}
-            - BubbleSort:   {extra_args:  3, machines: [yuria3]}
-            - QuickSort:    {extra_args:  1, machines: [yuria ]}
-            - Sum:          {extra_args:  2, machines: [yuria2]}
+            - BubbleSort:   {extra_args: 30, machines: [yuria3]}
+            - QuickSort:    {extra_args: 12, machines: [yuria ]}
+            - Sum:          {extra_args: 20, machines: [yuria2]}
             - Towers:       {extra_args:  2, machines: [yuria3]}
-            - TreeSort:     {extra_args:  1, machines: [yuria ]}
-            - IntegerLoop:  {extra_args:  2, machines: [yuria2]}
-            - FieldLoop:    {extra_args:  1, machines: [yuria3]}
-            - WhileLoop:    {extra_args: 10, machines: [yuria ]}
-            - Mandelbrot:   {extra_args: 30, machines: [yuria2]}
+            - TreeSort:     {extra_args: 10, machines: [yuria ]}
+            - IntegerLoop:  {extra_args: 10, machines: [yuria2]}
+            - FieldLoop:    {extra_args:  5, machines: [yuria3]}
+            - WhileLoop:    {extra_args: 100, machines: [yuria ]}
+            - Mandelbrot:   {extra_args: 100, machines: [yuria2]}
 
             # - Test:     {invocations: 5, iterations: 1, machines: [yuria2]}
-            - TestGC:   {invocations: 5, iterations: 1, extra_args: 10, machines: [yuria2]}
+            - TestGC:   {invocations: 5, iterations: 1, extra_args: 100, machines: [yuria2]}
 
     awfy:
         gauge_adapter: RebenchLog
@@ -72,11 +72,11 @@ benchmark_suites:
         command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
         iterations: 1
         benchmarks:
-            - Loop:         {extra_args: 1, machines: [yuria3]}
-            - Queens:       {extra_args: 1, machines: [yuria2]}
-            - List:         {extra_args: 1, machines: [yuria2]}
-            - Recurse:      {extra_args: 1, machines: [yuria3]}
-            - Mandelbrot:   {extra_args: 3, machines: [yuria3]}
+            - Loop:         {extra_args: 40, machines: [yuria3]}
+            - Queens:       {extra_args: 10, machines: [yuria2]}
+            - List:         {extra_args: 10, machines: [yuria2]}
+            - Recurse:      {extra_args: 10, machines: [yuria3]}
+            - Mandelbrot:   {extra_args: 50, machines: [yuria3]}
 
     som-parse:
         gauge_adapter: RebenchLog
@@ -91,24 +91,24 @@ benchmark_suites:
         description: Basic interpreter benchmarks for comparing performance of most basic concepts.
         gauge_adapter: RebenchLog
         invocations: 5
-        command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 1"
+        command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
         benchmarks:
-            - ArgRead:                           {machines: [yuria2]}
-            - ArrayReadConst:                    {machines: [yuria2]}
-            - ArrayWriteConstConst:              {machines: [yuria2]}
-            - BlockSend0ConstReturn:             {machines: [yuria2]}
-            - Const:                             {machines: [yuria2]}
-            - FieldConstWrite:                   {machines: [yuria2]}
-            - FieldRead:                         {machines: [yuria2]}
-            - FieldReadIncWrite:                 {machines: [yuria2]}
-            - FieldReadWrite:                    {machines: [yuria3]}
-            - GlobalRead:                        {machines: [yuria3]}
-            - LocalConstWrite:                   {machines: [yuria3]}
-            - LocalRead:                         {machines: [yuria3]}
-            - LocalReadIncWrite:                 {machines: [yuria3]}
-            - LocalReadWrite:                    {machines: [yuria3]}
-            - SelfSend0:                         {machines: [yuria3]}
-            - SelfSend0BlockConstNonLocalReturn: {machines: [yuria3]}
+            - ArgRead:                           {extra_args: 5, machines: [yuria2]}
+            - ArrayReadConst:                    {extra_args: 5, machines: [yuria2]}
+            - ArrayWriteConstConst:              {extra_args: 5, machines: [yuria2]}
+            - BlockSend0ConstReturn:             {extra_args: 2, machines: [yuria2]}
+            - Const:                             {extra_args: 5, machines: [yuria2]}
+            - FieldConstWrite:                   {extra_args: 5, machines: [yuria2]}
+            - FieldRead:                         {extra_args: 5, machines: [yuria2]}
+            - FieldReadIncWrite:                 {extra_args: 2, machines: [yuria2]}
+            - FieldReadWrite:                    {extra_args: 5, machines: [yuria3]}
+            - GlobalRead:                        {extra_args: 5, machines: [yuria3]}
+            - LocalConstWrite:                   {extra_args: 5, machines: [yuria3]}
+            - LocalRead:                         {extra_args: 5, machines: [yuria3]}
+            - LocalReadIncWrite:                 {extra_args: 5, machines: [yuria3]}
+            - LocalReadWrite:                    {extra_args: 5, machines: [yuria3]}
+            - SelfSend0:                         {extra_args: 2, machines: [yuria3]}
+            - SelfSend0BlockConstNonLocalReturn: {extra_args: 1, machines: [yuria3]}
 
 executors:
     som-gcc-generational-inttag:            {path: ., executable: som-gcc-generational-inttag           }


### PR DESCRIPTION
- adjust benchmark size
- compile more in parallel
- GraphSearch needs memory…