### PR TITLE
Remove EvaluationRoutine to simplify block evaluation handling

### DIFF
--- a/src/unitTests/CloneObjectsTest.cpp
+++ b/src/unitTests/CloneObjectsTest.cpp
@@ -192,9 +192,6 @@ void CloneObjectsTest::testCloneEvaluationPrimitive() {
                                  clone->signature);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("holder differs!!", orig->holder,
                                  clone->holder);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("empty differs!!", orig->empty, clone->empty);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("routine differs!!", orig->routine,
-                                 clone->routine);
     CPPUNIT_ASSERT_EQUAL_MESSAGE("numberOfArguments differs!!",
                                  orig->numberOfArguments,
                                  clone->numberOfArguments);

--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -42,7 +42,7 @@ static const size_t NoOfFields_Class = 4 + NoOfFields_Object;
 static const size_t NoOfFields_Frame = 3 + NoOfFields_Array;
 static const size_t NoOfFields_Block = 2 + NoOfFields_Object;
 static const size_t NoOfFields_Primitive = NoOfFields_Invokable;
-static const size_t NoOfFields_EvaluationPrimitive = 1 + NoOfFields_Primitive;
+static const size_t NoOfFields_EvaluationPrimitive = NoOfFields_Invokable;
 
 static vector<gc_oop_t> walkedObjects;
 /*
@@ -88,7 +88,6 @@ void WalkObjectsTest::testWalkEvaluationPrimitive() {
 
     CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(evPrim->GetSignature())));
     CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(evPrim->GetHolder())));
-    CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(evPrim)));
     CPPUNIT_ASSERT_EQUAL(NoOfFields_EvaluationPrimitive, walkedObjects.size());
 }
 

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -504,7 +504,7 @@ VMClass* Universe::GetBlockClassWithArgs(long numberOfArguments) {
     VMSymbol* name = SymbolFor(Str.str());
     VMClass* result = LoadClassBasic(name, nullptr);
 
-    result->AddInstancePrimitive(new (GetHeap<HEAP_CLS>(), 0)
+    result->AddInstanceInvokable(new (GetHeap<HEAP_CLS>(), 0)
                                      VMEvaluationPrimitive(numberOfArguments));
 
     SetGlobal(name, result);

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -145,7 +145,7 @@ class GCInteger        : public GCAbstractObject { public: typedef VMInteger    
 class GCInvokable      : public GCAbstractObject { public: typedef VMInvokable      Loaded; };
 class GCMethod         : public GCInvokable      { public: typedef VMMethod         Loaded; };
 class GCPrimitive      : public GCInvokable      { public: typedef VMPrimitive      Loaded; };
-class GCEvaluationPrimitive : public GCPrimitive { public: typedef VMEvaluationPrimitive Loaded; };
+class GCEvaluationPrimitive : public GCInvokable { public: typedef VMEvaluationPrimitive Loaded; };
 class GCSafePrimitive  : public GCInvokable      { public: typedef VMSafePrimitive  Loaded; };
 class GCSafeUnaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeUnaryPrimitive  Loaded; };
 class GCSafeBinaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeBinaryPrimitive  Loaded; };

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -40,7 +40,6 @@
 #include "VMArray.h"
 #include "VMInvokable.h"
 #include "VMObject.h"
-#include "VMPrimitive.h"
 #include "VMSymbol.h"
 
 const size_t VMClass::VMClassNumberOfFields = 4;
@@ -94,13 +93,6 @@ bool VMClass::AddInstanceInvokable(VMInvokable* ptr) {
               instInvokables->CopyAndExtendWith((vm_oop_t)ptr));
 
     return true;
-}
-
-void VMClass::AddInstancePrimitive(VMPrimitive* ptr) {
-    if (AddInstanceInvokable(ptr)) {
-        // cout << "Warn: Primitive "<<ptr->GetSignature<<" is not in class
-        // definition for class " << name->GetStdString() << endl;
-    }
 }
 
 VMSymbol* VMClass::GetInstanceFieldName(long index) const {

--- a/src/vmobjects/VMClass.h
+++ b/src/vmobjects/VMClass.h
@@ -63,7 +63,6 @@ public:
     VMInvokable* LookupInvokable(VMSymbol*) const;
     long LookupFieldIndex(VMSymbol*) const;
     bool AddInstanceInvokable(VMInvokable*);
-    void AddInstancePrimitive(VMPrimitive*);
     VMSymbol* GetInstanceFieldName(long) const;
     size_t GetNumberOfInstanceFields() const;
     bool HasPrimitives() const;

--- a/src/vmobjects/VMPrimitive.h
+++ b/src/vmobjects/VMPrimitive.h
@@ -38,7 +38,7 @@ public:
 
     VMPrimitive(VMSymbol* sig);
 
-    VMClass* GetClass() const override { return load_ptr(primitiveClass); }
+    VMClass* GetClass() const final { return load_ptr(primitiveClass); }
 
     inline size_t GetObjectSize() const override { return sizeof(VMPrimitive); }
 

--- a/src/vmobjects/VMSafePrimitive.h
+++ b/src/vmobjects/VMSafePrimitive.h
@@ -8,7 +8,7 @@ public:
 
     VMSafePrimitive(VMSymbol* sig) : VMInvokable(sig) {}
 
-    VMClass* GetClass() const override { return load_ptr(primitiveClass); }
+    VMClass* GetClass() const final { return load_ptr(primitiveClass); }
 
     inline size_t GetObjectSize() const override {
         return sizeof(VMSafePrimitive);
@@ -31,8 +31,6 @@ public:
         : VMSafePrimitive(sig), prim(prim) {
         write_barrier(this, sig);
     }
-
-    VMClass* GetClass() const override { return load_ptr(primitiveClass); }
 
     inline size_t GetObjectSize() const override {
         return sizeof(VMSafeUnaryPrimitive);
@@ -62,8 +60,6 @@ public:
         write_barrier(this, sig);
     }
 
-    VMClass* GetClass() const override { return load_ptr(primitiveClass); }
-
     inline size_t GetObjectSize() const override {
         return sizeof(VMSafeBinaryPrimitive);
     }
@@ -91,8 +87,6 @@ public:
         : VMSafePrimitive(sig), prim(prim) {
         write_barrier(this, sig);
     }
-
-    VMClass* GetClass() const override { return load_ptr(primitiveClass); }
 
     inline size_t GetObjectSize() const override {
         return sizeof(VMSafeTernaryPrimitive);


### PR DESCRIPTION
I am not quite sure what the point of `EvaluationRoutine` is.
I suspect it was to make sure primitives can be handled uniformly with the block evaluation.
But that seems not very beneficial, and makes the code more complex.

So, this PR removes `EvaluationRoutine`.