### PR TITLE
Lower various operations to be primitives, matching PySOM

### DIFF
--- a/src/primitives/Array.cpp
+++ b/src/primitives/Array.cpp
@@ -59,8 +59,8 @@ static vm_oop_t arrNew_(vm_oop_t, vm_oop_t arg) {
 }
 
 _Array::_Array() : PrimitiveContainer() {
-    Add("new_", &arrNew_, true);
-    Add("at_", &arrAt_, false);
-    SetPrimitive("at_put_", new Routine<_Array>(this, &_Array::At_Put_, false));
+    Add("new:", &arrNew_, true);
+    Add("at:", &arrAt_, false);
+    SetPrimitive("at:put:", new Routine<_Array>(this, &_Array::At_Put_, false));
     Add("length", &arrLength, false);
 }

--- a/src/primitives/Array.cpp
+++ b/src/primitives/Array.cpp
@@ -29,23 +29,21 @@
 #include <cstdint>
 
 #include "../primitivesCore/PrimitiveContainer.h"
-#include "../primitivesCore/Routine.h"
 #include "../vm/Universe.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMArray.h"
 #include "../vmobjects/VMFrame.h"
 
-static vm_oop_t arrAt_(vm_oop_t leftObj, vm_oop_t idx) {
+static vm_oop_t arrAt(vm_oop_t leftObj, vm_oop_t idx) {
     VMArray* self = static_cast<VMArray*>(leftObj);
     return self->GetIndexableField(INT_VAL(idx) - 1);
 }
 
-void _Array::At_Put_(Interpreter*, VMFrame* frame) {
-    vm_oop_t value = frame->Pop();
-    vm_oop_t index = frame->Pop();
-    VMArray* self = static_cast<VMArray*>(frame->GetStackElement(0));
-    long i = INT_VAL(index);
+static vm_oop_t arrAtPut(vm_oop_t rcvr, vm_oop_t index, vm_oop_t value) {
+    VMArray* self = static_cast<VMArray*>(rcvr);
+    int64_t i = INT_VAL(index);
     self->SetIndexableField(i - 1, value);
+    return rcvr;
 }
 
 static vm_oop_t arrLength(vm_oop_t leftObj) {
@@ -53,14 +51,20 @@ static vm_oop_t arrLength(vm_oop_t leftObj) {
     return NEW_INT((int64_t)self->GetNumberOfIndexableFields());
 }
 
-static vm_oop_t arrNew_(vm_oop_t, vm_oop_t arg) {
+static vm_oop_t arrNew(vm_oop_t, vm_oop_t arg) {
     int64_t size = INT_VAL(arg);
     return GetUniverse()->NewArray(size);
 }
 
+static vm_oop_t arrCopy(vm_oop_t rcvr) {
+    VMArray* self = static_cast<VMArray*>(rcvr);
+    return self->Copy();
+}
+
 _Array::_Array() : PrimitiveContainer() {
-    Add("new:", &arrNew_, true);
-    Add("at:", &arrAt_, false);
-    SetPrimitive("at:put:", new Routine<_Array>(this, &_Array::At_Put_, false));
+    Add("new:", &arrNew, true);
+    Add("at:", &arrAt, false);
+    Add("at:put:", &arrAtPut, false);
     Add("length", &arrLength, false);
+    Add("copy", &arrCopy, false);
 }

--- a/src/primitives/Array.h
+++ b/src/primitives/Array.h
@@ -32,5 +32,4 @@
 class _Array : public PrimitiveContainer {
 public:
     _Array();
-    void At_Put_(Interpreter*, VMFrame*);
 };

--- a/src/primitives/Block.cpp
+++ b/src/primitives/Block.cpp
@@ -50,7 +50,7 @@ void _Block::Restart(Interpreter*, VMFrame* frame) {
 _Block::_Block() : PrimitiveContainer() {
     SetPrimitive("value", new Routine<_Block>(this, &_Block::Value, false));
     SetPrimitive("restart", new Routine<_Block>(this, &_Block::Restart, false));
-    SetPrimitive("value_", new Routine<_Block>(this, &_Block::Value_, false));
-    SetPrimitive("value_with_",
+    SetPrimitive("value:", new Routine<_Block>(this, &_Block::Value_, false));
+    SetPrimitive("value:with:",
                  new Routine<_Block>(this, &_Block::Value_with_, false));
 }

--- a/src/primitives/Block.cpp
+++ b/src/primitives/Block.cpp
@@ -27,30 +27,5 @@
 #include "Block.h"
 
 #include "../primitivesCore/PrimitiveContainer.h"
-#include "../primitivesCore/Routine.h"
-#include "../vmobjects/VMFrame.h"
 
-void _Block::Value(Interpreter*, VMFrame*) {
-    // intentionally left blank
-}
-
-void _Block::Value_(Interpreter*, VMFrame*) {
-    // intentionally left blank
-}
-
-void _Block::Value_with_(Interpreter*, VMFrame*) {
-    // intentionally left blank
-}
-
-void _Block::Restart(Interpreter*, VMFrame* frame) {
-    frame->SetBytecodeIndex(0);
-    frame->ResetStackPointer();
-}
-
-_Block::_Block() : PrimitiveContainer() {
-    SetPrimitive("value", new Routine<_Block>(this, &_Block::Value, false));
-    SetPrimitive("restart", new Routine<_Block>(this, &_Block::Restart, false));
-    SetPrimitive("value:", new Routine<_Block>(this, &_Block::Value_, false));
-    SetPrimitive("value:with:",
-                 new Routine<_Block>(this, &_Block::Value_with_, false));
-}
+_Block::_Block() : PrimitiveContainer() {}

--- a/src/primitives/Block.h
+++ b/src/primitives/Block.h
@@ -32,11 +32,4 @@
 class _Block : public PrimitiveContainer {
 public:
     _Block();
-    void Value(Interpreter*, VMFrame*);
-    void Restart(Interpreter*, VMFrame*);
-    void Value_(Interpreter*, VMFrame*);
-    void Value_with_(Interpreter*, VMFrame*);
-
-    void Spawn(Interpreter*, VMFrame*);
-    void Spawn_(Interpreter*, VMFrame*);
 };

--- a/src/primitives/Double.cpp
+++ b/src/primitives/Double.cpp
@@ -175,6 +175,60 @@ static vm_oop_t dblFromString(vm_oop_t, vm_oop_t rightObj) {
     return GetUniverse()->NewDouble(value);
 }
 
+static vm_oop_t dblLowerThanEqual(vm_oop_t leftPtr, vm_oop_t rightObj) {
+    PREPARE_OPERANDS;
+    if (left <= right) {
+        return load_ptr(trueObject);
+    } else {
+        return load_ptr(falseObject);
+    }
+}
+
+static vm_oop_t dblGreaterThan(vm_oop_t leftPtr, vm_oop_t rightObj) {
+    PREPARE_OPERANDS;
+    if (left > right) {
+        return load_ptr(trueObject);
+    } else {
+        return load_ptr(falseObject);
+    }
+}
+
+static vm_oop_t dblGreaterThanEqual(vm_oop_t leftPtr, vm_oop_t rightObj) {
+    PREPARE_OPERANDS;
+    if (left >= right) {
+        return load_ptr(trueObject);
+    } else {
+        return load_ptr(falseObject);
+    }
+}
+
+static vm_oop_t dblUnequal(vm_oop_t leftPtr, vm_oop_t rightObj) {
+    PREPARE_OPERANDS;
+    if (left != right) {
+        return load_ptr(trueObject);
+    } else {
+        return load_ptr(falseObject);
+    }
+}
+
+static vm_oop_t dblMin(vm_oop_t leftPtr, vm_oop_t rightObj) {
+    PREPARE_OPERANDS;
+    if (left < right) {
+        return leftPtr;
+    } else {
+        return rightObj;
+    }
+}
+
+static vm_oop_t dblMax(vm_oop_t leftPtr, vm_oop_t rightObj) {
+    PREPARE_OPERANDS;
+    if (left > right) {
+        return leftPtr;
+    } else {
+        return rightObj;
+    }
+}
+
 _Double::_Double() : PrimitiveContainer() {
     Add("+", &dblPlus, false);
     Add("-", &dblMinus, false);
@@ -191,4 +245,12 @@ _Double::_Double() : PrimitiveContainer() {
     Add("asInteger", &dblAsInteger, false);
     Add("PositiveInfinity", &dblPositiveInfinity, true);
     Add("fromString:", &dblFromString, true);
+
+    Add("<=", &dblLowerThanEqual, false);
+    Add(">", &dblGreaterThan, false);
+    Add(">=", &dblGreaterThanEqual, false);
+    Add("<>", &dblUnequal, false);
+    Add("~=", &dblUnequal, false);
+    Add("min:", &dblMin, false);
+    Add("max:", &dblMax, false);
 }

--- a/src/primitives/Double.cpp
+++ b/src/primitives/Double.cpp
@@ -176,19 +176,19 @@ static vm_oop_t dblFromString(vm_oop_t, vm_oop_t rightObj) {
 }
 
 _Double::_Double() : PrimitiveContainer() {
-    Add("plus", &dblPlus, false);
-    Add("minus", &dblMinus, false);
-    Add("star", &dblStar, false);
+    Add("+", &dblPlus, false);
+    Add("-", &dblMinus, false);
+    Add("*", &dblStar, false);
     Add("cos", &dblCos, false);
     Add("sin", &dblSin, false);
-    Add("slashslash", &dblSlashslash, false);
-    Add("percent", &dblPercent, false);
-    Add("equal", &dblEqual, false);
-    Add("lowerthan", &dblLowerthan, false);
+    Add("//", &dblSlashslash, false);
+    Add("%", &dblPercent, false);
+    Add("=", &dblEqual, false);
+    Add("<", &dblLowerthan, false);
     Add("asString", &dblAsString, false);
     Add("sqrt", &dblSqrt, false);
     Add("round", &dblRound, false);
     Add("asInteger", &dblAsInteger, false);
     Add("PositiveInfinity", &dblPositiveInfinity, true);
-    Add("fromString_", &dblFromString, true);
+    Add("fromString:", &dblFromString, true);
 }

--- a/src/primitives/Integer.cpp
+++ b/src/primitives/Integer.cpp
@@ -200,6 +200,39 @@ static vm_oop_t intLowerthan(vm_oop_t leftObj, vm_oop_t rightObj) {
     }
 }
 
+static vm_oop_t intLowerThanEqual(vm_oop_t leftObj, vm_oop_t rightObj) {
+    int64_t left = INT_VAL(leftObj);
+    doDoubleOpIfNeeded(left, rightObj, <=);
+
+    if (left <= INT_VAL(rightObj)) {
+        return load_ptr(trueObject);
+    } else {
+        return load_ptr(falseObject);
+    }
+}
+
+static vm_oop_t intGreaterThan(vm_oop_t leftObj, vm_oop_t rightObj) {
+    int64_t left = INT_VAL(leftObj);
+    doDoubleOpIfNeeded(left, rightObj, >);
+
+    if (left > INT_VAL(rightObj)) {
+        return load_ptr(trueObject);
+    } else {
+        return load_ptr(falseObject);
+    }
+}
+
+static vm_oop_t intGreaterThanEqual(vm_oop_t leftObj, vm_oop_t rightObj) {
+    int64_t left = INT_VAL(leftObj);
+    doDoubleOpIfNeeded(left, rightObj, >=);
+
+    if (left >= INT_VAL(rightObj)) {
+        return load_ptr(trueObject);
+    } else {
+        return load_ptr(falseObject);
+    }
+}
+
 static vm_oop_t intAsString(vm_oop_t self) {
     long integer = INT_VAL(self);
     ostringstream Str;
@@ -239,6 +272,44 @@ static vm_oop_t intAtRandom(vm_oop_t self) {
     return NEW_INT(result);
 }
 
+static vm_oop_t intAbs(vm_oop_t self) {
+    int64_t result = INT_VAL(self);
+    if (result < 0) {
+        return NEW_INT(abs(result));
+    }
+    return self;
+}
+
+static vm_oop_t intMin(vm_oop_t self, vm_oop_t arg) {
+    int64_t result = INT_VAL(self);
+
+    VMClass* cl = CLASS_OF(arg);
+    if (cl == load_ptr(doubleClass)) {
+        if (result < ((VMDouble*)arg)->GetEmbeddedDouble()) {
+            return self;
+        } else {
+            return arg;
+        }
+    }
+
+    return (result < INT_VAL(arg)) ? self : arg;
+}
+
+static vm_oop_t intMax(vm_oop_t self, vm_oop_t arg) {
+    int64_t result = INT_VAL(self);
+
+    VMClass* cl = CLASS_OF(arg);
+    if (cl == load_ptr(doubleClass)) {
+        if (result > ((VMDouble*)arg)->GetEmbeddedDouble()) {
+            return self;
+        } else {
+            return arg;
+        }
+    }
+
+    return (result > INT_VAL(arg)) ? self : arg;
+}
+
 static vm_oop_t intFromString(vm_oop_t, vm_oop_t right) {
     VMString* self = (VMString*)right;
     std::string str = self->GetStdString();
@@ -275,4 +346,8 @@ _Integer::_Integer() : PrimitiveContainer() {
     Add("<=", &intLowerThanEqual, false);
     Add(">", &intGreaterThan, false);
     Add(">=", &intGreaterThanEqual, false);
+
+    Add("abs", &intAbs, false);
+    Add("min:", &intMin, false);
+    Add("max:", &intMax, false);
 }

--- a/src/primitives/Integer.cpp
+++ b/src/primitives/Integer.cpp
@@ -275,7 +275,7 @@ static vm_oop_t intAtRandom(vm_oop_t self) {
 static vm_oop_t intAbs(vm_oop_t self) {
     int64_t result = INT_VAL(self);
     if (result < 0) {
-        return NEW_INT(abs(result));
+        return NEW_INT(-result);
     }
     return self;
 }
@@ -317,6 +317,17 @@ static vm_oop_t intFromString(vm_oop_t, vm_oop_t right) {
     return ParseInteger(str, 10, false);
 }
 
+static vm_oop_t intUnequal(vm_oop_t leftObj, vm_oop_t rightObj) {
+    int64_t left = INT_VAL(leftObj);
+    doDoubleOpIfNeeded(left, rightObj, !=);
+
+    if (left != INT_VAL(rightObj)) {
+        return load_ptr(trueObject);
+    } else {
+        return load_ptr(falseObject);
+    }
+}
+
 _Integer::_Integer() : PrimitiveContainer() {
     srand((unsigned)time(nullptr));
 
@@ -346,6 +357,8 @@ _Integer::_Integer() : PrimitiveContainer() {
     Add("<=", &intLowerThanEqual, false);
     Add(">", &intGreaterThan, false);
     Add(">=", &intGreaterThanEqual, false);
+    Add("<>", &intUnequal, false);
+    Add("~=", &intUnequal, false);
 
     Add("abs", &intAbs, false);
     Add("min:", &intMin, false);

--- a/src/primitives/Integer.cpp
+++ b/src/primitives/Integer.cpp
@@ -328,6 +328,21 @@ static vm_oop_t intUnequal(vm_oop_t leftObj, vm_oop_t rightObj) {
     }
 }
 
+static vm_oop_t intRange(vm_oop_t leftObj, vm_oop_t rightObj) {
+    int64_t left = INT_VAL(leftObj);
+    int64_t right = INT_VAL(rightObj);
+
+    int64_t numInteger = right - left + 1;
+    VMArray* arr = GetUniverse()->NewArray(numInteger);
+
+    size_t index = 0;
+    for (int64_t i = left; i <= right; i += 1, index += 1) {
+        arr->SetIndexableField(index, NEW_INT(i));
+    }
+
+    return arr;
+}
+
 _Integer::_Integer() : PrimitiveContainer() {
     srand((unsigned)time(nullptr));
 
@@ -363,4 +378,6 @@ _Integer::_Integer() : PrimitiveContainer() {
     Add("abs", &intAbs, false);
     Add("min:", &intMin, false);
     Add("max:", &intMax, false);
+
+    Add("to:", &intRange, false);
 }

--- a/src/primitives/Integer.cpp
+++ b/src/primitives/Integer.cpp
@@ -70,11 +70,6 @@ static vm_oop_t intPlus(vm_oop_t leftObj, vm_oop_t rightObj) {
     return NEW_INT(result);
 }
 
-static vm_oop_t intBitwiseAnd(vm_oop_t leftObj, vm_oop_t rightObj) {
-    int64_t result = (int64_t)INT_VAL(leftObj) & (int64_t)INT_VAL(rightObj);
-    return NEW_INT(result);
-}
-
 static vm_oop_t intBitwiseXor(vm_oop_t leftObj, vm_oop_t rightObj) {
     int64_t result = (int64_t)INT_VAL(leftObj) ^ (int64_t)INT_VAL(rightObj);
     return NEW_INT(result);
@@ -254,28 +249,26 @@ static vm_oop_t intFromString(vm_oop_t, vm_oop_t right) {
 _Integer::_Integer() : PrimitiveContainer() {
     srand((unsigned)time(nullptr));
 
-    Add("plus", &intPlus, false);
-    Add("bitAnd_", &intBitwiseAnd, false);
+    Add("+", &intPlus, false);
+    Add("-", &intMinus, false);
+    Add("*", &intStar, false);
+    Add("rem:", &intRem, false);
 
-    Add("minus", &intMinus, false);
-    Add("star", &intStar, false);
-    Add("rem_", &intRem, false);
-
-    Add("bitXor_", &intBitwiseXor, false);
-    Add("lowerthanlowerthan", &intLeftShift, false);
-    Add("greaterthangreaterthangreaterthan", &intUnsignedRightShift, false);
-    Add("slash", &intSlash, false);
-    Add("slashslash", &intSlashslash, false);
-    Add("percent", &intPercent, false);
-    Add("and", &intAnd, false);
-    Add("equal", &intEqual, false);
-    Add("equalequal", &intEqualEqual, false);
-    Add("lowerthan", &intLowerthan, false);
+    Add("bitXor:", &intBitwiseXor, false);
+    Add("<<", &intLeftShift, false);
+    Add(">>>", &intUnsignedRightShift, false);
+    Add("/", &intSlash, false);
+    Add("//", &intSlashslash, false);
+    Add("%", &intPercent, false);
+    Add("&", &intAnd, false);
+    Add("=", &intEqual, false);
+    Add("==", &intEqualEqual, false);
+    Add("<", &intLowerthan, false);
     Add("asString", &intAsString, false);
     Add("asDouble", &intAsDouble, false);
     Add("as32BitSignedValue", &intAs32BitSigned, false);
     Add("as32BitUnsignedValue", &intAs32BitUnsigned, false);
     Add("sqrt", &intSqrt, false);
     Add("atRandom", &intAtRandom, false);
-    Add("fromString_", &intFromString, true);
+    Add("fromString:", &intFromString, true);
 }

--- a/src/primitives/Integer.cpp
+++ b/src/primitives/Integer.cpp
@@ -271,4 +271,8 @@ _Integer::_Integer() : PrimitiveContainer() {
     Add("sqrt", &intSqrt, false);
     Add("atRandom", &intAtRandom, false);
     Add("fromString:", &intFromString, true);
+
+    Add("<=", &intLowerThanEqual, false);
+    Add(">", &intGreaterThan, false);
+    Add(">=", &intGreaterThanEqual, false);
 }

--- a/src/primitives/Method.cpp
+++ b/src/primitives/Method.cpp
@@ -40,6 +40,6 @@ void _Method::InvokeOn_With_(Interpreter* interp, VMFrame* frame) {
 _Method::_Method() : PrimitiveContainer() {
     Add("signature", &mSignature, false);
     Add("holder", &mHolder, false);
-    SetPrimitive("invokeOn_with_",
+    SetPrimitive("invokeOn:with:",
                  new Routine<_Method>(this, &_Method::InvokeOn_With_, false));
 }

--- a/src/primitives/Object.cpp
+++ b/src/primitives/Object.cpp
@@ -145,28 +145,28 @@ vm_oop_t objClass(vm_oop_t self) {
 }
 
 _Object::_Object() : PrimitiveContainer() {
-    Add("equalequal", &objEqualequal, false);
+    Add("==", &objEqualequal, false);
     Add("objectSize", &objObjectSize, false);
     Add("hashcode", &objHashcode, false);
     Add("inspect", &objInspect, false);
     Add("halt", &objHalt, false);
 
-    SetPrimitive("perform_",
+    SetPrimitive("perform:",
                  new Routine<_Object>(this, &_Object::Perform, false));
     SetPrimitive(
-        "perform_withArguments_",
+        "perform:withArguments:",
         new Routine<_Object>(this, &_Object::PerformWithArguments, false));
     SetPrimitive(
-        "perform_inSuperclass_",
+        "perform:inSuperclass:",
         new Routine<_Object>(this, &_Object::PerformInSuperclass, false));
-    SetPrimitive("perform_withArguments_inSuperclass_",
+    SetPrimitive("perform:withArguments:inSuperclass:",
                  new Routine<_Object>(
                      this, &_Object::PerformWithArgumentsInSuperclass, false));
 
-    Add("instVarAt_", &objInstVarAt, false);
-    SetPrimitive("instVarAt_put_",
+    Add("instVarAt:", &objInstVarAt, false);
+    SetPrimitive("instVarAt:put:",
                  new Routine<_Object>(this, &_Object::InstVarAtPut, false));
-    Add("instVarNamed_", &objInstVarNamed, false);
+    Add("instVarNamed:", &objInstVarNamed, false);
 
     Add("class", &objClass, false);
 }

--- a/src/primitives/Object.cpp
+++ b/src/primitives/Object.cpp
@@ -124,14 +124,10 @@ vm_oop_t objInstVarAt(vm_oop_t self, vm_oop_t idx) {
     return static_cast<VMObject*>(self)->GetField(field_idx);
 }
 
-void _Object::InstVarAtPut(Interpreter*, VMFrame* frame) {
-    vm_oop_t value = frame->Pop();
-    vm_oop_t idx = frame->Pop();
-    vm_oop_t self = frame->GetStackElement(0);
-
-    long field_idx = INT_VAL(idx) - 1;
-
+vm_oop_t objInstVarAtPut(vm_oop_t self, vm_oop_t idx, vm_oop_t value) {
+    size_t field_idx = INT_VAL(idx) - 1;
     static_cast<VMObject*>(self)->SetField(field_idx, value);
+    return self;
 }
 
 vm_oop_t objInstVarNamed(vm_oop_t self, vm_oop_t nameObj) {
@@ -164,8 +160,7 @@ _Object::_Object() : PrimitiveContainer() {
                      this, &_Object::PerformWithArgumentsInSuperclass, false));
 
     Add("instVarAt:", &objInstVarAt, false);
-    SetPrimitive("instVarAt:put:",
-                 new Routine<_Object>(this, &_Object::InstVarAtPut, false));
+    Add("instVarAt:put:", &objInstVarAtPut, false);
     Add("instVarNamed:", &objInstVarNamed, false);
 
     Add("class", &objClass, false);

--- a/src/primitives/Object.h
+++ b/src/primitives/Object.h
@@ -36,6 +36,4 @@ public:
     void PerformWithArguments(Interpreter*, VMFrame*);
     void PerformInSuperclass(Interpreter*, VMFrame*);
     void PerformWithArgumentsInSuperclass(Interpreter*, VMFrame*);
-
-    void InstVarAtPut(Interpreter*, VMFrame*);
 };

--- a/src/primitives/Primitive.cpp
+++ b/src/primitives/Primitive.cpp
@@ -40,6 +40,6 @@ _Primitive::_Primitive() : PrimitiveContainer() {
     Add("signature", &pSignature, false);
     Add("holder", &pHolder, false);
     SetPrimitive(
-        "invokeOn_with_",
+        "invokeOn:with:",
         new Routine<_Primitive>(this, &_Primitive::InvokeOn_With_, false));
 }

--- a/src/primitives/String.cpp
+++ b/src/primitives/String.cpp
@@ -29,10 +29,10 @@
 #include <cctype>
 #include <cstdint>
 #include <cstdio>
+#include <string>
 
 #include "../misc/defs.h"
 #include "../primitivesCore/PrimitiveContainer.h"
-#include "../primitivesCore/Routine.h"
 #include "../vm/Globals.h"
 #include "../vm/Symbols.h"
 #include "../vm/Universe.h"
@@ -80,6 +80,10 @@ static vm_oop_t strEqual(vm_oop_t leftObj, vm_oop_t op1) {
         return load_ptr(falseObject);
     }
 
+    if (leftObj == op1) {
+        return load_ptr(trueObject);
+    }
+
     VMClass* otherClass = CLASS_OF(op1);
     if (otherClass == load_ptr(stringClass) ||
         otherClass == load_ptr(symbolClass)) {
@@ -93,7 +97,9 @@ static vm_oop_t strEqual(vm_oop_t leftObj, vm_oop_t op1) {
     return load_ptr(falseObject);
 }
 
-static vm_oop_t strPrimSubstringFromTo(vm_oop_t rcvr, vm_oop_t start, vm_oop_t end) {
+static vm_oop_t strPrimSubstringFromTo(vm_oop_t rcvr,
+                                       vm_oop_t start,
+                                       vm_oop_t end) {
     VMString* self = static_cast<VMString*>(rcvr);
     std::string str = self->GetStdString();
 
@@ -108,8 +114,7 @@ static vm_oop_t strCharAt(vm_oop_t rcvr, vm_oop_t indexPtr) {
     VMString* self = static_cast<VMString*>(rcvr);
     int64_t index = INT_VAL(indexPtr) - 1;
 
-
-    if (unlikely(index < 0 || (size_t) index >= self->GetStringLength())) {
+    if (unlikely(index < 0 || (size_t)index >= self->GetStringLength())) {
         return GetUniverse()->NewString("Error - index out of bounds");
     }
 
@@ -186,7 +191,6 @@ _String::_String() : PrimitiveContainer() {
     Add("isWhiteSpace", &strIsWhiteSpace, false);
     Add("isLetters", &strIsLetters, false);
     Add("isDigits", &strIsDigits, false);
-
 
     Add("charAt:", &strCharAt, false);
 }

--- a/src/primitives/String.cpp
+++ b/src/primitives/String.cpp
@@ -169,13 +169,13 @@ static vm_oop_t strIsDigits(vm_oop_t rcvr) {
 }
 
 _String::_String() : PrimitiveContainer() {
-    Add("concatenate_", &strConcatenate_, false);
+    Add("concatenate:", &strConcatenate_, false);
     Add("asSymbol", &strAsSymbol, false);
     Add("hashcode", &strHashcode, false);
     Add("length", &strLength, false);
-    Add("equal", &strEqual, false);
+    Add("=", &strEqual, false);
     SetPrimitive(
-        "primSubstringFrom_to_",
+        "primSubstringFrom:to:",
         new Routine<_String>(this, &_String::PrimSubstringFrom_to_, false));
     Add("isWhiteSpace", &strIsWhiteSpace, false);
     Add("isLetters", &strIsLetters, false);

--- a/src/primitives/String.h
+++ b/src/primitives/String.h
@@ -32,5 +32,4 @@
 class _String : public PrimitiveContainer {
 public:
     _String();
-    void PrimSubstringFrom_to_(Interpreter*, VMFrame*);
 };

--- a/src/primitives/System.cpp
+++ b/src/primitives/System.cpp
@@ -63,10 +63,10 @@ static vm_oop_t sysGlobal_(vm_oop_t, vm_oop_t rightObj) {
     return result ? result : load_ptr(nilObject);
 }
 
-void _System::Global_put_(Interpreter*, VMFrame* frame) {
-    vm_oop_t value = frame->Pop();
-    VMSymbol* arg = static_cast<VMSymbol*>(frame->Pop());
-    GetUniverse()->SetGlobal(arg, value);
+static vm_oop_t sysGlobalPut(vm_oop_t sys, vm_oop_t sym, vm_oop_t val) {
+    VMSymbol* arg = static_cast<VMSymbol*>(sym);
+    GetUniverse()->SetGlobal(arg, val);
+    return sys;
 }
 
 static vm_oop_t sysHasGlobal_(vm_oop_t, vm_oop_t rightObj) {
@@ -175,8 +175,7 @@ _System::_System(void) : PrimitiveContainer() {
     gettimeofday(&start_time, nullptr);
 
     Add("global:", &sysGlobal_, false);
-    SetPrimitive("global:put:",
-                 new Routine<_System>(this, &_System::Global_put_, false));
+    Add("global:put:", &sysGlobalPut, false);
     Add("hasGlobal:", &sysHasGlobal_, false);
     Add("load:", &sysLoad_, false);
     Add("exit:", &sysExit_, false);

--- a/src/primitives/System.cpp
+++ b/src/primitives/System.cpp
@@ -106,13 +106,6 @@ static vm_oop_t sysPrintNewline(vm_oop_t leftObj) {
     return leftObj;
 }
 
-static vm_oop_t sysPrintNewline_(vm_oop_t leftObj, vm_oop_t rightObj) {
-    VMString* arg = static_cast<VMString*>(rightObj);
-    std::string str = arg->GetStdString();
-    Print(str + "\n");
-    return leftObj;
-}
-
 static vm_oop_t sysErrorPrint_(vm_oop_t leftObj, vm_oop_t rightObj) {
     VMString* arg = static_cast<VMString*>(rightObj);
     std::string str = arg->GetStdString();
@@ -181,22 +174,21 @@ void _System::PrintStackTrace(Interpreter*, VMFrame* frame) {
 _System::_System(void) : PrimitiveContainer() {
     gettimeofday(&start_time, nullptr);
 
-    Add("global_", &sysGlobal_, false);
-    SetPrimitive("global_put_",
+    Add("global:", &sysGlobal_, false);
+    SetPrimitive("global:put:",
                  new Routine<_System>(this, &_System::Global_put_, false));
-    Add("hasGlobal_", &sysHasGlobal_, false);
-    Add("load_", &sysLoad_, false);
-    Add("exit_", &sysExit_, false);
-    Add("printString_", &sysPrintString_, false);
+    Add("hasGlobal:", &sysHasGlobal_, false);
+    Add("load:", &sysLoad_, false);
+    Add("exit:", &sysExit_, false);
+    Add("printString:", &sysPrintString_, false);
     Add("printNewline", &sysPrintNewline, false);
-    Add("printNewline_", &sysPrintNewline_, false);
-    Add("errorPrint_", &sysErrorPrint_, false);
-    Add("errorPrintln_", &sysErrorPrintNewline_, false);
+    Add("errorPrint:", &sysErrorPrint_, false);
+    Add("errorPrintln:", &sysErrorPrintNewline_, false);
     Add("time", &sysTime, false);
     Add("ticks", &sysTicks, false);
     Add("fullGC", &sysFullGC, false);
 
-    Add("loadFile_", &sysLoadFile_, false);
+    Add("loadFile:", &sysLoadFile_, false);
     SetPrimitive("printStackTrace",
                  new Routine<_System>(this, &_System::PrintStackTrace, false));
 }

--- a/src/primitives/System.h
+++ b/src/primitives/System.h
@@ -36,6 +36,5 @@ public:
     _System(void);
     virtual ~_System();
 
-    void Global_put_(Interpreter*, VMFrame*);
     void PrintStackTrace(Interpreter*, VMFrame*);
 };

--- a/src/primitivesCore/PrimitiveContainer.cpp
+++ b/src/primitivesCore/PrimitiveContainer.cpp
@@ -48,18 +48,21 @@ void PrimitiveContainer::SetPrimitive(const char* name,
 void PrimitiveContainer::Add(const char* name,
                              BinaryPrimitiveRoutine routine,
                              bool classSide) {
+    assert(binaryPrims.find(name) == binaryPrims.end());
     binaryPrims[std::string(name)] = {routine, classSide};
 }
 
 void PrimitiveContainer::Add(const char* name,
                              UnaryPrimitiveRoutine routine,
                              bool classSide) {
+    assert(unaryPrims.find(name) == unaryPrims.end());
     unaryPrims[std::string(name)] = {routine, classSide};
 }
 
 void PrimitiveContainer::Add(const char* name,
                              TernaryPrimitiveRoutine routine,
                              bool classSide) {
+    assert(ternaryPrims.find(name) == ternaryPrims.end());
     ternaryPrims[std::string(name)] = {routine, classSide};
 }
 

--- a/src/primitivesCore/PrimitiveContainer.cpp
+++ b/src/primitivesCore/PrimitiveContainer.cpp
@@ -57,6 +57,12 @@ void PrimitiveContainer::Add(const char* name,
     unaryPrims[std::string(name)] = {routine, classSide};
 }
 
+void PrimitiveContainer::Add(const char* name,
+                             TernaryPrimitiveRoutine routine,
+                             bool classSide) {
+    ternaryPrims[std::string(name)] = {routine, classSide};
+}
+
 PrimitiveRoutine* PrimitiveContainer::GetPrimitive(
     const std::string& routineName) {
     if (methods.find(routineName) != methods.end()) {
@@ -90,6 +96,21 @@ void PrimitiveContainer::InstallPrimitives(VMClass* clazz, bool classSide) {
         VMSymbol* sig = SymbolFor(p.first);
         if (clazz->AddInstanceInvokable(
                 VMSafePrimitive::GetSafeBinary(sig, p.second))) {
+            cout << "Warn: Primitive " << p.first
+                 << " is not in class definition for class "
+                 << clazz->GetName()->GetStdString() << endl;
+        }
+    }
+
+    for (auto const& p : ternaryPrims) {
+        assert(p.second.IsValid());
+        if (classSide != p.second.isClassSide) {
+            continue;
+        }
+
+        VMSymbol* sig = SymbolFor(p.first);
+        if (clazz->AddInstanceInvokable(
+                VMSafePrimitive::GetSafeTernary(sig, p.second))) {
             cout << "Warn: Primitive " << p.first
                  << " is not in class definition for class "
                  << clazz->GetName()->GetStdString() << endl;

--- a/src/primitivesCore/PrimitiveContainer.h
+++ b/src/primitivesCore/PrimitiveContainer.h
@@ -55,9 +55,11 @@ public:
 
     void Add(const char* name, UnaryPrimitiveRoutine, bool classSide);
     void Add(const char* name, BinaryPrimitiveRoutine, bool classSide);
+    void Add(const char* name, TernaryPrimitiveRoutine, bool classSide);
 
 private:
     std::map<std::string, PrimitiveRoutine*> methods{};
     std::map<std::string, UnaryPrim> unaryPrims{};
     std::map<std::string, BinaryPrim> binaryPrims{};
+    std::map<std::string, TernaryPrim> ternaryPrims{};
 };

--- a/src/primitivesCore/PrimitiveContainer.h
+++ b/src/primitivesCore/PrimitiveContainer.h
@@ -51,8 +51,7 @@ public:
 
     PrimitiveRoutine* GetPrimitive(const std::string& routineName);
 
-    UnaryPrim GetSafeUnary(const std::string& routineName);
-    BinaryPrim GetSafeBinary(const std::string& routineName);
+    void InstallPrimitives(VMClass* clazz, bool classSide);
 
     void Add(const char* name, UnaryPrimitiveRoutine, bool classSide);
     void Add(const char* name, BinaryPrimitiveRoutine, bool classSide);

--- a/src/primitivesCore/PrimitiveLoader.cpp
+++ b/src/primitivesCore/PrimitiveLoader.cpp
@@ -41,9 +41,9 @@
 #include "../primitives/Symbol.h"
 #include "../primitives/System.h"
 #include "../vm/Print.h"
+#include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/PrimitiveRoutine.h"
 #include "PrimitiveContainer.h"
-#include "Primitives.h"
 
 PrimitiveLoader PrimitiveLoader::loader;
 
@@ -86,36 +86,20 @@ PrimitiveRoutine* PrimitiveLoader::GetPrimitiveRoutine(const std::string& cname,
     return loader.getPrimitiveRoutine(cname, mname, isPrimitive);
 }
 
-UnaryPrim PrimitiveLoader::GetUnaryPrim(const std::string& cname,
-                                        const std::string& mname) {
-    return loader.getUnaryPrim(cname, mname);
+void PrimitiveLoader::InstallPrimitives(const std::string& cname,
+                                        VMClass* clazz,
+                                        bool classSide) {
+    loader.installPrimitives(cname, clazz, classSide);
 }
 
-UnaryPrim PrimitiveLoader::getUnaryPrim(const std::string& cname,
-                                        const std::string& mname) {
+void PrimitiveLoader::installPrimitives(const std::string& cname,
+                                        VMClass* clazz,
+                                        bool classSide) {
     if (primitiveObjects.find(cname) == primitiveObjects.end()) {
-        ErrorPrint("Primitive object not found for name: " + cname + "\n");
-        return UnaryPrim();
+        return;
     }
 
-    PrimitiveContainer* primitive = primitiveObjects[cname];
-    return primitive->GetSafeUnary(mname);
-}
-
-BinaryPrim PrimitiveLoader::GetBinaryPrim(const std::string& cname,
-                                          const std::string& mname) {
-    return loader.getBinaryPrim(cname, mname);
-}
-
-BinaryPrim PrimitiveLoader::getBinaryPrim(const std::string& cname,
-                                          const std::string& mname) {
-    if (primitiveObjects.find(cname) == primitiveObjects.end()) {
-        ErrorPrint("Primitive object not found for name: " + cname + "\n");
-        return BinaryPrim();
-    }
-
-    PrimitiveContainer* primitive = primitiveObjects[cname];
-    return primitive->GetSafeBinary(mname);
+    primitiveObjects[cname]->InstallPrimitives(clazz, classSide);
 }
 
 PrimitiveRoutine* PrimitiveLoader::getPrimitiveRoutine(const std::string& cname,

--- a/src/primitivesCore/PrimitiveLoader.h
+++ b/src/primitivesCore/PrimitiveLoader.h
@@ -54,21 +54,19 @@ public:
                                                  const std::string& mname,
                                                  bool isPrimitive);
 
-    static BinaryPrim GetBinaryPrim(const std::string& cname,
-                                    const std::string& mname);
-    static UnaryPrim GetUnaryPrim(const std::string& cname,
-                                  const std::string& mname);
+    static void InstallPrimitives(const std::string& cname,
+                                  VMClass* clazz,
+                                  bool classSide);
 
 private:
+    void installPrimitives(const std::string& cname,
+                           VMClass* clazz,
+                           bool classSide);
+
     bool supportsClass(const std::string& name);
     PrimitiveRoutine* getPrimitiveRoutine(const std::string& cname,
                                           const std::string& mname,
                                           bool isPrimitive);
-
-    UnaryPrim getUnaryPrim(const std::string& cname, const std::string& mname);
-
-    BinaryPrim getBinaryPrim(const std::string& cname,
-                             const std::string& mname);
 
     std::map<StdString, PrimitiveContainer*> primitiveObjects{};
 

--- a/src/primitivesCore/Primitives.h
+++ b/src/primitivesCore/Primitives.h
@@ -4,6 +4,7 @@
 
 using UnaryPrimitiveRoutine = vm_oop_t(vm_oop_t);
 using BinaryPrimitiveRoutine = vm_oop_t(vm_oop_t, vm_oop_t);
+using TernaryPrimitiveRoutine = vm_oop_t(vm_oop_t, vm_oop_t, vm_oop_t);
 
 class UnaryPrim {
 public:
@@ -31,6 +32,21 @@ public:
     void MarkObjectAsInvalid() { pointer = nullptr; }
 
     vm_oop_t (*pointer)(vm_oop_t, vm_oop_t);
+
+    bool isClassSide;
+};
+
+class TernaryPrim {
+public:
+    TernaryPrim(TernaryPrimitiveRoutine ptr, bool classSide)
+        : pointer(ptr), isClassSide(classSide) {}
+    explicit TernaryPrim() : pointer(nullptr), isClassSide(false) {}
+
+    bool IsValid() const { return pointer != nullptr; }
+
+    void MarkObjectAsInvalid() { pointer = nullptr; }
+
+    vm_oop_t (*pointer)(vm_oop_t, vm_oop_t, vm_oop_t);
 
     bool isClassSide;
 };

--- a/src/unitTests/CloneObjectsTest.cpp
+++ b/src/unitTests/CloneObjectsTest.cpp
@@ -109,8 +109,8 @@ void CloneObjectsTest::testCloneSymbol() {
                                  clone->GetClass());
     CPPUNIT_ASSERT_EQUAL_MESSAGE("objectSize differs!!", orig->GetObjectSize(),
                                  clone->GetObjectSize());
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("string differs!!!", orig->GetPlainString(),
-                                 clone->GetPlainString());
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("string differs!!!", orig->GetStdString(),
+                                 clone->GetStdString());
     CPPUNIT_ASSERT_EQUAL_MESSAGE("hash differs!!", orig->GetHash(),
                                  clone->GetHash());
 }

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -32,6 +32,7 @@ void* vt_object;
 void* vt_primitive;
 void* vt_safe_un_primitive;
 void* vt_safe_bin_primitive;
+void* vt_safe_ter_primitive;
 void* vt_string;
 void* vt_symbol;
 
@@ -63,7 +64,8 @@ bool IsValidObject(vm_oop_t obj) {
              vt == vt_double || vt == vt_eval_primitive || vt == vt_frame ||
              vt == vt_integer || vt == vt_method || vt == vt_object ||
              vt == vt_primitive || vt == vt_safe_un_primitive ||
-             vt == vt_safe_bin_primitive || vt == vt_string || vt == vt_symbol;
+             vt == vt_safe_bin_primitive || vt == vt_safe_ter_primitive ||
+             vt == vt_string || vt == vt_symbol;
     if (!b) {
         assert(b && "Expected vtable to be one of the known ones.");
         return false;
@@ -101,6 +103,7 @@ void set_vt_to_null() {
     vt_primitive = nullptr;
     vt_safe_un_primitive = nullptr;
     vt_safe_bin_primitive = nullptr;
+    vt_safe_ter_primitive = nullptr;
     vt_string = nullptr;
     vt_symbol = nullptr;
 }
@@ -159,6 +162,10 @@ void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
     VMSafeBinaryPrimitive* sbp2 = new (GetHeap<HEAP_CLS>(), 0)
         VMSafeBinaryPrimitive(someValidSymbol, BinaryPrim());
     vt_safe_bin_primitive = get_vtable(sbp2);
+
+    VMSafeTernaryPrimitive* sbp3 = new (GetHeap<HEAP_CLS>(), 0)
+        VMSafeTernaryPrimitive(someValidSymbol, TernaryPrim());
+    vt_safe_ter_primitive = get_vtable(sbp3);
 
     VMString* str =
         new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -58,7 +58,6 @@
 #include "../vmobjects/VMObject.h"
 #include "../vmobjects/VMObjectBase.h"
 #include "../vmobjects/VMString.h"
-#include "../vmobjects/VMSymbol.h"
 #include "Globals.h"
 #include "IsValidObject.h"
 #include "LogAllocation.h"

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -89,6 +89,7 @@ class VMPrimitive;
 class VMSafePrimitive;
 class VMSafeUnaryPrimitive;
 class VMSafeBinaryPrimitive;
+class VMSafeTernaryPrimitive;
 class VMString;
 class VMSymbol;
 
@@ -148,6 +149,7 @@ class GCEvaluationPrimitive : public GCPrimitive { public: typedef VMEvaluationP
 class GCSafePrimitive  : public GCInvokable      { public: typedef VMSafePrimitive  Loaded; };
 class GCSafeUnaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeUnaryPrimitive  Loaded; };
 class GCSafeBinaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeBinaryPrimitive  Loaded; };
+class GCSafeTernaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeTernaryPrimitive  Loaded; };
 class GCString         : public GCAbstractObject { public: typedef VMString         Loaded; };
 class GCSymbol         : public GCString         { public: typedef VMSymbol         Loaded; };
 // clang-format on

--- a/src/vmobjects/VMArray.cpp
+++ b/src/vmobjects/VMArray.cpp
@@ -67,6 +67,17 @@ void VMArray::SetIndexableField(size_t idx, vm_oop_t value) {
     SetField(idx, value);
 }
 
+VMArray* VMArray::Copy() const {
+    VMArray* copy = GetUniverse()->NewArray(GetNumberOfIndexableFields());
+
+    const size_t additionalSpace = totalObjectSize - sizeof(VMArray);
+    void* destination = SHIFTED_PTR(copy, sizeof(VMArray));
+    const void* source = SHIFTED_PTR(this, sizeof(VMArray));
+    memcpy(destination, source, additionalSpace);
+
+    return copy;
+}
+
 VMArray* VMArray::CopyAndExtendWith(vm_oop_t item) const {
     const size_t fields = GetNumberOfIndexableFields();
     VMArray* result = GetUniverse()->NewArray(fields + 1);

--- a/src/vmobjects/VMArray.h
+++ b/src/vmobjects/VMArray.h
@@ -46,6 +46,9 @@ public:
 
     inline size_t GetNumberOfIndexableFields() const { return numberOfFields; }
 
+    /** Used from language level, via primitive */
+    VMArray* Copy() const;
+
     VMArray* CopyAndExtendWith(vm_oop_t) const;
     vm_oop_t GetIndexableField(size_t idx) const;
     void SetIndexableField(size_t idx, vm_oop_t value);

--- a/src/vmobjects/VMSafePrimitive.cpp
+++ b/src/vmobjects/VMSafePrimitive.cpp
@@ -37,6 +37,21 @@ void VMSafeBinaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
     frame->Push(prim.pointer(leftObj, rightObj));
 }
 
+VMSafePrimitive* VMSafePrimitive::GetSafeTernary(VMSymbol* sig,
+                                                 TernaryPrim prim) {
+    VMSafeTernaryPrimitive* p =
+        new (GetHeap<HEAP_CLS>(), 0) VMSafeTernaryPrimitive(sig, prim);
+    return p;
+}
+
+void VMSafeTernaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
+    vm_oop_t arg2 = frame->Pop();
+    vm_oop_t arg1 = frame->Pop();
+    vm_oop_t self = frame->Pop();
+
+    frame->Push(prim.pointer(self, arg1, arg2));
+}
+
 std::string VMSafePrimitive::AsDebugString() const {
     return "SafePrim(" + GetClass()->GetName()->GetStdString() + ">>#" +
            GetSignature()->GetStdString() + ")";
@@ -51,5 +66,11 @@ AbstractVMObject* VMSafeUnaryPrimitive::CloneForMovingGC() const {
 AbstractVMObject* VMSafeBinaryPrimitive::CloneForMovingGC() const {
     VMSafeBinaryPrimitive* prim =
         new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMSafeBinaryPrimitive(*this);
+    return prim;
+}
+
+AbstractVMObject* VMSafeTernaryPrimitive::CloneForMovingGC() const {
+    VMSafeTernaryPrimitive* prim =
+        new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMSafeTernaryPrimitive(*this);
     return prim;
 }

--- a/src/vmobjects/VMSymbol.cpp
+++ b/src/vmobjects/VMSymbol.cpp
@@ -28,7 +28,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <sstream>
 #include <string>
 
 #include "../memory/Heap.h"
@@ -69,70 +68,6 @@ VMSymbol* VMSymbol::CloneForMovingGC() const {
 
 VMClass* VMSymbol::GetClass() const {
     return load_ptr(symbolClass);
-}
-
-std::string VMSymbol::GetPlainString() const {
-    ostringstream str;
-    char* chars = this->chars;
-    size_t length = this->length;
-    for (size_t i = 0; i < length; i++) {
-        char c = chars[i];
-        switch (c) {
-            case '~':
-                str << "tilde";
-                break;
-            case '&':
-                str << "and";
-                break;
-            case '|':
-                str << "bar";
-                break;
-            case '*':
-                str << "star";
-                break;
-            case '/':
-                str << "slash";
-                break;
-            case '@':
-                str << "at";
-                break;
-            case '+':
-                str << "plus";
-                break;
-            case '-':
-                str << "minus";
-                break;
-            case '=':
-                str << "equal";
-                break;
-            case '>':
-                str << "greaterthan";
-                break;
-            case '<':
-                str << "lowerthan";
-                break;
-            case ',':
-                str << "comma";
-                break;
-            case '%':
-                str << "percent";
-                break;
-            case '\\':
-                str << "backslash";
-                break;
-            case ':':
-                str << '_';
-                break;
-            default:
-                if (c != 0) {
-                    str << c;
-                }
-                break;
-        }
-    }
-    std::string st = str.str();
-
-    return st;
 }
 
 void VMSymbol::WalkObjects(walk_heap_fn walk) {

--- a/src/vmobjects/VMSymbol.h
+++ b/src/vmobjects/VMSymbol.h
@@ -36,7 +36,6 @@ public:
     typedef GCSymbol Stored;
 
     VMSymbol(const size_t length, const char* const str);
-    StdString GetPlainString() const;
     size_t GetObjectSize() const override;
     VMSymbol* CloneForMovingGC() const override;
     VMClass* GetClass() const override;


### PR DESCRIPTION
Also introduce ternary safe primitives and use them where possible.

Lowered primitives:
 - Array>>#copy
 - Double #<=, #>, #>=, #<>, #~=, #min:, #max:
 - Integer #<=, #>, #>=, #<>, #~=, #min:, #max:, #abs, #to:
 - String>>#charAt:
