### PR TITLE
Add RETURN_SELF and optimize the DUP, POP_X, POP sequences

### DIFF
--- a/src/compiler/BytecodeGenerator.cpp
+++ b/src/compiler/BytecodeGenerator.cpp
@@ -246,6 +246,10 @@ void EmitSUPERSEND(MethodGenerationContext& mgenc, VMSymbol* msg) {
     Emit2(mgenc, BC_SUPER_SEND, idx, stackEffect);
 }
 
+void EmitRETURNSELF(MethodGenerationContext& mgenc) {
+    Emit1(mgenc, BC_RETURN_SELF, 0);
+}
+
 void EmitRETURNLOCAL(MethodGenerationContext& mgenc) {
     Emit1(mgenc, BC_RETURN_LOCAL, 0);
 }

--- a/src/compiler/BytecodeGenerator.cpp
+++ b/src/compiler/BytecodeGenerator.cpp
@@ -186,7 +186,9 @@ void EmitPUSHGLOBAL(MethodGenerationContext& mgenc, VMSymbol* global) {
 }
 
 void EmitPOP(MethodGenerationContext& mgenc) {
-    Emit1(mgenc, BC_POP, -1);
+    if (!mgenc.OptimizeDupPopPopSequence()) {
+        Emit1(mgenc, BC_POP, -1);
+    }
 }
 
 void EmitPOPLOCAL(MethodGenerationContext& mgenc, long idx, int ctx) {
@@ -247,6 +249,7 @@ void EmitSUPERSEND(MethodGenerationContext& mgenc, VMSymbol* msg) {
 }
 
 void EmitRETURNSELF(MethodGenerationContext& mgenc) {
+    mgenc.OptimizeDupPopPopSequence();
     Emit1(mgenc, BC_RETURN_SELF, 0);
 }
 

--- a/src/compiler/BytecodeGenerator.h
+++ b/src/compiler/BytecodeGenerator.h
@@ -55,6 +55,7 @@ void EmitPOPARGUMENT(MethodGenerationContext& mgenc, long idx, int ctx);
 void EmitPOPFIELD(MethodGenerationContext& mgenc, VMSymbol* field);
 void EmitSEND(MethodGenerationContext& mgenc, VMSymbol* msg);
 void EmitSUPERSEND(MethodGenerationContext& mgenc, VMSymbol* msg);
+void EmitRETURNSELF(MethodGenerationContext& mgenc);
 void EmitRETURNLOCAL(MethodGenerationContext& mgenc);
 void EmitRETURNNONLOCAL(MethodGenerationContext& mgenc);
 

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -38,6 +38,8 @@
 
 class Parser;
 
+#define NUM_LAST_BYTECODES 4
+
 class MethodGenerationContext {
 public:
     MethodGenerationContext(ClassGenerationContext& holder,
@@ -84,6 +86,8 @@ public:
     bool IsFinished() const { return finished; }
 
     void RemoveLastBytecode() { bytecode.pop_back(); };
+    void RemoveLastPopForBlockLocalReturn();
+
     size_t GetNumberOfArguments();
     void AddBytecode(uint8_t bc, size_t stackEffect);
     void AddBytecodeArgument(uint8_t bc);
@@ -109,11 +113,26 @@ public:
     void EmitBackwardsJumpOffsetToTarget(size_t loopBeginIdx);
     void PatchJumpOffsetToPointToNextInstruction(size_t indexOfOffset);
 
+    bool OptimizeDupPopPopSequence();
+
 private:
+    bool optimizeIncFieldPush() {
+        // TODO: implement
+        return false;
+    }
+
     void removeLastBytecodes(size_t numBytecodes);
+    void removeLastBytecodeAt(size_t indexFromEnd);
+
     bool hasOneLiteralBlockArgument();
     bool hasTwoLiteralBlockArguments();
+    uint8_t lastBytecodeAt(size_t indexFromEnd);
     bool lastBytecodeIs(size_t indexFromEnd, uint8_t bytecode);
+    uint8_t lastBytecodeIsOneOf(size_t indexFromEnd,
+                                uint8_t (*predicate)(uint8_t));
+
+    size_t getOffsetOfLastBytecode(size_t indexFromEnd);
+
     std::tuple<vm_oop_t, vm_oop_t> extractBlockMethodsAndRemoveBytecodes();
     vm_oop_t extractBlockMethodAndRemoveBytecode();
 
@@ -143,7 +162,7 @@ private:
     size_t currentStackDepth;
     size_t maxStackDepth;
 
-    std::array<uint8_t, 4> last4Bytecodes;
+    std::array<uint8_t, NUM_LAST_BYTECODES> last4Bytecodes;
 
     std::vector<BackJump> inlinedLoops;
 

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -348,7 +348,8 @@ void Parser::methodBlock(MethodGenerationContext& mgenc) {
     // terminating the last expression, so the last expression's value must be
     // popped off the stack and a ^self be generated
     if (!mgenc.IsFinished()) {
-        // don't need to pop of the value, because RETURN_SELF doesn't need stack space
+        // don't need to pop of the value, because RETURN_SELF doesn't need
+        // stack space
         EmitRETURNSELF(mgenc);
         mgenc.SetFinished();
     }
@@ -422,7 +423,7 @@ void Parser::blockBody(MethodGenerationContext& mgenc, bool seen_period,
             // a POP has been generated which must be elided (blocks always
             // return the value of the last expression, regardless of whether it
             // was terminated with a . or not)
-            mgenc.RemoveLastBytecode();
+            mgenc.RemoveLastPopForBlockLocalReturn();
         }
         if (!is_inlined) {
             // if the block is empty, we need to return nil

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -348,9 +348,8 @@ void Parser::methodBlock(MethodGenerationContext& mgenc) {
     // terminating the last expression, so the last expression's value must be
     // popped off the stack and a ^self be generated
     if (!mgenc.IsFinished()) {
-        EmitPOP(mgenc);
-        EmitPUSHARGUMENT(mgenc, 0, 0);
-        EmitRETURNLOCAL(mgenc);
+        // don't need to pop of the value, because RETURN_SELF doesn't need stack space
+        EmitRETURNSELF(mgenc);
         mgenc.SetFinished();
     }
 
@@ -435,10 +434,8 @@ void Parser::blockBody(MethodGenerationContext& mgenc, bool seen_period,
         }
     } else if (sym == EndTerm) {
         // it does not matter whether a period has been seen, as the end of the
-        // method has been found (EndTerm) - so it is safe to emit a "return
-        // self"
-        EmitPUSHARGUMENT(mgenc, 0, 0);
-        EmitRETURNLOCAL(mgenc);
+        // method has been found (EndTerm). It's safe to emit a "return self"
+        EmitRETURNSELF(mgenc);
         mgenc.SetFinished();
     } else {
         expression(mgenc);
@@ -450,6 +447,20 @@ void Parser::blockBody(MethodGenerationContext& mgenc, bool seen_period,
 }
 
 void Parser::result(MethodGenerationContext& mgenc) {
+    // try first to parse a `^ self` to emit RETURN_SELF
+    if (!mgenc.IsBlockMethod() && sym == Identifier && text == strSelf) {
+        PeekForNextSymbolFromLexerIfNecessary();
+        if (nextSym == Period || nextSym == EndTerm) {
+            expect(Identifier);
+
+            EmitRETURNSELF(mgenc);
+            mgenc.SetFinished();
+
+            accept(Period);
+            return;
+        }
+    }
+
     expression(mgenc);
 
     if (mgenc.IsBlockMethod()) {
@@ -463,7 +474,7 @@ void Parser::result(MethodGenerationContext& mgenc) {
 }
 
 void Parser::expression(MethodGenerationContext& mgenc) {
-    Peek();
+    PeekForNextSymbolFromLexerIfNecessary();
     if (nextSym == Assign) {
         assignation(mgenc);
     } else {

--- a/src/interpreter/InterpreterLoop.h
+++ b/src/interpreter/InterpreterLoop.h
@@ -41,6 +41,7 @@ vm_oop_t Start() {
                            &&LABEL_BC_SUPER_SEND,
                            &&LABEL_BC_RETURN_LOCAL,
                            &&LABEL_BC_RETURN_NON_LOCAL,
+                           &&LABEL_BC_RETURN_SELF,
                            &&LABEL_BC_INC,
                            &&LABEL_BC_JUMP,
                            &&LABEL_BC_JUMP_ON_FALSE_POP,
@@ -260,6 +261,13 @@ LABEL_BC_RETURN_NON_LOCAL:
     PROLOGUE(1);
     doReturnNonLocal();
     DISPATCH_NOGC();
+
+LABEL_BC_RETURN_SELF: {
+    PROLOGUE(1);
+    assert(GetFrame()->GetContext() == nullptr && "RETURN_SELF is not allowed in blocks");
+    popFrameAndPushResult(GetFrame()->GetArgumentInCurrentContext(0));
+    DISPATCH_NOGC();
+}
 
 LABEL_BC_INC:
     PROLOGUE(1);

--- a/src/interpreter/InterpreterLoop.h
+++ b/src/interpreter/InterpreterLoop.h
@@ -264,7 +264,8 @@ LABEL_BC_RETURN_NON_LOCAL:
 
 LABEL_BC_RETURN_SELF: {
     PROLOGUE(1);
-    assert(GetFrame()->GetContext() == nullptr && "RETURN_SELF is not allowed in blocks");
+    assert(GetFrame()->GetContext() == nullptr &&
+           "RETURN_SELF is not allowed in blocks");
     popFrameAndPushResult(GetFrame()->GetArgumentInCurrentContext(0));
     DISPATCH_NOGC();
 }

--- a/src/interpreter/bytecodes.cpp
+++ b/src/interpreter/bytecodes.cpp
@@ -148,6 +148,88 @@ bool IsJumpBytecode(uint8_t bc) {
     return BC_JUMP <= bc && bc <= BC_JUMP2_BACKWARD;
 }
 
+uint8_t IsPushConstBytecode(uint8_t bc) {
+    switch (bc) {
+        case BC_PUSH_CONSTANT:
+        case BC_PUSH_CONSTANT_0:
+        case BC_PUSH_CONSTANT_1:
+        case BC_PUSH_CONSTANT_2:
+        case BC_PUSH_0:
+        case BC_PUSH_1:
+        case BC_PUSH_NIL:
+            return bc;
+
+        default:
+            return BC_INVALID;
+    }
+}
+
+uint8_t IsPushArgBytecode(uint8_t bc) {
+    switch (bc) {
+        case BC_PUSH_SELF:
+        case BC_PUSH_ARG_1:
+        case BC_PUSH_ARG_2:
+        case BC_PUSH_ARGUMENT:
+            return bc;
+
+        default:
+            return BC_INVALID;
+    }
+}
+
+uint8_t IsPushFieldBytecode(uint8_t bc) {
+    switch (bc) {
+        case BC_PUSH_FIELD:
+        case BC_PUSH_FIELD_0:
+        case BC_PUSH_FIELD_1:
+            return bc;
+
+        default:
+            return BC_INVALID;
+    }
+}
+
+uint8_t IsPopFieldBytecode(uint8_t bc) {
+    switch (bc) {
+        case BC_POP_FIELD:
+        case BC_POP_FIELD_0:
+        case BC_POP_FIELD_1:
+            return bc;
+
+        default:
+            return BC_INVALID;
+    }
+}
+
+uint8_t IsReturnFieldBytecode(uint8_t bc) {
+    switch (bc) {
+        case BC_RETURN_FIELD_0:
+        case BC_RETURN_FIELD_1:
+        case BC_RETURN_FIELD_2:
+            return bc;
+
+        default:
+            return BC_INVALID;
+    }
+}
+
+uint8_t IsPopSmthBytecode(uint8_t bc) {
+    switch (bc) {
+        case BC_POP_LOCAL:
+        case BC_POP_LOCAL_0:
+        case BC_POP_LOCAL_1:
+        case BC_POP_LOCAL_2:
+        case BC_POP_ARGUMENT:
+        case BC_POP_FIELD:
+        case BC_POP_FIELD_0:
+        case BC_POP_FIELD_1:
+            return bc;
+
+        default:
+            return BC_INVALID;
+    }
+}
+
 bool Bytecode::BytecodeDefinitionsAreConsistent() {
     bool namesAndLengthMatch =
         (sizeof(Bytecode::bytecodeNames) / sizeof(char*)) ==

--- a/src/interpreter/bytecodes.cpp
+++ b/src/interpreter/bytecodes.cpp
@@ -66,6 +66,7 @@ const uint8_t Bytecode::bytecodeLengths[] = {
     2,  // BC_SUPER_SEND
     1,  // BC_RETURN_LOCAL
     1,  // BC_RETURN_NON_LOCAL
+    1,  // BC_RETURN_SELF
     1,  // BC_INC
 
     3,  // BC_JUMP
@@ -122,21 +123,22 @@ const char* Bytecode::bytecodeNames[] = {
     "SUPER_SEND      ",        // 33
     "RETURN_LOCAL    ",        // 34
     "RETURN_NON_LOCAL",        // 35
-    "INC             ",        // 36
-    "JUMP            ",        // 37
-    "JUMP_ON_FALSE_POP",       // 38
-    "JUMP_ON_TRUE_POP",        // 39
-    "JUMP_ON_FALSE_TOP_NIL",   // 40
-    "JUMP_ON_TRUE_TOP_NIL",    // 41
-    "JUMP_IF_GREATER ",        // 42
-    "JUMP_BACKWARD   ",        // 43
-    "JUMP2           ",        // 44
-    "JUMP2_ON_FALSE_POP",      // 45
-    "JUMP2_ON_TRUE_POP",       // 46
-    "JUMP2_ON_FALSE_TOP_NIL",  // 47
-    "JUMP2_ON_TRUE_TOP_NIL",   // 48
-    "JUMP2_IF_GREATER",        // 49
-    "JUMP2_BACKWARD  ",        // 50
+    "RETURN_SELF     ",        // 36
+    "INC             ",        // 37
+    "JUMP            ",        // 38
+    "JUMP_ON_FALSE_POP",       // 39
+    "JUMP_ON_TRUE_POP",        // 40
+    "JUMP_ON_FALSE_TOP_NIL",   // 41
+    "JUMP_ON_TRUE_TOP_NIL",    // 42
+    "JUMP_IF_GREATER ",        // 43
+    "JUMP_BACKWARD   ",        // 44
+    "JUMP2           ",        // 45
+    "JUMP2_ON_FALSE_POP",      // 46
+    "JUMP2_ON_TRUE_POP",       // 47
+    "JUMP2_ON_FALSE_TOP_NIL",  // 48
+    "JUMP2_ON_TRUE_TOP_NIL",   // 49
+    "JUMP2_IF_GREATER",        // 50
+    "JUMP2_BACKWARD  ",        // 51
 };
 
 bool IsJumpBytecode(uint8_t bc) {

--- a/src/interpreter/bytecodes.h
+++ b/src/interpreter/bytecodes.h
@@ -69,21 +69,22 @@
 #define BC_SUPER_SEND             33
 #define BC_RETURN_LOCAL           34
 #define BC_RETURN_NON_LOCAL       35
-#define BC_INC                    36
-#define BC_JUMP                   37
-#define BC_JUMP_ON_FALSE_POP      38
-#define BC_JUMP_ON_TRUE_POP       39
-#define BC_JUMP_ON_FALSE_TOP_NIL  40
-#define BC_JUMP_ON_TRUE_TOP_NIL   41
-#define BC_JUMP_IF_GREATER        42
-#define BC_JUMP_BACKWARD          43
-#define BC_JUMP2                  44
-#define BC_JUMP2_ON_FALSE_POP     45
-#define BC_JUMP2_ON_TRUE_POP      46
-#define BC_JUMP2_ON_FALSE_TOP_NIL 47
-#define BC_JUMP2_ON_TRUE_TOP_NIL  48
-#define BC_JUMP2_IF_GREATER       49
-#define BC_JUMP2_BACKWARD         50
+#define BC_RETURN_SELF            36
+#define BC_INC                    37
+#define BC_JUMP                   38
+#define BC_JUMP_ON_FALSE_POP      39
+#define BC_JUMP_ON_TRUE_POP       40
+#define BC_JUMP_ON_FALSE_TOP_NIL  41
+#define BC_JUMP_ON_TRUE_TOP_NIL   42
+#define BC_JUMP_IF_GREATER        43
+#define BC_JUMP_BACKWARD          44
+#define BC_JUMP2                  45
+#define BC_JUMP2_ON_FALSE_POP     46
+#define BC_JUMP2_ON_TRUE_POP      47
+#define BC_JUMP2_ON_FALSE_TOP_NIL 48
+#define BC_JUMP2_ON_TRUE_TOP_NIL  49
+#define BC_JUMP2_IF_GREATER       50
+#define BC_JUMP2_BACKWARD         51
 
 #define _LAST_BYTECODE BC_JUMP2_BACKWARD
 
@@ -104,7 +105,6 @@
 #define BC_RETURN_FIELD_0    246
 #define BC_RETURN_FIELD_1    245
 #define BC_RETURN_FIELD_2    244
-#define BC_RETURN_SELF       243
 // clang-format on
 
 // properties of the bytecodes

--- a/src/interpreter/bytecodes.h
+++ b/src/interpreter/bytecodes.h
@@ -135,3 +135,9 @@ inline uint16_t ComputeOffset(uint8_t byte1, uint8_t byte2) {
 }
 
 bool IsJumpBytecode(uint8_t bc);
+uint8_t IsPushConstBytecode(uint8_t bc);
+uint8_t IsPushFieldBytecode(uint8_t bc);
+uint8_t IsPushArgBytecode(uint8_t bc);
+uint8_t IsPopFieldBytecode(uint8_t bc);
+uint8_t IsPopSmthBytecode(uint8_t bc);
+uint8_t IsReturnFieldBytecode(uint8_t bc);

--- a/src/unitTests/BytecodeGenerationTest.cpp
+++ b/src/unitTests/BytecodeGenerationTest.cpp
@@ -115,24 +115,12 @@ void BytecodeGenerationTest::testIfPushConstantSame() {
                                         #a. #b. #c. #d.
                                         true ifFalse: [ #a. #b. #c. #d. ]
                                       ) )""");
-    check(bytecodes, {BC_PUSH_CONSTANT_0,
-                      BC_POP,
-                      BC_PUSH_CONSTANT_1,
-                      BC_POP,
-                      BC_PUSH_CONSTANT_2,
-                      BC_POP,
-                      BC(BC_PUSH_CONSTANT, 3),
-                      BC_POP,
-                      BC(BC_PUSH_CONSTANT, 4),
-                      BC(BC_JUMP_ON_TRUE_TOP_NIL, 11, 0),
-                      BC_PUSH_CONSTANT_0,
-                      BC_POP,
-                      BC_PUSH_CONSTANT_1,
-                      BC_POP,
-                      BC_PUSH_CONSTANT_2,
-                      BC_POP,
-                      BC(BC_PUSH_CONSTANT, 3),
-                      BC_RETURN_SELF});
+    check(bytecodes, {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_CONSTANT_1, BC_POP,
+                      BC_PUSH_CONSTANT_2, BC_POP, BC(BC_PUSH_CONSTANT, 3),
+                      BC_POP, BC(BC_PUSH_CONSTANT, 4),
+                      BC(BC_JUMP_ON_TRUE_TOP_NIL, 11, 0), BC_PUSH_CONSTANT_0,
+                      BC_POP, BC_PUSH_CONSTANT_1, BC_POP, BC_PUSH_CONSTANT_2,
+                      BC_POP, BC(BC_PUSH_CONSTANT, 3), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testIfPushConstantDifferent() {
@@ -141,24 +129,13 @@ void BytecodeGenerationTest::testIfPushConstantDifferent() {
                                         #a. #b. #c. #d.
                                         true ifFalse: [ #e. #f. #g. #h. ]
                                       ) )""");
-    check(bytecodes, {BC_PUSH_CONSTANT_0,
-                      BC_POP,
-                      BC_PUSH_CONSTANT_1,
-                      BC_POP,
-                      BC_PUSH_CONSTANT_2,
-                      BC_POP,
-                      BC(BC_PUSH_CONSTANT, 3),
-                      BC_POP,
-                      BC(BC_PUSH_CONSTANT, 4),
-                      BC(BC_JUMP_ON_TRUE_TOP_NIL, 14, 0),
-                      BC(BC_PUSH_CONSTANT, 5),
-                      BC_POP,
-                      BC(BC_PUSH_CONSTANT, 6),
-                      BC_POP,
-                      BC(BC_PUSH_CONSTANT, 7),
-                      BC_POP,
-                      BC(BC_PUSH_CONSTANT, 8),
-                      BC_RETURN_SELF});
+    check(bytecodes,
+          {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_CONSTANT_1, BC_POP,
+           BC_PUSH_CONSTANT_2, BC_POP, BC(BC_PUSH_CONSTANT, 3), BC_POP,
+           BC(BC_PUSH_CONSTANT, 4), BC(BC_JUMP_ON_TRUE_TOP_NIL, 14, 0),
+           BC(BC_PUSH_CONSTANT, 5), BC_POP, BC(BC_PUSH_CONSTANT, 6), BC_POP,
+           BC(BC_PUSH_CONSTANT, 7), BC_POP, BC(BC_PUSH_CONSTANT, 8),
+           BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testExplicitReturnSelf() {
@@ -170,32 +147,27 @@ void BytecodeGenerationTest::testExplicitReturnSelf() {
 void BytecodeGenerationTest::testDupPopArgumentPop() {
     auto bytecodes = methodToBytecode("test: arg = ( arg := 1. ^ self )");
 
-    check(bytecodes, {BC_PUSH_1, BC_DUP, BC(BC_POP_ARGUMENT, 1, 0),
-                      BC_POP,
-                      BC_RETURN_SELF});
+    check(bytecodes, {BC_PUSH_1, BC(BC_POP_ARGUMENT, 1, 0), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopArgumentPopImplicitReturnSelf() {
     auto bytecodes = methodToBytecode("test: arg = ( arg := 1 )");
 
-    check(bytecodes, {BC_PUSH_1, BC_DUP, BC(BC_POP_ARGUMENT, 1, 0),
-                      BC_RETURN_SELF});
+    check(bytecodes, {BC_PUSH_1, BC(BC_POP_ARGUMENT, 1, 0), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopLocalPop() {
     auto bytecodes =
         methodToBytecode("test = ( | local | local := 1. ^ self )");
 
-    check(bytecodes, {BC_PUSH_1, BC_DUP, BC_POP_LOCAL_0, BC_POP,
-                      BC_RETURN_SELF});
+    check(bytecodes, {BC_PUSH_1, BC_POP_LOCAL_0, BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopField0Pop() {
     addField("field");
     auto bytecodes = methodToBytecode("test = ( field := 1. ^ self )");
 
-    check(bytecodes, {BC_PUSH_1, BC_DUP, BC_POP_FIELD_0, BC_POP,
-                      BC_RETURN_SELF});
+    check(bytecodes, {BC_PUSH_1, BC_POP_FIELD_0, BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopFieldPop() {
@@ -206,16 +178,14 @@ void BytecodeGenerationTest::testDupPopFieldPop() {
     addField("field");
     auto bytecodes = methodToBytecode("test = ( field := 1. ^ self )");
 
-    check(bytecodes, {BC_PUSH_1, BC_DUP, BC(BC_POP_FIELD, 4), BC_POP,
-                      BC_RETURN_SELF});
+    check(bytecodes, {BC_PUSH_1, BC(BC_POP_FIELD, 4), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopFieldReturnSelf() {
     addField("field");
     auto bytecodes = methodToBytecode("test: val = ( field := val )");
 
-    check(bytecodes, {BC_PUSH_ARG_1, BC_DUP, BC_POP_FIELD_0,
-                      BC_RETURN_SELF});
+    check(bytecodes, {BC_PUSH_ARG_1, BC_POP_FIELD_0, BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopFieldNReturnSelf() {
@@ -227,7 +197,7 @@ void BytecodeGenerationTest::testDupPopFieldNReturnSelf() {
     addField("field");
     auto bytecodes = methodToBytecode("test: val = ( field := val )");
 
-    check(bytecodes, {BC_PUSH_ARG_1, BC_DUP, BC(BC_POP_FIELD, 5), BC_RETURN_SELF});
+    check(bytecodes, {BC_PUSH_ARG_1, BC(BC_POP_FIELD, 5), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testSendDupPopFieldReturnLocal() {
@@ -251,8 +221,8 @@ void BytecodeGenerationTest::testSendDupPopFieldReturnLocalPeriod() {
 void BytecodeGenerationTest::testBlockDupPopArgumentPopReturnArg() {
     auto bytecodes = blockToBytecode("[:arg | arg := 1. arg ]");
 
-    check(bytecodes, {BC_PUSH_1, BC_DUP, BC(BC_POP_ARGUMENT, 1, 0), BC_POP,
-                      BC_PUSH_ARG_1, BC_RETURN_LOCAL});
+    check(bytecodes, {BC_PUSH_1, BC(BC_POP_ARGUMENT, 1, 0), BC_PUSH_ARG_1,
+                      BC_RETURN_LOCAL});
 }
 
 void BytecodeGenerationTest::testBlockDupPopArgumentImplicitReturn() {
@@ -302,8 +272,8 @@ void BytecodeGenerationTest::testPushArgOpt() {
                                       ) )""");
     check(bytecodes,
           {BC_PUSH_SELF, BC_POP, BC_PUSH_ARG_1, BC_POP, BC_PUSH_ARG_2, BC_POP,
-           BC(BC_PUSH_ARGUMENT, 3, 0), BC_POP, BC(BC_PUSH_ARGUMENT, 4, 0), BC_POP,
-           BC_RETURN_SELF});
+           BC(BC_PUSH_ARGUMENT, 3, 0), BC_POP, BC(BC_PUSH_ARGUMENT, 4, 0),
+           BC_POP, BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testPushFieldOpt() {
@@ -312,10 +282,9 @@ void BytecodeGenerationTest::testPushFieldOpt() {
     addField("f3");
     addField("f4");
     auto bytecodes = methodToBytecode("test = ( f1. f2. f3. f4 )");
-    check(
-        bytecodes,
-        {BC_PUSH_FIELD_0, BC_POP, BC_PUSH_FIELD_1, BC_POP, BC(BC_PUSH_FIELD, 2),
-         BC_POP, BC(BC_PUSH_FIELD, 3), BC_RETURN_SELF});
+    check(bytecodes,
+          {BC_PUSH_FIELD_0, BC_POP, BC_PUSH_FIELD_1, BC_POP,
+           BC(BC_PUSH_FIELD, 2), BC_POP, BC(BC_PUSH_FIELD, 3), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testBlockPushFieldOpt() {
@@ -342,12 +311,9 @@ void BytecodeGenerationTest::testPopLocalOpt() {
                                         l5 := 1.
                                       ) )""");
     check(bytecodes,
-          {BC_PUSH_1,    BC_DUP,         BC_POP_LOCAL_0,         BC_POP,
-           BC_PUSH_1,    BC_DUP,         BC_POP_LOCAL_1,         BC_POP,
-           BC_PUSH_1,    BC_DUP,         BC_POP_LOCAL_2,         BC_POP,
-           BC_PUSH_1,    BC_DUP,         BC(BC_POP_LOCAL, 3, 0), BC_POP,
-           BC_PUSH_1,    BC_DUP,         BC(BC_POP_LOCAL, 4, 0), BC_POP,
-           BC_RETURN_SELF});
+          {BC_PUSH_1, BC_POP_LOCAL_0, BC_PUSH_1, BC_POP_LOCAL_1, BC_PUSH_1,
+           BC_POP_LOCAL_2, BC_PUSH_1, BC(BC_POP_LOCAL, 3, 0), BC_PUSH_1,
+           BC(BC_POP_LOCAL, 4, 0), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testPopFieldOpt() {
@@ -362,10 +328,10 @@ void BytecodeGenerationTest::testPopFieldOpt() {
                                         f3 := 1.
                                         f4 := 1.
                                       ) )""");
-    check(bytecodes,
-          {BC_PUSH_1, BC_DUP, BC_POP_FIELD_0, BC_POP, BC_PUSH_1, BC_DUP,
-           BC_POP_FIELD_1, BC_POP, BC_PUSH_1, BC_DUP, BC(BC_POP_FIELD, 2),
-           BC_POP, BC_PUSH_1, BC_DUP, BC(BC_POP_FIELD, 3), BC_POP, BC_RETURN_SELF});
+    check(
+        bytecodes,
+        {BC_PUSH_1, BC_POP_FIELD_0, BC_PUSH_1, BC_POP_FIELD_1, BC_PUSH_1,
+         BC(BC_POP_FIELD, 2), BC_PUSH_1, BC(BC_POP_FIELD, 3), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::check(std::vector<uint8_t> actual,
@@ -597,11 +563,10 @@ void BytecodeGenerationTest::ifTrueWithSomethingAndLiteralReturn(
     bool twoByte2 = bytecode.bytecode == BC_PUSH_GLOBAL ||
                     bytecode.bytecode == BC_PUSH_BLOCK;
 
-    check(
-        bytecodes,
-        {BC_PUSH_SELF, BC(BC_SEND, 0),
-         BC(BC_JUMP_ON_FALSE_TOP_NIL, twoByte2 ? 7 : 6, 0), BC_PUSH_CONSTANT_1,
-         BC_POP, bytecode, BC_POP, BC_RETURN_SELF});
+    check(bytecodes,
+          {BC_PUSH_SELF, BC(BC_SEND, 0),
+           BC(BC_JUMP_ON_FALSE_TOP_NIL, twoByte2 ? 7 : 6, 0),
+           BC_PUSH_CONSTANT_1, BC_POP, bytecode, BC_POP, BC_RETURN_SELF});
 
     tearDown();
 }
@@ -709,7 +674,7 @@ void BytecodeGenerationTest::testInliningOfToDo() {
                              // block's code
            BC_POP,           // cleanup after block
            BC_INC,           // increment top, the iteration counter
-        
+
            // jump back to the jump_if_greater bytecode
            BC(BC_JUMP_BACKWARD, 8, 0),
 

--- a/src/unitTests/BytecodeGenerationTest.cpp
+++ b/src/unitTests/BytecodeGenerationTest.cpp
@@ -95,7 +95,7 @@ std::vector<uint8_t> BytecodeGenerationTest::blockToBytecode(
 void BytecodeGenerationTest::testEmptyMethodReturnsSelf() {
     auto bytecodes = methodToBytecode("test = ( )");
 
-    check(bytecodes, {BC(BC_PUSH_SELF), BC(BC_RETURN_LOCAL)});
+    check(bytecodes, {BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testPushConstant() {
@@ -106,7 +106,7 @@ void BytecodeGenerationTest::testPushConstant() {
     check(bytecodes,
           {BC_PUSH_0, BC_POP, BC_PUSH_1, BC_POP, BC_PUSH_NIL, BC_POP,
            BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_CONSTANT_1, BC_POP,
-           BC_PUSH_CONSTANT_2, BC_POP, BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC_PUSH_CONSTANT_2, BC_POP, BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testIfPushConstantSame() {
@@ -132,9 +132,7 @@ void BytecodeGenerationTest::testIfPushConstantSame() {
                       BC_PUSH_CONSTANT_2,
                       BC_POP,
                       BC(BC_PUSH_CONSTANT, 3),
-                      BC_POP,
-                      BC_PUSH_SELF,
-                      BC_RETURN_LOCAL});
+                      BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testIfPushConstantDifferent() {
@@ -160,45 +158,44 @@ void BytecodeGenerationTest::testIfPushConstantDifferent() {
                       BC(BC_PUSH_CONSTANT, 7),
                       BC_POP,
                       BC(BC_PUSH_CONSTANT, 8),
-                      BC_POP,
-                      BC_PUSH_SELF,
-                      BC_RETURN_LOCAL});
+                      BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testExplicitReturnSelf() {
     auto bytecodes = methodToBytecode("test = ( ^ self )");
 
-    check(bytecodes, {BC_PUSH_SELF, BC_RETURN_LOCAL});
+    check(bytecodes, {BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopArgumentPop() {
     auto bytecodes = methodToBytecode("test: arg = ( arg := 1. ^ self )");
 
-    check(bytecodes, {BC_PUSH_1, BC_DUP, BC(BC_POP_ARGUMENT, 1, 0), BC_POP,
-                      BC_PUSH_SELF, BC_RETURN_LOCAL});
+    check(bytecodes, {BC_PUSH_1, BC_DUP, BC(BC_POP_ARGUMENT, 1, 0),
+                      BC_POP,
+                      BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopArgumentPopImplicitReturnSelf() {
     auto bytecodes = methodToBytecode("test: arg = ( arg := 1 )");
 
-    check(bytecodes, {BC_PUSH_1, BC_DUP, BC(BC_POP_ARGUMENT, 1, 0), BC_POP,
-                      BC_PUSH_SELF, BC_RETURN_LOCAL});
+    check(bytecodes, {BC_PUSH_1, BC_DUP, BC(BC_POP_ARGUMENT, 1, 0),
+                      BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopLocalPop() {
     auto bytecodes =
         methodToBytecode("test = ( | local | local := 1. ^ self )");
 
-    check(bytecodes, {BC_PUSH_1, BC_DUP, BC_POP_LOCAL_0, BC_POP, BC_PUSH_SELF,
-                      BC_RETURN_LOCAL});
+    check(bytecodes, {BC_PUSH_1, BC_DUP, BC_POP_LOCAL_0, BC_POP,
+                      BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopField0Pop() {
     addField("field");
     auto bytecodes = methodToBytecode("test = ( field := 1. ^ self )");
 
-    check(bytecodes, {BC_PUSH_1, BC_DUP, BC_POP_FIELD_0, BC_POP, BC_PUSH_SELF,
-                      BC_RETURN_LOCAL});
+    check(bytecodes, {BC_PUSH_1, BC_DUP, BC_POP_FIELD_0, BC_POP,
+                      BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopFieldPop() {
@@ -210,15 +207,15 @@ void BytecodeGenerationTest::testDupPopFieldPop() {
     auto bytecodes = methodToBytecode("test = ( field := 1. ^ self )");
 
     check(bytecodes, {BC_PUSH_1, BC_DUP, BC(BC_POP_FIELD, 4), BC_POP,
-                      BC_PUSH_SELF, BC_RETURN_LOCAL});
+                      BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopFieldReturnSelf() {
     addField("field");
     auto bytecodes = methodToBytecode("test: val = ( field := val )");
 
-    check(bytecodes, {BC_PUSH_ARG_1, BC_DUP, BC_POP_FIELD_0, BC_POP,
-                      BC_PUSH_SELF, BC_RETURN_LOCAL});
+    check(bytecodes, {BC_PUSH_ARG_1, BC_DUP, BC_POP_FIELD_0,
+                      BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testDupPopFieldNReturnSelf() {
@@ -230,8 +227,7 @@ void BytecodeGenerationTest::testDupPopFieldNReturnSelf() {
     addField("field");
     auto bytecodes = methodToBytecode("test: val = ( field := val )");
 
-    check(bytecodes, {BC_PUSH_ARG_1, BC_DUP, BC(BC_POP_FIELD, 5), BC_POP,
-                      BC_PUSH_SELF, BC_RETURN_LOCAL});
+    check(bytecodes, {BC_PUSH_ARG_1, BC_DUP, BC(BC_POP_FIELD, 5), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testSendDupPopFieldReturnLocal() {
@@ -296,8 +292,7 @@ void BytecodeGenerationTest::testPushLocalOpt() {
                                       ) )""");
     check(bytecodes,
           {BC_PUSH_LOCAL_0, BC_POP, BC_PUSH_LOCAL_1, BC_POP, BC_PUSH_LOCAL_2,
-           BC_POP, BC(BC_PUSH_LOCAL, 3, 0), BC_POP, BC_PUSH_SELF,
-           BC_RETURN_LOCAL});
+           BC_POP, BC(BC_PUSH_LOCAL, 3, 0), BC_POP, BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testPushArgOpt() {
@@ -307,8 +302,8 @@ void BytecodeGenerationTest::testPushArgOpt() {
                                       ) )""");
     check(bytecodes,
           {BC_PUSH_SELF, BC_POP, BC_PUSH_ARG_1, BC_POP, BC_PUSH_ARG_2, BC_POP,
-           BC(BC_PUSH_ARGUMENT, 3, 0), BC_POP, BC(BC_PUSH_ARGUMENT, 4, 0),
-           BC_POP, BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC(BC_PUSH_ARGUMENT, 3, 0), BC_POP, BC(BC_PUSH_ARGUMENT, 4, 0), BC_POP,
+           BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testPushFieldOpt() {
@@ -320,7 +315,7 @@ void BytecodeGenerationTest::testPushFieldOpt() {
     check(
         bytecodes,
         {BC_PUSH_FIELD_0, BC_POP, BC_PUSH_FIELD_1, BC_POP, BC(BC_PUSH_FIELD, 2),
-         BC_POP, BC(BC_PUSH_FIELD, 3), BC_POP, BC_PUSH_SELF, BC_RETURN_LOCAL});
+         BC_POP, BC(BC_PUSH_FIELD, 3), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testBlockPushFieldOpt() {
@@ -352,7 +347,7 @@ void BytecodeGenerationTest::testPopLocalOpt() {
            BC_PUSH_1,    BC_DUP,         BC_POP_LOCAL_2,         BC_POP,
            BC_PUSH_1,    BC_DUP,         BC(BC_POP_LOCAL, 3, 0), BC_POP,
            BC_PUSH_1,    BC_DUP,         BC(BC_POP_LOCAL, 4, 0), BC_POP,
-           BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testPopFieldOpt() {
@@ -370,8 +365,7 @@ void BytecodeGenerationTest::testPopFieldOpt() {
     check(bytecodes,
           {BC_PUSH_1, BC_DUP, BC_POP_FIELD_0, BC_POP, BC_PUSH_1, BC_DUP,
            BC_POP_FIELD_1, BC_POP, BC_PUSH_1, BC_DUP, BC(BC_POP_FIELD, 2),
-           BC_POP, BC_PUSH_1, BC_DUP, BC(BC_POP_FIELD, 3), BC_POP, BC_PUSH_SELF,
-           BC_RETURN_LOCAL});
+           BC_POP, BC_PUSH_1, BC_DUP, BC(BC_POP_FIELD, 3), BC_POP, BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::check(std::vector<uint8_t> actual,
@@ -457,7 +451,7 @@ void BytecodeGenerationTest::testWhileInlining(const char* selector,
         bytecodes,
         {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_CONSTANT_1, BC(jumpBytecode, 8, 0),
          BC_PUSH_ARG_1, BC_POP, BC(BC_JUMP_BACKWARD, 6, 0), BC_PUSH_NIL, BC_POP,
-         BC_PUSH_CONSTANT_2, BC_POP, BC_PUSH_SELF, BC_RETURN_LOCAL});
+         BC_PUSH_CONSTANT_2, BC_RETURN_SELF});
 }
 
 /** This test checks whether the jumps in the while loop are correct after it
@@ -565,7 +559,7 @@ void BytecodeGenerationTest::ifTrueWithLiteralReturn(std::string literal,
     check(bytecodes,
           {BC_PUSH_SELF, BC(BC_SEND, 0),
            BC(BC_JUMP_ON_FALSE_TOP_NIL, twoByte2 ? 5 : 4, 0), bytecode, BC_POP,
-           BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC_RETURN_SELF});
 
     tearDown();
 }
@@ -607,7 +601,7 @@ void BytecodeGenerationTest::ifTrueWithSomethingAndLiteralReturn(
         bytecodes,
         {BC_PUSH_SELF, BC(BC_SEND, 0),
          BC(BC_JUMP_ON_FALSE_TOP_NIL, twoByte2 ? 7 : 6, 0), BC_PUSH_CONSTANT_1,
-         BC_POP, bytecode, BC_POP, BC_PUSH_SELF, BC_RETURN_LOCAL});
+         BC_POP, bytecode, BC_POP, BC_RETURN_SELF});
 
     tearDown();
 }
@@ -622,8 +616,7 @@ void BytecodeGenerationTest::testIfTrueIfFalseArg() {
     check(bytecodes,
           {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_SELF, BC(BC_SEND, 1),
            BC(BC_JUMP_ON_FALSE_POP, 7, 0), BC_PUSH_ARG_1, BC(BC_JUMP, 4, 0),
-           BC_PUSH_ARG_2, BC_POP, BC_PUSH_CONSTANT_2, BC_POP, BC_PUSH_SELF,
-           BC_RETURN_LOCAL});
+           BC_PUSH_ARG_2, BC_POP, BC_PUSH_CONSTANT_2, BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testIfTrueIfFalseNlrArg1() {
@@ -636,8 +629,8 @@ void BytecodeGenerationTest::testIfTrueIfFalseNlrArg1() {
     check(bytecodes,
           {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_SELF, BC(BC_SEND, 1),
            BC(BC_JUMP_ON_FALSE_POP, 8, 0), BC_PUSH_ARG_1, BC_RETURN_LOCAL,
-           BC(BC_JUMP, 4, 0), BC_PUSH_ARG_2, BC_POP, BC_PUSH_CONSTANT_2, BC_POP,
-           BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC(BC_JUMP, 4, 0), BC_PUSH_ARG_2, BC_POP, BC_PUSH_CONSTANT_2,
+           BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testIfTrueIfFalseNlrArg2() {
@@ -650,8 +643,8 @@ void BytecodeGenerationTest::testIfTrueIfFalseNlrArg2() {
     check(bytecodes,
           {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_SELF, BC(BC_SEND, 1),
            BC(BC_JUMP_ON_FALSE_POP, 7, 0), BC_PUSH_ARG_1, BC(BC_JUMP, 5, 0),
-           BC_PUSH_ARG_2, BC_RETURN_LOCAL, BC_POP, BC_PUSH_CONSTANT_2, BC_POP,
-           BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC_PUSH_ARG_2, BC_RETURN_LOCAL, BC_POP, BC_PUSH_CONSTANT_2,
+           BC_RETURN_SELF});
 }
 void BytecodeGenerationTest::testInliningOfOr() {
     inliningOfOr("or:");
@@ -670,9 +663,9 @@ void BytecodeGenerationTest::inliningOfOr(std::string selector) {
            BC_PUSH_CONSTANT_1,  // push the `#val`
            BC(BC_JUMP, 4, 0),
            // false branch, jump_on_true target, push true
-           BC_PUSH_CONSTANT_0, BC_POP,
+           BC_PUSH_CONSTANT_0,
            // target of the jump in the true branch
-           BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC_RETURN_SELF});
 
     tearDown();
 }
@@ -694,9 +687,9 @@ void BytecodeGenerationTest::inliningOfAnd(std::string selector) {
            BC_PUSH_CONSTANT_1,  // push the `#val`
            BC(BC_JUMP, 4, 0),
            // false branch, jump_on_false target, push false
-           BC_PUSH_CONSTANT_2, BC_POP,
+           BC_PUSH_CONSTANT_2,
            // target of the jump in the true branch
-           BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC_RETURN_SELF});
 
     tearDown();
 }
@@ -716,12 +709,12 @@ void BytecodeGenerationTest::testInliningOfToDo() {
                              // block's code
            BC_POP,           // cleanup after block
            BC_INC,           // increment top, the iteration counter
-           BC(BC_JUMP_BACKWARD, 8,
-              0),  // jump back to the jump_if_greater bytecode
-           BC_POP,
+        
+           // jump back to the jump_if_greater bytecode
+           BC(BC_JUMP_BACKWARD, 8, 0),
 
            // jump_if_greater target
-           BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC_RETURN_SELF});
 }
 
 /*


### PR DESCRIPTION
The main motivation for this PR is to simplify bytecode sequences, remove a bit of cruft, to make it easier to recognize setters as trivial methods.

Though, this also gives a bit of a performance benefit, especially on micro benchmarks.
The PR also adds more of the unusual infrastructure we have to deal with bytecodes.



https://rebench.dev/SOMpp/compare/dc902fb54bd693ccc02f3cbd4f1cedc2ae802649..e33d58323d14ab2e3f5befc7c37218df9c3cbab1

Run time: median -1% (min. -46%, max. 14%)