### PR TITLE
Add support for trivial methods

### DIFF
--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		0A3A3CB31A5D5476004CB03B /* PrimitiveLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F52032B0FA6624C00E75857 /* PrimitiveLoader.cpp */; };
 		0A5A7E912C5D45A00011C783 /* VMSafePrimitive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E902C5D45A00011C783 /* VMSafePrimitive.cpp */; };
 		0A5A7E922C5D45A00011C783 /* VMSafePrimitive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E902C5D45A00011C783 /* VMSafePrimitive.cpp */; };
+		0A5A7E962C60F5BB0011C783 /* VMTrivialMethod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E952C60F5BB0011C783 /* VMTrivialMethod.cpp */; };
+		0A5A7E972C60F5BB0011C783 /* VMTrivialMethod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E952C60F5BB0011C783 /* VMTrivialMethod.cpp */; };
 		0A67EA7519ACD43A00830E3B /* CloneObjectsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7019ACD43A00830E3B /* CloneObjectsTest.cpp */; };
 		0A67EA7619ACD43A00830E3B /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7119ACD43A00830E3B /* main.cpp */; };
 		0A67EA7819ACD43A00830E3B /* WalkObjectsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7319ACD43A00830E3B /* WalkObjectsTest.cpp */; };
@@ -225,6 +227,8 @@
 		0A5A7E8F2C5D30390011C783 /* VMSafePrimitive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMSafePrimitive.h; sourceTree = "<group>"; };
 		0A5A7E902C5D45A00011C783 /* VMSafePrimitive.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VMSafePrimitive.cpp; sourceTree = "<group>"; };
 		0A5A7E932C5DA9A90011C783 /* Primitives.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Primitives.h; sourceTree = "<group>"; };
+		0A5A7E942C602E8C0011C783 /* VMTrivialMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMTrivialMethod.h; sourceTree = "<group>"; };
+		0A5A7E952C60F5BB0011C783 /* VMTrivialMethod.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VMTrivialMethod.cpp; sourceTree = "<group>"; };
 		0A67EA6719ACD37200830E3B /* unittests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = unittests; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A67EA7019ACD43A00830E3B /* CloneObjectsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CloneObjectsTest.cpp; path = unitTests/CloneObjectsTest.cpp; sourceTree = "<group>"; };
 		0A67EA7119ACD43A00830E3B /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = unitTests/main.cpp; sourceTree = "<group>"; };
@@ -671,6 +675,8 @@
 				3F5203580FA6624C00E75857 /* VMSymbol.h */,
 				0A5A7E8F2C5D30390011C783 /* VMSafePrimitive.h */,
 				0A5A7E902C5D45A00011C783 /* VMSafePrimitive.cpp */,
+				0A5A7E942C602E8C0011C783 /* VMTrivialMethod.h */,
+				0A5A7E952C60F5BB0011C783 /* VMTrivialMethod.cpp */,
 			);
 			path = vmobjects;
 			sourceTree = "<group>";
@@ -881,6 +887,7 @@
 				0A1886DD1832BCC800A2CBCA /* ClassGenerationContext.cpp in Sources */,
 				0A3A3C941A5D546D004CB03B /* Class.cpp in Sources */,
 				0A1C98672C4D340300735850 /* Symbols.cpp in Sources */,
+				0A5A7E962C60F5BB0011C783 /* VMTrivialMethod.cpp in Sources */,
 				0A18870B1832C0E400A2CBCA /* AbstractObject.cpp in Sources */,
 				0AB80AD82C394806006B6419 /* Globals.cpp in Sources */,
 				0A3A3C991A5D546D004CB03B /* Primitive.cpp in Sources */,
@@ -997,6 +1004,7 @@
 				0A1C986C2C4D363A00735850 /* LogAllocation.cpp in Sources */,
 				0A67EA9319ACD83200830E3B /* SourcecodeCompiler.cpp in Sources */,
 				0A1C98682C4D340300735850 /* Symbols.cpp in Sources */,
+				0A5A7E972C60F5BB0011C783 /* VMTrivialMethod.cpp in Sources */,
 				0AB80AD42C392B78006B6419 /* Print.cpp in Sources */,
 				0A3A3CA41A5D546D004CB03B /* Double.cpp in Sources */,
 				0A1C98772C5526AD00735850 /* DebugCopyingCollector.cpp in Sources */,

--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		0A5A7E922C5D45A00011C783 /* VMSafePrimitive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E902C5D45A00011C783 /* VMSafePrimitive.cpp */; };
 		0A5A7E962C60F5BB0011C783 /* VMTrivialMethod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E952C60F5BB0011C783 /* VMTrivialMethod.cpp */; };
 		0A5A7E972C60F5BB0011C783 /* VMTrivialMethod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E952C60F5BB0011C783 /* VMTrivialMethod.cpp */; };
+		0A5A7E9A2C617E400011C783 /* TrivialMethodTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E992C617E400011C783 /* TrivialMethodTest.cpp */; };
 		0A5A7E9D2C617EE00011C783 /* TestWithParsing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E9C2C617EE00011C783 /* TestWithParsing.cpp */; };
 		0A67EA7519ACD43A00830E3B /* CloneObjectsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7019ACD43A00830E3B /* CloneObjectsTest.cpp */; };
 		0A67EA7619ACD43A00830E3B /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7119ACD43A00830E3B /* main.cpp */; };
@@ -230,6 +231,8 @@
 		0A5A7E932C5DA9A90011C783 /* Primitives.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Primitives.h; sourceTree = "<group>"; };
 		0A5A7E942C602E8C0011C783 /* VMTrivialMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMTrivialMethod.h; sourceTree = "<group>"; };
 		0A5A7E952C60F5BB0011C783 /* VMTrivialMethod.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VMTrivialMethod.cpp; sourceTree = "<group>"; };
+		0A5A7E982C617E2B0011C783 /* TrivialMethodTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TrivialMethodTest.h; path = unitTests/TrivialMethodTest.h; sourceTree = "<group>"; };
+		0A5A7E992C617E400011C783 /* TrivialMethodTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TrivialMethodTest.cpp; path = unitTests/TrivialMethodTest.cpp; sourceTree = "<group>"; };
 		0A5A7E9B2C617EC70011C783 /* TestWithParsing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestWithParsing.h; path = unitTests/TestWithParsing.h; sourceTree = "<group>"; };
 		0A5A7E9C2C617EE00011C783 /* TestWithParsing.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TestWithParsing.cpp; path = unitTests/TestWithParsing.cpp; sourceTree = "<group>"; };
 		0A67EA6719ACD37200830E3B /* unittests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = unittests; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -456,6 +459,8 @@
 				0A67EA7419ACD43A00830E3B /* WriteBarrierTest.cpp */,
 				0A1C98562C3DD87300735850 /* unitTests/BytecodeGenerationTest.h */,
 				0A1C98572C3DD88500735850 /* unitTests/BytecodeGenerationTest.cpp */,
+				0A5A7E982C617E2B0011C783 /* TrivialMethodTest.h */,
+				0A5A7E992C617E400011C783 /* TrivialMethodTest.cpp */,
 				0A5A7E9B2C617EC70011C783 /* TestWithParsing.h */,
 				0A5A7E9C2C617EE00011C783 /* TestWithParsing.cpp */,
 			);
@@ -963,6 +968,7 @@
 				0A3A3CB21A5D5476004CB03B /* PrimitiveContainer.cpp in Sources */,
 				0A1C98582C3DD88500735850 /* unitTests/BytecodeGenerationTest.cpp in Sources */,
 				0A1C986F2C4F1D3900735850 /* debug.cpp in Sources */,
+				0A5A7E9A2C617E400011C783 /* TrivialMethodTest.cpp in Sources */,
 				0A67EA8419ACD74800830E3B /* VMFrame.cpp in Sources */,
 				0A67EA7D19ACD74800830E3B /* Signature.cpp in Sources */,
 				0A67EA7E19ACD74800830E3B /* VMArray.cpp in Sources */,

--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		0A5A7E922C5D45A00011C783 /* VMSafePrimitive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E902C5D45A00011C783 /* VMSafePrimitive.cpp */; };
 		0A5A7E962C60F5BB0011C783 /* VMTrivialMethod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E952C60F5BB0011C783 /* VMTrivialMethod.cpp */; };
 		0A5A7E972C60F5BB0011C783 /* VMTrivialMethod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E952C60F5BB0011C783 /* VMTrivialMethod.cpp */; };
+		0A5A7E9D2C617EE00011C783 /* TestWithParsing.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A5A7E9C2C617EE00011C783 /* TestWithParsing.cpp */; };
 		0A67EA7519ACD43A00830E3B /* CloneObjectsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7019ACD43A00830E3B /* CloneObjectsTest.cpp */; };
 		0A67EA7619ACD43A00830E3B /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7119ACD43A00830E3B /* main.cpp */; };
 		0A67EA7819ACD43A00830E3B /* WalkObjectsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0A67EA7319ACD43A00830E3B /* WalkObjectsTest.cpp */; };
@@ -229,6 +230,8 @@
 		0A5A7E932C5DA9A90011C783 /* Primitives.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Primitives.h; sourceTree = "<group>"; };
 		0A5A7E942C602E8C0011C783 /* VMTrivialMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMTrivialMethod.h; sourceTree = "<group>"; };
 		0A5A7E952C60F5BB0011C783 /* VMTrivialMethod.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VMTrivialMethod.cpp; sourceTree = "<group>"; };
+		0A5A7E9B2C617EC70011C783 /* TestWithParsing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TestWithParsing.h; path = unitTests/TestWithParsing.h; sourceTree = "<group>"; };
+		0A5A7E9C2C617EE00011C783 /* TestWithParsing.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TestWithParsing.cpp; path = unitTests/TestWithParsing.cpp; sourceTree = "<group>"; };
 		0A67EA6719ACD37200830E3B /* unittests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = unittests; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A67EA7019ACD43A00830E3B /* CloneObjectsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CloneObjectsTest.cpp; path = unitTests/CloneObjectsTest.cpp; sourceTree = "<group>"; };
 		0A67EA7119ACD43A00830E3B /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = unitTests/main.cpp; sourceTree = "<group>"; };
@@ -453,6 +456,8 @@
 				0A67EA7419ACD43A00830E3B /* WriteBarrierTest.cpp */,
 				0A1C98562C3DD87300735850 /* unitTests/BytecodeGenerationTest.h */,
 				0A1C98572C3DD88500735850 /* unitTests/BytecodeGenerationTest.cpp */,
+				0A5A7E9B2C617EC70011C783 /* TestWithParsing.h */,
+				0A5A7E9C2C617EE00011C783 /* TestWithParsing.cpp */,
 			);
 			name = unittests;
 			sourceTree = "<group>";
@@ -953,6 +958,7 @@
 				0A3A3CA31A5D546D004CB03B /* Class.cpp in Sources */,
 				0A67EA9019ACD83200830E3B /* Lexer.cpp in Sources */,
 				0AB80AD92C394806006B6419 /* Globals.cpp in Sources */,
+				0A5A7E9D2C617EE00011C783 /* TestWithParsing.cpp in Sources */,
 				0A3A3CA71A5D546D004CB03B /* Object.cpp in Sources */,
 				0A3A3CB21A5D5476004CB03B /* PrimitiveContainer.cpp in Sources */,
 				0A1C98582C3DD88500735850 /* unitTests/BytecodeGenerationTest.cpp in Sources */,

--- a/src/compiler/BytecodeGenerator.cpp
+++ b/src/compiler/BytecodeGenerator.cpp
@@ -322,8 +322,7 @@ size_t Emit3WithDummy(MethodGenerationContext& mgenc, uint8_t bytecode,
     return index;
 }
 
-void EmitPushFieldWithIndex(MethodGenerationContext& mgenc, uint8_t fieldIdx,
-                            uint8_t ctxLevel) {
+void EmitPushFieldWithIndex(MethodGenerationContext& mgenc, uint8_t fieldIdx) {
     // if (ctxLevel == 0) {
     if (fieldIdx == 0) {
         Emit1(mgenc, BC_PUSH_FIELD_0, 1);

--- a/src/compiler/BytecodeGenerator.cpp
+++ b/src/compiler/BytecodeGenerator.cpp
@@ -119,7 +119,7 @@ void EmitPUSHFIELD(MethodGenerationContext& mgenc, VMSymbol* field) {
     }
 }
 
-void EmitPUSHBLOCK(MethodGenerationContext& mgenc, VMMethod* block) {
+void EmitPUSHBLOCK(MethodGenerationContext& mgenc, VMInvokable* block) {
     const int8_t idx = mgenc.AddLiteralIfAbsent(block);
     Emit2(mgenc, BC_PUSH_BLOCK, idx, 1);
 }

--- a/src/compiler/BytecodeGenerator.h
+++ b/src/compiler/BytecodeGenerator.h
@@ -44,7 +44,7 @@ void EmitDUP(MethodGenerationContext& mgenc);
 void EmitPUSHLOCAL(MethodGenerationContext& mgenc, long idx, int ctx);
 void EmitPUSHARGUMENT(MethodGenerationContext& mgenc, long idx, int ctx);
 void EmitPUSHFIELD(MethodGenerationContext& mgenc, VMSymbol* field);
-void EmitPUSHBLOCK(MethodGenerationContext& mgenc, VMMethod* block);
+void EmitPUSHBLOCK(MethodGenerationContext& mgenc, VMInvokable* block);
 void EmitPUSHCONSTANT(MethodGenerationContext& mgenc, vm_oop_t cst);
 void EmitPUSHCONSTANT(MethodGenerationContext& mgenc, uint8_t literalIndex);
 void EmitPUSHCONSTANTString(MethodGenerationContext& mgenc, VMString* str);

--- a/src/compiler/BytecodeGenerator.h
+++ b/src/compiler/BytecodeGenerator.h
@@ -71,7 +71,6 @@ void EmitJumpBackwardWithOffset(MethodGenerationContext& mgenc,
 size_t Emit3WithDummy(MethodGenerationContext& mgenc, uint8_t bytecode,
                       size_t stackEffect);
 
-void EmitPushFieldWithIndex(MethodGenerationContext& mgenc, uint8_t fieldIdx,
-                            uint8_t ctxLevel);
+void EmitPushFieldWithIndex(MethodGenerationContext& mgenc, uint8_t fieldIdx);
 void EmitPopFieldWithIndex(MethodGenerationContext& mgenc, uint8_t fieldIdx,
                            uint8_t ctxLevel);

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -168,6 +168,30 @@ VMTrivialMethod* MethodGenerationContext::assembleGlobalReturn() {
     return MakeGlobalReturn(signature, arguments, globalName);
 }
 
+VMTrivialMethod* MethodGenerationContext::assembleFieldGetter(
+    uint8_t pushCandidate) {
+    if (bytecode.size() != (Bytecode::GetBytecodeLength(pushCandidate) +
+                            Bytecode::GetBytecodeLength(BC_RETURN_LOCAL))) {
+        return nullptr;
+    }
+
+    size_t fieldIndex;
+    if (pushCandidate == BC_PUSH_FIELD_0) {
+        fieldIndex = 0;
+    } else if (pushCandidate == BC_PUSH_FIELD_1) {
+        fieldIndex = 1;
+    } else {
+        assert(pushCandidate == BC_PUSH_FIELD);
+        // -2: -1 to skip over a 1-byte BC_RETURN_LOCAL,
+        // and of course -1 for length vs offset
+        fieldIndex = bytecode.at(bytecode.size() - 2);
+        assert(fieldIndex > 1 &&
+               "BC_PUSH_FIELD with index 0 or 1 is not optimal");
+    }
+
+    return MakeGetter(signature, arguments, fieldIndex);
+}
+
 VMPrimitive* MethodGenerationContext::AssemblePrimitive(bool classSide) {
     return VMPrimitive::GetEmptyPrimitive(signature, classSide);
 }

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -152,6 +152,22 @@ VMTrivialMethod* MethodGenerationContext::assembleLiteralReturn(
         "returns a literal");
 }
 
+VMTrivialMethod* MethodGenerationContext::assembleGlobalReturn() {
+    if (bytecode.size() != (Bytecode::GetBytecodeLength(BC_PUSH_GLOBAL) +
+                            Bytecode::GetBytecodeLength(BC_RETURN_LOCAL))) {
+        return nullptr;
+    }
+
+    if (literals.size() != 1) {
+        GetUniverse()->ErrorExit(
+            "Unexpected situation when trying to create trivial method that "
+            "reads a global. New Bytecode?");
+    }
+
+    VMSymbol* globalName = (VMSymbol*)literals.at(0);
+    return MakeGlobalReturn(signature, arguments, globalName);
+}
+
 VMPrimitive* MethodGenerationContext::AssemblePrimitive(bool classSide) {
     return VMPrimitive::GetEmptyPrimitive(signature, classSide);
 }

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -119,7 +119,7 @@ public:
 private:
     VMTrivialMethod* assembleTrivialMethod();
     VMTrivialMethod* assembleLiteralReturn(uint8_t pushCandidate);
-    VMTrivialMethod* assembleGlobalReturn() { return nullptr; }
+    VMTrivialMethod* assembleGlobalReturn();
     VMTrivialMethod* assembleFieldGetter(uint8_t pushCandidate) {
         return nullptr;
     }

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -120,9 +120,7 @@ private:
     VMTrivialMethod* assembleTrivialMethod();
     VMTrivialMethod* assembleLiteralReturn(uint8_t pushCandidate);
     VMTrivialMethod* assembleGlobalReturn();
-    VMTrivialMethod* assembleFieldGetter(uint8_t pushCandidate) {
-        return nullptr;
-    }
+    VMTrivialMethod* assembleFieldGetter(uint8_t pushCandidate);
     VMTrivialMethod* assembleFieldSetter() { return nullptr; }
     VMTrivialMethod* assembleFieldGetterFromReturn(uint8_t pushCandidate) {
         return nullptr;

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -46,7 +46,7 @@ public:
                             MethodGenerationContext* outer = nullptr);
     ~MethodGenerationContext();
 
-    VMMethod* Assemble();
+    VMInvokable* Assemble();
     VMPrimitive* AssemblePrimitive(bool classSide);
 
     int8_t FindLiteralIndex(vm_oop_t lit);
@@ -107,6 +107,7 @@ public:
 
     void CompleteLexicalScope();
     void MergeIntoScope(LexicalScope& scopeToBeInlined);
+    void InlineAsLocals(vector<Variable>& vars);
 
     uint8_t GetInlinedLocalIdx(const Variable* var) const;
 
@@ -116,6 +117,17 @@ public:
     bool OptimizeDupPopPopSequence();
 
 private:
+    VMTrivialMethod* assembleTrivialMethod();
+    VMTrivialMethod* assembleLiteralReturn(uint8_t pushCandidate);
+    VMTrivialMethod* assembleGlobalReturn() { return nullptr; }
+    VMTrivialMethod* assembleFieldGetter(uint8_t pushCandidate) {
+        return nullptr;
+    }
+    VMTrivialMethod* assembleFieldSetter() { return nullptr; }
+    VMTrivialMethod* assembleFieldGetterFromReturn(uint8_t pushCandidate) {
+        return nullptr;
+    }
+
     bool optimizeIncFieldPush() {
         // TODO: implement
         return false;
@@ -130,17 +142,18 @@ private:
     bool lastBytecodeIs(size_t indexFromEnd, uint8_t bytecode);
     uint8_t lastBytecodeIsOneOf(size_t indexFromEnd,
                                 uint8_t (*predicate)(uint8_t));
-
+    
     size_t getOffsetOfLastBytecode(size_t indexFromEnd);
 
-    std::tuple<vm_oop_t, vm_oop_t> extractBlockMethodsAndRemoveBytecodes();
-    vm_oop_t extractBlockMethodAndRemoveBytecode();
+    std::tuple<VMInvokable*, VMInvokable*>
+    extractBlockMethodsAndRemoveBytecodes();
+    VMInvokable* extractBlockMethodAndRemoveBytecode();
 
-    vm_oop_t getLastBlockMethodAndFreeLiteral(uint8_t blockLiteralIdx);
+    VMInvokable* getLastBlockMethodAndFreeLiteral(uint8_t blockLiteralIdx);
 
     void completeJumpsAndEmitReturningNil(Parser& parser, size_t loopBeginIdx,
                                           size_t jumpOffsetIdxToSkipLoopBody);
-    void inlineAsLocals(vector<Variable>& vars);
+
     void checkJumpOffset(size_t jumpOffset, uint8_t bytecode);
     void resetLastBytecodeBuffer();
 

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -116,12 +116,14 @@ public:
 
     bool OptimizeDupPopPopSequence();
 
+    bool LastBytecodeIs(size_t indexFromEnd, uint8_t bytecode);
+
 private:
     VMTrivialMethod* assembleTrivialMethod();
     VMTrivialMethod* assembleLiteralReturn(uint8_t pushCandidate);
     VMTrivialMethod* assembleGlobalReturn();
     VMTrivialMethod* assembleFieldGetter(uint8_t pushCandidate);
-    VMTrivialMethod* assembleFieldSetter() { return nullptr; }
+    VMTrivialMethod* assembleFieldSetter();
     VMTrivialMethod* assembleFieldGetterFromReturn(uint8_t pushCandidate) {
         return nullptr;
     }
@@ -137,10 +139,10 @@ private:
     bool hasOneLiteralBlockArgument();
     bool hasTwoLiteralBlockArguments();
     uint8_t lastBytecodeAt(size_t indexFromEnd);
-    bool lastBytecodeIs(size_t indexFromEnd, uint8_t bytecode);
+
     uint8_t lastBytecodeIsOneOf(size_t indexFromEnd,
                                 uint8_t (*predicate)(uint8_t));
-    
+
     size_t getOffsetOfLastBytecode(size_t indexFromEnd);
 
     std::tuple<VMInvokable*, VMInvokable*>

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -548,7 +548,7 @@ bool Parser::primary(MethodGenerationContext& mgenc) {
 
             nestedBlock(bgenc);
 
-            VMMethod* blockMethod = bgenc.Assemble();
+            VMInvokable* blockMethod = bgenc.Assemble();
             EmitPUSHBLOCK(mgenc, blockMethod);
             break;
         }

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -208,14 +208,17 @@ void Interpreter::doPushLocalWithIndex(uint8_t localIndex) {
 }
 
 void Interpreter::doPushArgument(long bytecodeIndex) {
-    uint8_t bc1 = method->GetBytecode(bytecodeIndex + 1);
-    uint8_t bc2 = method->GetBytecode(bytecodeIndex + 2);
+    uint8_t argIndex = method->GetBytecode(bytecodeIndex + 1);
+    uint8_t contextLevel = method->GetBytecode(bytecodeIndex + 2);
 
-    assert(!(bc1 == 0 && bc2 == 0 && "should have been BC_PUSH_SELF"));
-    assert(!(bc1 == 1 && bc2 == 0 && "should have been BC_PUSH_ARG_1"));
-    assert(!(bc1 == 2 && bc2 == 0 && "should have been BC_PUSH_ARG_2"));
+    assert(!(argIndex == 0 && contextLevel == 0 &&
+             "should have been BC_PUSH_SELF"));
+    assert(!(argIndex == 1 && contextLevel == 0 &&
+             "should have been BC_PUSH_ARG_1"));
+    assert(!(argIndex == 2 && contextLevel == 0 &&
+             "should have been BC_PUSH_ARG_2"));
 
-    vm_oop_t argument = GetFrame()->GetArgument(bc1, bc2);
+    vm_oop_t argument = GetFrame()->GetArgument(argIndex, contextLevel);
 
     GetFrame()->Push(argument);
 }

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -243,8 +243,8 @@ void Interpreter::doPushFieldWithIndex(uint8_t fieldIndex) {
 }
 
 void Interpreter::doPushBlock(long bytecodeIndex) {
-    VMMethod* blockMethod =
-        static_cast<VMMethod*>(method->GetConstant(bytecodeIndex));
+    vm_oop_t block = method->GetConstant(bytecodeIndex);
+    VMInvokable* blockMethod = static_cast<VMInvokable*>(block);
 
     long numOfArgs = blockMethod->GetNumberOfArguments();
 

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -260,22 +260,25 @@ void Interpreter::doPushGlobal(long bytecodeIndex) {
     if (global != nullptr) {
         GetFrame()->Push(global);
     } else {
-        vm_oop_t arguments[] = {globalName};
-        vm_oop_t self = GetSelf();
-
-        // check if there is enough space on the stack for this unplanned Send
-        // unknowGlobal: needs 2 slots, one for "this" and one for the argument
-        long additionalStackSlots = 2 - GetFrame()->RemainingStackSize();
-        if (additionalStackSlots > 0) {
-            GetFrame()->SetBytecodeIndex(bytecodeIndexGlobal);
-            // copy current frame into a bigger one and replace the current
-            // frame
-            SetFrame(
-                VMFrame::EmergencyFrameFrom(GetFrame(), additionalStackSlots));
-        }
-
-        AS_OBJ(self)->Send(this, unknownGlobal, arguments, 1);
+        SendUnknownGlobal(globalName);
     }
+}
+
+void Interpreter::SendUnknownGlobal(VMSymbol* globalName) {
+    vm_oop_t arguments[] = {globalName};
+    vm_oop_t self = GetSelf();
+
+    // check if there is enough space on the stack for this unplanned Send
+    // unknowGlobal: needs 2 slots, one for "this" and one for the argument
+    long additionalStackSlots = 2 - GetFrame()->RemainingStackSize();
+    if (additionalStackSlots > 0) {
+        GetFrame()->SetBytecodeIndex(bytecodeIndexGlobal);
+        // copy current frame into a bigger one and replace the current
+        // frame
+        SetFrame(VMFrame::EmergencyFrameFrom(GetFrame(), additionalStackSlots));
+    }
+
+    AS_OBJ(self)->Send(this, unknownGlobal, arguments, 1);
 }
 
 void Interpreter::doPop() {

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -57,6 +57,8 @@ public:
     uint8_t* GetBytecodes() const;
     void WalkGlobals(walk_heap_fn);
 
+    void SendUnknownGlobal(VMSymbol* globalName);
+
 private:
     vm_oop_t GetSelf() const;
 

--- a/src/misc/debug.cpp
+++ b/src/misc/debug.cpp
@@ -15,6 +15,6 @@ std::string DebugGetClassName(gc_oop_t obj) {
     return CLASS_OF(obj)->GetName()->GetStdString();
 }
 
-void DebugDumpMethod(VMMethod* method) {
-    Disassembler::DumpMethod(method, "", false);
+void DebugDumpMethod(VMInvokable* method) {
+    Disassembler::DumpMethod((VMMethod*)method, "", false);
 }

--- a/src/misc/debug.h
+++ b/src/misc/debug.h
@@ -98,4 +98,4 @@ static inline void DebugTrace(const char* fmt, ...) {
 
 std::string DebugGetClassName(vm_oop_t);
 std::string DebugGetClassName(gc_oop_t);
-void DebugDumpMethod(VMMethod* method);
+void DebugDumpMethod(VMInvokable* method);

--- a/src/unitTests/BytecodeGenerationTest.cpp
+++ b/src/unitTests/BytecodeGenerationTest.cpp
@@ -6,91 +6,13 @@
 #include <cstdint>
 #include <cstdio>
 #include <queue>
-#include <sstream>
 #include <string>
 #include <vector>
 
-#include "../compiler/ClassGenerationContext.h"
-#include "../compiler/Disassembler.h"
-#include "../compiler/MethodGenerationContext.h"
-#include "../compiler/Parser.h"
 #include "../interpreter/bytecodes.h"
 #include "../misc/StringUtil.h"
-#include "../vm/Symbols.h"
 #include "../vmobjects/VMMethod.h"
-
-void BytecodeGenerationTest::dump(MethodGenerationContext* mgenc) {
-    Disassembler::DumpMethod(mgenc, "");
-}
-
-void BytecodeGenerationTest::ensureCGenC() {
-    if (_cgenc != nullptr) {
-        return;
-    }
-
-    _cgenc = new ClassGenerationContext();
-    _cgenc->SetName(SymbolFor("Test"));
-}
-
-void BytecodeGenerationTest::ensureMGenC() {
-    if (_mgenc != nullptr) {
-        return;
-    }
-    ensureCGenC();
-
-    _mgenc = new MethodGenerationContext(*_cgenc);
-    std::string self = strSelf;
-    _mgenc->AddArgument(self, {0, 0});
-}
-
-void BytecodeGenerationTest::ensureBGenC() {
-    if (_bgenc != nullptr) {
-        return;
-    }
-    ensureCGenC();
-    ensureMGenC();
-
-    _mgenc->SetSignature(SymbolFor("test"));
-    _bgenc = new MethodGenerationContext(*_cgenc, _mgenc);
-}
-
-void BytecodeGenerationTest::addField(const char* fieldName) {
-    ensureCGenC();
-    _cgenc->AddInstanceField(SymbolFor(fieldName));
-}
-
-std::vector<uint8_t> BytecodeGenerationTest::methodToBytecode(
-    const char* source, bool dumpBytecodes) {
-    ensureMGenC();
-
-    istringstream ss(source);
-
-    std::string fileName = "test";
-    Parser parser(ss, fileName);
-    parser.method(*_mgenc);
-
-    if (dumpBytecodes) {
-        dump(_mgenc);
-    }
-    return _mgenc->GetBytecodes();
-}
-
-std::vector<uint8_t> BytecodeGenerationTest::blockToBytecode(
-    const char* source, bool dumpBytecodes) {
-    ensureBGenC();
-
-    istringstream ss(source);
-
-    std::string fileName = "test";
-    Parser parser(ss, fileName);
-
-    parser.nestedBlock(*_bgenc);
-
-    if (dumpBytecodes) {
-        dump(_bgenc);
-    }
-    return _bgenc->GetBytecodes();
-}
+#include "TestWithParsing.h"
 
 void BytecodeGenerationTest::testEmptyMethodReturnsSelf() {
     auto bytecodes = methodToBytecode("test = ( )");
@@ -332,74 +254,6 @@ void BytecodeGenerationTest::testPopFieldOpt() {
         bytecodes,
         {BC_PUSH_1, BC_POP_FIELD_0, BC_PUSH_1, BC_POP_FIELD_1, BC_PUSH_1,
          BC(BC_POP_FIELD, 2), BC_PUSH_1, BC(BC_POP_FIELD, 3), BC_RETURN_SELF});
-}
-
-void BytecodeGenerationTest::check(std::vector<uint8_t> actual,
-                                   std::vector<BC>
-                                       expected) {
-    size_t i = 0;
-    size_t bci = 0;
-    for (; bci < actual.size() && i < expected.size();) {
-        uint8_t actualBc = actual.at(bci);
-        uint8_t bcLength = Bytecode::GetBytecodeLength(actualBc);
-
-        BC expectedBc = expected.at(i);
-
-        char msg[1000];
-        snprintf(msg, 1000, "Bytecode %zu expected %s but got %s", i,
-                 Bytecode::GetBytecodeName(expectedBc.bytecode),
-                 Bytecode::GetBytecodeName(actualBc));
-        if (expectedBc.bytecode != actualBc) {
-            dump(_mgenc);
-        }
-        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, expectedBc.bytecode, actualBc);
-
-        snprintf(
-            msg, 1000,
-            "Bytecode %zu (%s) was expected to have length %zu, but had %zu", i,
-            Bytecode::GetBytecodeName(actualBc), expectedBc.size,
-            (size_t)bcLength);
-
-        if (expectedBc.size != bcLength) {
-            dump(_mgenc);
-        }
-        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, expectedBc.size, (size_t)bcLength);
-
-        if (bcLength > 1) {
-            snprintf(msg, 1000,
-                     "Bytecode %zu (%s), arg1 expected %hhu but got %hhu", i,
-                     Bytecode::GetBytecodeName(expectedBc.bytecode),
-                     expectedBc.arg1, actual.at(bci + 1));
-            if (expectedBc.arg1 != actual.at(bci + 1)) {
-                dump(_mgenc);
-            }
-            CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, expectedBc.arg1,
-                                         actual.at(bci + 1));
-
-            if (bcLength > 2) {
-                snprintf(msg, 1000,
-                         "Bytecode %zu (%s), arg2 expected %hhu but got %hhu",
-                         i, Bytecode::GetBytecodeName(expectedBc.bytecode),
-                         expectedBc.arg2, actual.at(bci + 2));
-                if (expectedBc.arg2 != actual.at(bci + 2)) {
-                    dump(_mgenc);
-                }
-                CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, expectedBc.arg2,
-                                             actual.at(bci + 2));
-            }
-        }
-
-        i += 1;
-        bci += bcLength;
-    }
-    if (expected.size() != i || actual.size() != bci) {
-        dump(_mgenc);
-    }
-
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("All expected bytecodes covered",
-                                 expected.size(), i);
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("All actual bytecodes covered", actual.size(),
-                                 bci);
 }
 
 void BytecodeGenerationTest::testWhileInlining(const char* selector,

--- a/src/unitTests/BytecodeGenerationTest.cpp
+++ b/src/unitTests/BytecodeGenerationTest.cpp
@@ -554,7 +554,7 @@ void BytecodeGenerationTest::ifArg(std::string selector, int8_t jumpBytecode) {
     check(bytecodes,
           {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_SELF, BC(BC_SEND, 1),
            BC(jumpBytecode, 4, 0), BC_PUSH_ARG_1, BC_POP, BC_PUSH_CONSTANT_2,
-           BC_POP, BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC_RETURN_SELF});
 
     tearDown();
 }
@@ -568,8 +568,7 @@ void BytecodeGenerationTest::testKeywordIfTrueArg() {
     check(bytecodes,
           {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_SELF, BC_PUSH_CONSTANT_1,
            BC(BC_SEND, 2), BC(BC_JUMP_ON_FALSE_TOP_NIL, 4, 0), BC_PUSH_ARG_1,
-           BC_POP, BC(BC_PUSH_CONSTANT, 3), BC_POP, BC_PUSH_SELF,
-           BC_RETURN_LOCAL});
+           BC_POP, BC(BC_PUSH_CONSTANT, 3), BC_RETURN_SELF});
 }
 
 void BytecodeGenerationTest::testIfReturnNonLocal() {
@@ -591,7 +590,7 @@ void BytecodeGenerationTest::ifReturnNonLocal(std::string selector,
     check(bytecodes,
           {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_SELF, BC(BC_SEND, 1),
            BC(jumpBytecode, 5, 0), BC_PUSH_ARG_1, BC_RETURN_LOCAL, BC_POP,
-           BC_PUSH_CONSTANT_2, BC_POP, BC_PUSH_SELF, BC_RETURN_LOCAL});
+           BC_PUSH_CONSTANT_2, BC_RETURN_SELF});
 
     tearDown();
 }

--- a/src/unitTests/BytecodeGenerationTest.h
+++ b/src/unitTests/BytecodeGenerationTest.h
@@ -5,25 +5,9 @@
 #include "../compiler/ClassGenerationContext.h"
 #include "../compiler/MethodGenerationContext.h"
 #include "../interpreter/bytecodes.h"
+#include "TestWithParsing.h"
 
-class BC {
-public:
-    BC(uint8_t bytecode) : bytecode(bytecode), arg1(0), arg2(0), size(1) {}
-
-    BC(uint8_t bytecode, uint8_t arg1)
-        : bytecode(bytecode), arg1(arg1), arg2(0), size(2) {}
-
-    BC(uint8_t bytecode, uint8_t arg1, uint8_t arg2)
-        : bytecode(bytecode), arg1(arg1), arg2(arg2), size(3) {}
-
-    uint8_t bytecode;
-    uint8_t arg1;
-    uint8_t arg2;
-
-    size_t size;
-};
-
-class BytecodeGenerationTest : public CPPUNIT_NS::TestCase {
+class BytecodeGenerationTest : public TestWithParsing {
     CPPUNIT_TEST_SUITE(BytecodeGenerationTest);
     CPPUNIT_TEST(testEmptyMethodReturnsSelf);
     CPPUNIT_TEST(testPushConstant);
@@ -74,35 +58,7 @@ class BytecodeGenerationTest : public CPPUNIT_NS::TestCase {
 
     CPPUNIT_TEST_SUITE_END();
 
-public:
-    inline void setUp() {}
-
-    inline void tearDown() {
-        delete _cgenc;
-        _cgenc = nullptr;
-
-        delete _mgenc;
-        _mgenc = nullptr;
-
-        delete _bgenc;
-        _bgenc = nullptr;
-    }
-
 private:
-    ClassGenerationContext* _cgenc;
-    MethodGenerationContext* _mgenc;
-    MethodGenerationContext* _bgenc;
-
-    void ensureCGenC();
-    void ensureMGenC();
-    void ensureBGenC();
-    void addField(const char* fieldName);
-
-    std::vector<uint8_t> methodToBytecode(const char* source,
-                                          bool dumpBytecodes = false);
-    std::vector<uint8_t> blockToBytecode(const char* source,
-                                         bool dumpBytecodes = false);
-
     void testEmptyMethodReturnsSelf();
 
     void testPushConstant();
@@ -173,8 +129,4 @@ private:
     void testInliningOfToDo();
 
     void testJumpQueuesOrdering();
-
-    void dump(MethodGenerationContext* mgenc);
-
-    void check(std::vector<uint8_t> actual, std::vector<BC> expected);
 };

--- a/src/unitTests/BytecodeGenerationTest.h
+++ b/src/unitTests/BytecodeGenerationTest.h
@@ -66,6 +66,9 @@ class BytecodeGenerationTest : public CPPUNIT_NS::TestCase {
     CPPUNIT_TEST(testInliningOfOr);
     CPPUNIT_TEST(testInliningOfAnd);
     CPPUNIT_TEST(testInliningOfToDo);
+    CPPUNIT_TEST(testIfArg);
+    CPPUNIT_TEST(testKeywordIfTrueArg);
+    CPPUNIT_TEST(testIfReturnNonLocal);
 
     CPPUNIT_TEST(testJumpQueuesOrdering);
 
@@ -154,6 +157,13 @@ private:
     void testIfTrueIfFalseArg();
     void testIfTrueIfFalseNlrArg1();
     void testIfTrueIfFalseNlrArg2();
+
+    void testIfArg();
+    void ifArg(std::string selector, int8_t jumpBytecode);
+    void testKeywordIfTrueArg();
+
+    void testIfReturnNonLocal();
+    void ifReturnNonLocal(std::string selector, int8_t jumpBytecode);
 
     void testInliningOfOr();
     void inliningOfOr(std::string selector);

--- a/src/unitTests/TestWithParsing.cpp
+++ b/src/unitTests/TestWithParsing.cpp
@@ -1,0 +1,159 @@
+#include "TestWithParsing.h"
+
+#include <cassert>
+#include <cppunit/TestAssert.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "../compiler/ClassGenerationContext.h"
+#include "../compiler/Disassembler.h"
+#include "../compiler/MethodGenerationContext.h"
+#include "../compiler/Parser.h"
+#include "../interpreter/bytecodes.h"
+#include "../vm/Symbols.h"
+#include "../vmobjects/VMMethod.h"
+
+void TestWithParsing::dump(MethodGenerationContext* mgenc) {
+    Disassembler::DumpMethod(mgenc, "");
+}
+
+void TestWithParsing::ensureCGenC() {
+    if (_cgenc != nullptr) {
+        return;
+    }
+
+    _cgenc = new ClassGenerationContext();
+    _cgenc->SetName(SymbolFor("Test"));
+}
+
+void TestWithParsing::ensureMGenC() {
+    if (_mgenc != nullptr) {
+        return;
+    }
+    ensureCGenC();
+
+    _mgenc = new MethodGenerationContext(*_cgenc);
+    std::string self = strSelf;
+    _mgenc->AddArgument(self, {0, 0});
+}
+
+void TestWithParsing::ensureBGenC() {
+    if (_bgenc != nullptr) {
+        return;
+    }
+    ensureCGenC();
+    ensureMGenC();
+
+    _mgenc->SetSignature(SymbolFor("test"));
+    _bgenc = new MethodGenerationContext(*_cgenc, _mgenc);
+}
+
+void TestWithParsing::addField(const char* fieldName) {
+    ensureCGenC();
+    _cgenc->AddInstanceField(SymbolFor(fieldName));
+}
+
+std::vector<uint8_t> TestWithParsing::methodToBytecode(const char* source,
+                                                       bool dumpBytecodes) {
+    ensureMGenC();
+
+    istringstream ss(source);
+
+    std::string fileName = "test";
+    Parser parser(ss, fileName);
+    parser.method(*_mgenc);
+
+    if (dumpBytecodes) {
+        dump(_mgenc);
+    }
+    return _mgenc->GetBytecodes();
+}
+
+std::vector<uint8_t> TestWithParsing::blockToBytecode(const char* source,
+                                                      bool dumpBytecodes) {
+    ensureBGenC();
+
+    istringstream ss(source);
+
+    std::string fileName = "test";
+    Parser parser(ss, fileName);
+
+    parser.nestedBlock(*_bgenc);
+
+    if (dumpBytecodes) {
+        dump(_bgenc);
+    }
+    return _bgenc->GetBytecodes();
+}
+
+void TestWithParsing::check(std::vector<uint8_t> actual,
+                            std::vector<BC>
+                                expected) {
+    size_t i = 0;
+    size_t bci = 0;
+    for (; bci < actual.size() && i < expected.size();) {
+        uint8_t actualBc = actual.at(bci);
+        uint8_t bcLength = Bytecode::GetBytecodeLength(actualBc);
+
+        BC expectedBc = expected.at(i);
+
+        char msg[1000];
+        snprintf(msg, 1000, "Bytecode %zu expected %s but got %s", i,
+                 Bytecode::GetBytecodeName(expectedBc.bytecode),
+                 Bytecode::GetBytecodeName(actualBc));
+        if (expectedBc.bytecode != actualBc) {
+            dump(_mgenc);
+        }
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, expectedBc.bytecode, actualBc);
+
+        snprintf(
+            msg, 1000,
+            "Bytecode %zu (%s) was expected to have length %zu, but had %zu", i,
+            Bytecode::GetBytecodeName(actualBc), expectedBc.size,
+            (size_t)bcLength);
+
+        if (expectedBc.size != bcLength) {
+            dump(_mgenc);
+        }
+        CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, expectedBc.size, (size_t)bcLength);
+
+        if (bcLength > 1) {
+            snprintf(msg, 1000,
+                     "Bytecode %zu (%s), arg1 expected %hhu but got %hhu", i,
+                     Bytecode::GetBytecodeName(expectedBc.bytecode),
+                     expectedBc.arg1, actual.at(bci + 1));
+            if (expectedBc.arg1 != actual.at(bci + 1)) {
+                dump(_mgenc);
+            }
+            CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, expectedBc.arg1,
+                                         actual.at(bci + 1));
+
+            if (bcLength > 2) {
+                snprintf(msg, 1000,
+                         "Bytecode %zu (%s), arg2 expected %hhu but got %hhu",
+                         i, Bytecode::GetBytecodeName(expectedBc.bytecode),
+                         expectedBc.arg2, actual.at(bci + 2));
+                if (expectedBc.arg2 != actual.at(bci + 2)) {
+                    dump(_mgenc);
+                }
+                CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, expectedBc.arg2,
+                                             actual.at(bci + 2));
+            }
+        }
+
+        i += 1;
+        bci += bcLength;
+    }
+    if (expected.size() != i || actual.size() != bci) {
+        dump(_mgenc);
+    }
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("All expected bytecodes covered",
+                                 expected.size(), i);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("All actual bytecodes covered", actual.size(),
+                                 bci);
+}

--- a/src/unitTests/TestWithParsing.h
+++ b/src/unitTests/TestWithParsing.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "../compiler/ClassGenerationContext.h"
+#include "../compiler/MethodGenerationContext.h"
+
+class BC {
+public:
+    BC(uint8_t bytecode) : bytecode(bytecode), arg1(0), arg2(0), size(1) {}
+
+    BC(uint8_t bytecode, uint8_t arg1)
+        : bytecode(bytecode), arg1(arg1), arg2(0), size(2) {}
+
+    BC(uint8_t bytecode, uint8_t arg1, uint8_t arg2)
+        : bytecode(bytecode), arg1(arg1), arg2(arg2), size(3) {}
+
+    uint8_t bytecode;
+    uint8_t arg1;
+    uint8_t arg2;
+
+    size_t size;
+};
+
+class TestWithParsing : public CPPUNIT_NS::TestCase {
+public:
+    inline void setUp() {}
+
+    inline void tearDown() {
+        delete _cgenc;
+        _cgenc = nullptr;
+
+        delete _mgenc;
+        _mgenc = nullptr;
+
+        delete _bgenc;
+        _bgenc = nullptr;
+    }
+
+protected:
+    ClassGenerationContext* _cgenc;
+    MethodGenerationContext* _mgenc;
+    MethodGenerationContext* _bgenc;
+
+    void ensureCGenC();
+    void ensureMGenC();
+    void ensureBGenC();
+    void addField(const char* fieldName);
+
+    std::vector<uint8_t> methodToBytecode(const char* source,
+                                          bool dumpBytecodes = false);
+    std::vector<uint8_t> blockToBytecode(const char* source,
+                                         bool dumpBytecodes = false);
+
+    void dump(MethodGenerationContext* mgenc);
+
+    void check(std::vector<uint8_t> actual, std::vector<BC> expected);
+};

--- a/src/unitTests/TrivialMethodTest.cpp
+++ b/src/unitTests/TrivialMethodTest.cpp
@@ -1,0 +1,224 @@
+#include "TrivialMethodTest.h"
+
+#include <cppunit/TestAssert.h>
+#include <string>
+
+#include "../compiler/MethodGenerationContext.h"
+#include "../vm/IsValidObject.h"
+#include "../vmobjects/VMInvokable.h"
+
+void TrivialMethodTest::literalReturn(std::string source) {
+    std::string s = "test = ( ^ " + source + " )";
+    methodToBytecode(s.data());
+    VMInvokable* m = _mgenc->Assemble();
+
+    std::string expected = "Expected to be trivial: " + s;
+    bool result = IsLiteralReturn(m);
+    CPPUNIT_ASSERT_MESSAGE(expected.data(), result);
+
+    tearDown();
+}
+
+void TrivialMethodTest::testLiteralReturn() {
+    literalReturn("0");
+    literalReturn("1");
+    literalReturn("-10");
+    literalReturn("3333");
+    literalReturn("'str'");
+    literalReturn("#sym");
+    literalReturn("1.1");
+    literalReturn("-2342.234");
+    literalReturn("true");
+    literalReturn("false");
+    literalReturn("nil");
+}
+
+void TrivialMethodTest::blockLiteralReturn(std::string source) {
+    std::string s = "[ " + source + " ]";
+    blockToBytecode(s.data());
+    VMInvokable* m = _bgenc->Assemble();
+
+    std::string expected = "Expected to be trivial: " + s;
+    bool result = IsLiteralReturn(m);
+    CPPUNIT_ASSERT_MESSAGE(expected.data(), result);
+
+    tearDown();
+}
+
+void TrivialMethodTest::testBlockLiteralReturn() {
+    blockLiteralReturn("0");
+    blockLiteralReturn("1");
+    blockLiteralReturn("-10");
+    blockLiteralReturn("3333");
+    blockLiteralReturn("'str'");
+    blockLiteralReturn("#sym");
+    blockLiteralReturn("1.1");
+    blockLiteralReturn("-2342.234");
+    blockLiteralReturn("true");
+    blockLiteralReturn("false");
+    blockLiteralReturn("nil");
+}
+
+void TrivialMethodTest::literalNoReturn(std::string source) {
+    std::string s = "test = ( " + source + " )";
+    methodToBytecode(s.data());
+    VMInvokable* m = _mgenc->Assemble();
+
+    std::string expected = "Expected to be non-trivial: " + s;
+    bool result = IsLiteralReturn(m);
+    CPPUNIT_ASSERT_MESSAGE(expected.data(), !result);
+
+    tearDown();
+}
+
+void TrivialMethodTest::testLiteralNoReturn() {
+    literalNoReturn("0");
+    literalNoReturn("1");
+    literalNoReturn("-10");
+    literalNoReturn("3333");
+    literalNoReturn("'str'");
+    literalNoReturn("#sym");
+    literalNoReturn("1.1");
+    literalNoReturn("-2342.234");
+    literalNoReturn("true");
+    literalNoReturn("false");
+    literalNoReturn("nil");
+}
+
+void TrivialMethodTest::nonTrivialLiteralReturn(std::string source) {
+    std::string s = "test = ( 1. ^ " + source + " )";
+    methodToBytecode(s.data());
+    VMInvokable* m = _mgenc->Assemble();
+
+    std::string expected = "Expected to be non-trivial: " + s;
+    bool result = !IsLiteralReturn(m);
+    CPPUNIT_ASSERT_MESSAGE(expected.data(), result);
+
+    tearDown();
+}
+
+void TrivialMethodTest::testNonTrivialLiteralReturn() {
+    nonTrivialLiteralReturn("0");
+    nonTrivialLiteralReturn("1");
+    nonTrivialLiteralReturn("-10");
+    nonTrivialLiteralReturn("3333");
+    nonTrivialLiteralReturn("'str'");
+    nonTrivialLiteralReturn("#sym");
+    nonTrivialLiteralReturn("1.1");
+    nonTrivialLiteralReturn("-2342.234");
+    nonTrivialLiteralReturn("true");
+    nonTrivialLiteralReturn("false");
+    nonTrivialLiteralReturn("nil");
+}
+
+/*
+
+ @pytest.mark.parametrize("source", ["Nil", "system", "MyClassFooBar"])
+ def test_global_return(mgenc, source):
+     body_or_none = parse_method(mgenc, "test = ( ^ " + source + " )")
+     m = mgenc.assemble(body_or_none)
+     assert isinstance(m, GlobalRead)
+
+
+ def test_non_trivial_global_return(mgenc):
+     body_or_none = parse_method(mgenc, "test = ( #foo. ^ system )")
+     m = mgenc.assemble(body_or_none)
+     assert isinstance(m, AstMethod) or isinstance(m, BcMethod)
+
+ def test_unknown_global_in_block(bgenc):
+     """
+     In PySOM we can actually support this, in TruffleSOM we can't
+     because of the difference in frame format.
+     """
+     body_or_none = parse_block(bgenc, "[ UnknownGlobalSSSS ]")
+     m = bgenc.assemble(body_or_none)
+     assert isinstance(m, GlobalRead)
+
+ def test_field_getter_0(cgenc, mgenc):
+     add_field(cgenc, "field")
+     body_or_none = parse_method(mgenc, "test = ( ^ field )")
+     m = mgenc.assemble(body_or_none)
+     assert isinstance(m, FieldRead)
+
+
+ def test_field_getter_n(cgenc, mgenc):
+     add_field(cgenc, "a")
+     add_field(cgenc, "b")
+     add_field(cgenc, "c")
+     add_field(cgenc, "d")
+     add_field(cgenc, "e")
+     add_field(cgenc, "field")
+     body_or_none = parse_method(mgenc, "test = ( ^ field )")
+     m = mgenc.assemble(body_or_none)
+     assert isinstance(m, FieldRead)
+
+
+ def test_non_trivial_getter_0(cgenc, mgenc):
+     add_field(cgenc, "field")
+     body = parse_method(mgenc, "test = ( 0. ^ field )")
+     m = mgenc.assemble(body)
+     assert isinstance(m, AstMethod) or isinstance(m, BcMethod)
+
+
+ def test_non_trivial_getter_n(cgenc, mgenc):
+     add_field(cgenc, "a")
+     add_field(cgenc, "b")
+     add_field(cgenc, "c")
+     add_field(cgenc, "d")
+     add_field(cgenc, "e")
+     add_field(cgenc, "field")
+     body = parse_method(mgenc, "test = ( 0. ^ field )")
+     m = mgenc.assemble(body)
+     assert isinstance(m, AstMethod) or isinstance(m, BcMethod)
+
+
+ @pytest.mark.parametrize(
+     "source", ["field := val", "field := val.", "field := val. ^ self"]
+ )
+ def test_field_setter_0(cgenc, mgenc, source):
+     add_field(cgenc, "field")
+     body_or_none = parse_method(mgenc, "test: val = ( " + source + " )")
+     m = mgenc.assemble(body_or_none)
+     assert isinstance(m, FieldWrite)
+
+
+ @pytest.mark.parametrize(
+     "source", ["field := value", "field := value.", "field := value. ^ self"]
+ )
+ def test_field_setter_n(cgenc, mgenc, source):
+     add_field(cgenc, "a")
+     add_field(cgenc, "b")
+     add_field(cgenc, "c")
+     add_field(cgenc, "d")
+     add_field(cgenc, "e")
+     add_field(cgenc, "field")
+     body_or_none = parse_method(mgenc, "test: value = ( " + source + " )")
+     m = mgenc.assemble(body_or_none)
+     assert isinstance(m, FieldWrite)
+
+
+ def test_non_trivial_field_setter_0(cgenc, mgenc):
+     add_field(cgenc, "field")
+     body_or_none = parse_method(mgenc, "test: val = ( 0. field := value )")
+     m = mgenc.assemble(body_or_none)
+     assert isinstance(m, AstMethod) or isinstance(m, BcMethod)
+
+
+ def test_non_trivial_field_setter_n(cgenc, mgenc):
+     add_field(cgenc, "a")
+     add_field(cgenc, "b")
+     add_field(cgenc, "c")
+     add_field(cgenc, "d")
+     add_field(cgenc, "e")
+     add_field(cgenc, "field")
+     body_or_none = parse_method(mgenc, "test: val = ( 0. field := value )")
+     m = mgenc.assemble(body_or_none)
+     assert isinstance(m, AstMethod) or isinstance(m, BcMethod)
+
+ def test_block_return(mgenc):
+     body_or_none = parse_method(mgenc, "test = ( ^ [] )")
+     m = mgenc.assemble(body_or_none)
+     assert isinstance(m, AstMethod) or isinstance(m, BcMethod)
+
+
+ */

--- a/src/unitTests/TrivialMethodTest.cpp
+++ b/src/unitTests/TrivialMethodTest.cpp
@@ -148,45 +148,61 @@ void TrivialMethodTest::testUnknownGlobalInBlock() {
     CPPUNIT_ASSERT_MESSAGE(expected.data(), result);
 }
 
+void TrivialMethodTest::testFieldGetter0() {
+    addField("field");
+    methodToBytecode("test = ( ^ field )");
+
+    VMInvokable* m = _mgenc->Assemble();
+
+    std::string expected = "Expected to be trivial: test = ( ^ field )";
+    bool result = IsGetter(m);
+    CPPUNIT_ASSERT_MESSAGE(expected.data(), result);
+}
+
+void TrivialMethodTest::testFieldGetterN() {
+    addField("a");
+    addField("b");
+    addField("c");
+    addField("d");
+    addField("e");
+    addField("field");
+    methodToBytecode("test = ( ^ field )");
+
+    VMInvokable* m = _mgenc->Assemble();
+
+    std::string expected = "Expected to be trivial: test = ( ^ field )";
+    bool result = IsGetter(m);
+    CPPUNIT_ASSERT_MESSAGE(expected.data(), result);
+}
+
+void TrivialMethodTest::testNonTrivialFieldGetter0() {
+    addField("field");
+    methodToBytecode("test = ( 0. ^ field )");
+
+    VMInvokable* m = _mgenc->Assemble();
+
+    std::string expected = "Expected to be non-trivial: test = ( 0. ^ field )";
+    bool result = !IsGetter(m);
+    CPPUNIT_ASSERT_MESSAGE(expected.data(), result);
+}
+
+void TrivialMethodTest::testNonTrivialFieldGetterN() {
+    addField("a");
+    addField("b");
+    addField("c");
+    addField("d");
+    addField("e");
+    addField("field");
+    methodToBytecode("test = ( 0. ^ field )");
+
+    VMInvokable* m = _mgenc->Assemble();
+
+    std::string expected = "Expected to be non-trivial: test = ( 0. ^ field )";
+    bool result = !IsGetter(m);
+    CPPUNIT_ASSERT_MESSAGE(expected.data(), result);
+}
+
 /*
- def test_field_getter_0(cgenc, mgenc):
-     add_field(cgenc, "field")
-     body_or_none = parse_method(mgenc, "test = ( ^ field )")
-     m = mgenc.assemble(body_or_none)
-     assert isinstance(m, FieldRead)
-
-
- def test_field_getter_n(cgenc, mgenc):
-     add_field(cgenc, "a")
-     add_field(cgenc, "b")
-     add_field(cgenc, "c")
-     add_field(cgenc, "d")
-     add_field(cgenc, "e")
-     add_field(cgenc, "field")
-     body_or_none = parse_method(mgenc, "test = ( ^ field )")
-     m = mgenc.assemble(body_or_none)
-     assert isinstance(m, FieldRead)
-
-
- def test_non_trivial_getter_0(cgenc, mgenc):
-     add_field(cgenc, "field")
-     body = parse_method(mgenc, "test = ( 0. ^ field )")
-     m = mgenc.assemble(body)
-     assert isinstance(m, AstMethod) or isinstance(m, BcMethod)
-
-
- def test_non_trivial_getter_n(cgenc, mgenc):
-     add_field(cgenc, "a")
-     add_field(cgenc, "b")
-     add_field(cgenc, "c")
-     add_field(cgenc, "d")
-     add_field(cgenc, "e")
-     add_field(cgenc, "field")
-     body = parse_method(mgenc, "test = ( 0. ^ field )")
-     m = mgenc.assemble(body)
-     assert isinstance(m, AstMethod) or isinstance(m, BcMethod)
-
-
  @pytest.mark.parametrize(
      "source", ["field := val", "field := val.", "field := val. ^ self"]
  )

--- a/src/unitTests/TrivialMethodTest.h
+++ b/src/unitTests/TrivialMethodTest.h
@@ -13,6 +13,10 @@ class TrivialMethodTest : public TestWithParsing {
     CPPUNIT_TEST(testGlobalReturn);
     CPPUNIT_TEST(testNonTrivialGlobalReturn);
     CPPUNIT_TEST(testUnknownGlobalInBlock);
+    CPPUNIT_TEST(testFieldGetter0);
+    CPPUNIT_TEST(testFieldGetterN);
+    CPPUNIT_TEST(testNonTrivialFieldGetter0);
+    CPPUNIT_TEST(testNonTrivialFieldGetterN);
     CPPUNIT_TEST_SUITE_END();
 
 private:
@@ -33,4 +37,10 @@ private:
 
     void testNonTrivialGlobalReturn();
     void testUnknownGlobalInBlock();
+
+    void testFieldGetter0();
+    void testFieldGetterN();
+
+    void testNonTrivialFieldGetter0();
+    void testNonTrivialFieldGetterN();
 };

--- a/src/unitTests/TrivialMethodTest.h
+++ b/src/unitTests/TrivialMethodTest.h
@@ -17,6 +17,11 @@ class TrivialMethodTest : public TestWithParsing {
     CPPUNIT_TEST(testFieldGetterN);
     CPPUNIT_TEST(testNonTrivialFieldGetter0);
     CPPUNIT_TEST(testNonTrivialFieldGetterN);
+    CPPUNIT_TEST(testFieldSetter0);
+    CPPUNIT_TEST(testFieldSetterN);
+    CPPUNIT_TEST(testNonTrivialFieldSetter0);
+    CPPUNIT_TEST(testNonTrivialFieldSetterN);
+    CPPUNIT_TEST(testBlockReturn);
     CPPUNIT_TEST_SUITE_END();
 
 private:
@@ -43,4 +48,13 @@ private:
 
     void testNonTrivialFieldGetter0();
     void testNonTrivialFieldGetterN();
+
+    void testFieldSetter0();
+    void fieldSetter0(std::string source);
+    void testFieldSetterN();
+    void fieldSetterN(std::string source);
+    void testNonTrivialFieldSetter0();
+    void testNonTrivialFieldSetterN();
+
+    void testBlockReturn();
 };

--- a/src/unitTests/TrivialMethodTest.h
+++ b/src/unitTests/TrivialMethodTest.h
@@ -10,6 +10,9 @@ class TrivialMethodTest : public TestWithParsing {
     CPPUNIT_TEST(testLiteralNoReturn);
     CPPUNIT_TEST(testBlockLiteralReturn);
     CPPUNIT_TEST(testNonTrivialLiteralReturn);
+    CPPUNIT_TEST(testGlobalReturn);
+    CPPUNIT_TEST(testNonTrivialGlobalReturn);
+    CPPUNIT_TEST(testUnknownGlobalInBlock);
     CPPUNIT_TEST_SUITE_END();
 
 private:
@@ -24,4 +27,10 @@ private:
 
     void testNonTrivialLiteralReturn();
     void nonTrivialLiteralReturn(std::string source);
+
+    void testGlobalReturn();
+    void globalReturn(std::string source);
+
+    void testNonTrivialGlobalReturn();
+    void testUnknownGlobalInBlock();
 };

--- a/src/unitTests/TrivialMethodTest.h
+++ b/src/unitTests/TrivialMethodTest.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "TestWithParsing.h"
+
+class TrivialMethodTest : public TestWithParsing {
+    CPPUNIT_TEST_SUITE(TrivialMethodTest);
+    CPPUNIT_TEST(testLiteralReturn);
+    CPPUNIT_TEST(testLiteralNoReturn);
+    CPPUNIT_TEST(testBlockLiteralReturn);
+    CPPUNIT_TEST(testNonTrivialLiteralReturn);
+    CPPUNIT_TEST_SUITE_END();
+
+private:
+    void testLiteralReturn();
+    void literalReturn(std::string source);
+
+    void testBlockLiteralReturn();
+    void blockLiteralReturn(std::string source);
+
+    void testLiteralNoReturn();
+    void literalNoReturn(std::string source);
+
+    void testNonTrivialLiteralReturn();
+    void nonTrivialLiteralReturn(std::string source);
+};

--- a/src/unitTests/main.cpp
+++ b/src/unitTests/main.cpp
@@ -20,6 +20,7 @@
 #include "BasicInterpreterTests.h"
 #include "BytecodeGenerationTest.h"
 #include "CloneObjectsTest.h"
+#include "TrivialMethodTest.h"
 #include "WalkObjectsTest.h"
 
 #if GC_TYPE == GENERATIONAL
@@ -32,6 +33,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(CloneObjectsTest);
 CPPUNIT_TEST_SUITE_REGISTRATION(WriteBarrierTest);
 #endif
 CPPUNIT_TEST_SUITE_REGISTRATION(BytecodeGenerationTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(TrivialMethodTest);
 CPPUNIT_TEST_SUITE_REGISTRATION(BasicInterpreterTests);
 
 int main(int ac, char** av) {

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -39,6 +39,7 @@ void* vt_safe_ter_primitive;
 void* vt_literal_return;
 void* vt_global_return;
 void* vt_getter;
+void* vt_setter;
 void* vt_string;
 void* vt_symbol;
 
@@ -72,7 +73,7 @@ bool IsValidObject(vm_oop_t obj) {
              vt == vt_primitive || vt == vt_safe_un_primitive ||
              vt == vt_safe_bin_primitive || vt == vt_safe_ter_primitive ||
              vt == vt_string || vt == vt_symbol || vt == vt_literal_return ||
-             vt == vt_global_return || vt == vt_getter;
+             vt == vt_global_return || vt == vt_getter || vt == vt_setter;
     if (!b) {
         assert(b && "Expected vtable to be one of the known ones.");
         return false;
@@ -114,6 +115,7 @@ void set_vt_to_null() {
     vt_literal_return = nullptr;
     vt_global_return = nullptr;
     vt_getter = nullptr;
+    vt_setter = nullptr;
     vt_string = nullptr;
     vt_symbol = nullptr;
 }
@@ -150,6 +152,11 @@ bool IsGlobalReturn(vm_oop_t obj) {
 bool IsGetter(vm_oop_t obj) {
     assert(vt_getter != nullptr);
     return get_vtable(AS_OBJ(obj)) == vt_getter;
+}
+
+bool IsSetter(vm_oop_t obj) {
+    assert(vt_setter != nullptr);
+    return get_vtable(AS_OBJ(obj)) == vt_setter;
 }
 
 void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
@@ -209,6 +216,10 @@ void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
     VMGetter* get =
         new (GetHeap<HEAP_CLS>(), 0) VMGetter(someValidSymbol, v, 0);
     vt_getter = get_vtable(get);
+
+    VMSetter* set =
+        new (GetHeap<HEAP_CLS>(), 0) VMSetter(someValidSymbol, v, 0, 0);
+    vt_setter = get_vtable(set);
 
     VMString* str =
         new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -38,6 +38,7 @@ void* vt_safe_bin_primitive;
 void* vt_safe_ter_primitive;
 void* vt_literal_return;
 void* vt_global_return;
+void* vt_getter;
 void* vt_string;
 void* vt_symbol;
 
@@ -71,7 +72,7 @@ bool IsValidObject(vm_oop_t obj) {
              vt == vt_primitive || vt == vt_safe_un_primitive ||
              vt == vt_safe_bin_primitive || vt == vt_safe_ter_primitive ||
              vt == vt_string || vt == vt_symbol || vt == vt_literal_return ||
-             vt == vt_global_return;
+             vt == vt_global_return || vt == vt_getter;
     if (!b) {
         assert(b && "Expected vtable to be one of the known ones.");
         return false;
@@ -112,6 +113,7 @@ void set_vt_to_null() {
     vt_safe_ter_primitive = nullptr;
     vt_literal_return = nullptr;
     vt_global_return = nullptr;
+    vt_getter = nullptr;
     vt_string = nullptr;
     vt_symbol = nullptr;
 }
@@ -143,6 +145,11 @@ bool IsLiteralReturn(vm_oop_t obj) {
 bool IsGlobalReturn(vm_oop_t obj) {
     assert(vt_global_return != nullptr);
     return get_vtable(AS_OBJ(obj)) == vt_global_return;
+}
+
+bool IsGetter(vm_oop_t obj) {
+    assert(vt_getter != nullptr);
+    return get_vtable(AS_OBJ(obj)) == vt_getter;
 }
 
 void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
@@ -198,6 +205,10 @@ void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
     VMGlobalReturn* gr = new (GetHeap<HEAP_CLS>(), 0)
         VMGlobalReturn(someValidSymbol, v, someValidSymbol);
     vt_global_return = get_vtable(gr);
+
+    VMGetter* get =
+        new (GetHeap<HEAP_CLS>(), 0) VMGetter(someValidSymbol, v, 0);
+    vt_getter = get_vtable(get);
 
     VMString* str =
         new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -37,6 +37,7 @@ void* vt_safe_un_primitive;
 void* vt_safe_bin_primitive;
 void* vt_safe_ter_primitive;
 void* vt_literal_return;
+void* vt_global_return;
 void* vt_string;
 void* vt_symbol;
 
@@ -69,7 +70,8 @@ bool IsValidObject(vm_oop_t obj) {
              vt == vt_integer || vt == vt_method || vt == vt_object ||
              vt == vt_primitive || vt == vt_safe_un_primitive ||
              vt == vt_safe_bin_primitive || vt == vt_safe_ter_primitive ||
-             vt == vt_string || vt == vt_symbol || vt == vt_literal_return;
+             vt == vt_string || vt == vt_symbol || vt == vt_literal_return ||
+             vt == vt_global_return;
     if (!b) {
         assert(b && "Expected vtable to be one of the known ones.");
         return false;
@@ -109,6 +111,7 @@ void set_vt_to_null() {
     vt_safe_bin_primitive = nullptr;
     vt_safe_ter_primitive = nullptr;
     vt_literal_return = nullptr;
+    vt_global_return = nullptr;
     vt_string = nullptr;
     vt_symbol = nullptr;
 }
@@ -135,6 +138,11 @@ bool IsVMSymbol(vm_oop_t obj) {
 bool IsLiteralReturn(vm_oop_t obj) {
     assert(vt_literal_return != nullptr);
     return get_vtable(AS_OBJ(obj)) == vt_literal_return;
+}
+
+bool IsGlobalReturn(vm_oop_t obj) {
+    assert(vt_global_return != nullptr);
+    return get_vtable(AS_OBJ(obj)) == vt_global_return;
 }
 
 void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
@@ -186,6 +194,10 @@ void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
     VMLiteralReturn* lr = new (GetHeap<HEAP_CLS>(), 0)
         VMLiteralReturn(someValidSymbol, v, someValidSymbol);
     vt_literal_return = get_vtable(lr);
+
+    VMGlobalReturn* gr = new (GetHeap<HEAP_CLS>(), 0)
+        VMGlobalReturn(someValidSymbol, v, someValidSymbol);
+    vt_global_return = get_vtable(gr);
 
     VMString* str =
         new (GetHeap<HEAP_CLS>(), PADDED_SIZE(1)) VMString(0, nullptr);

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -132,6 +132,11 @@ bool IsVMSymbol(vm_oop_t obj) {
     return get_vtable(AS_OBJ(obj)) == vt_symbol;
 }
 
+bool IsLiteralReturn(vm_oop_t obj) {
+    assert(vt_literal_return != nullptr);
+    return get_vtable(AS_OBJ(obj)) == vt_literal_return;
+}
+
 void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
     // These objects are allocated on the heap. So, they will get GC'ed soon
     // enough.

--- a/src/vm/IsValidObject.h
+++ b/src/vm/IsValidObject.h
@@ -11,6 +11,7 @@ bool IsVMSymbol(vm_oop_t obj);
 bool IsLiteralReturn(vm_oop_t obj);
 bool IsGlobalReturn(vm_oop_t obj);
 bool IsGetter(vm_oop_t obj);
+bool IsSetter(vm_oop_t obj);
 
 void set_vt_to_null();
 

--- a/src/vm/IsValidObject.h
+++ b/src/vm/IsValidObject.h
@@ -9,6 +9,7 @@ bool IsVMInteger(vm_oop_t obj);
 bool IsVMMethod(vm_oop_t obj);
 bool IsVMSymbol(vm_oop_t obj);
 bool IsLiteralReturn(vm_oop_t obj);
+bool IsGlobalReturn(vm_oop_t obj);
 
 void set_vt_to_null();
 

--- a/src/vm/IsValidObject.h
+++ b/src/vm/IsValidObject.h
@@ -10,6 +10,7 @@ bool IsVMMethod(vm_oop_t obj);
 bool IsVMSymbol(vm_oop_t obj);
 bool IsLiteralReturn(vm_oop_t obj);
 bool IsGlobalReturn(vm_oop_t obj);
+bool IsGetter(vm_oop_t obj);
 
 void set_vt_to_null();
 

--- a/src/vm/IsValidObject.h
+++ b/src/vm/IsValidObject.h
@@ -8,6 +8,7 @@ bool IsValidObject(vm_oop_t obj);
 bool IsVMInteger(vm_oop_t obj);
 bool IsVMMethod(vm_oop_t obj);
 bool IsVMSymbol(vm_oop_t obj);
+bool IsLiteralReturn(vm_oop_t obj);
 
 void set_vt_to_null();
 

--- a/src/vm/IsValidObject.h
+++ b/src/vm/IsValidObject.h
@@ -6,6 +6,7 @@
 bool IsValidObject(vm_oop_t obj);
 
 bool IsVMInteger(vm_oop_t obj);
+bool IsVMMethod(vm_oop_t obj);
 bool IsVMSymbol(vm_oop_t obj);
 
 void set_vt_to_null();

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -698,7 +698,7 @@ VMArray* Universe::NewArrayList(std::vector<vm_oop_t>& list) const {
     return result;
 }
 
-VMBlock* Universe::NewBlock(VMMethod* method, VMFrame* context,
+VMBlock* Universe::NewBlock(VMInvokable* method, VMFrame* context,
                             long arguments) {
     VMBlock* result = new (GetHeap<HEAP_CLS>(), 0) VMBlock(method, context);
     result->SetClass(GetBlockClassWithArgs(arguments));

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -71,7 +71,7 @@ public:
     VMArray* NewArrayFromStrings(const vector<StdString>&) const;
     VMArray* NewArrayOfSymbolsFromStrings(const vector<StdString>&) const;
 
-    VMBlock* NewBlock(VMMethod*, VMFrame*, long);
+    VMBlock* NewBlock(VMInvokable*, VMFrame*, long);
     VMClass* NewClass(VMClass*) const;
     VMFrame* NewFrame(VMFrame*, VMMethod*) const;
     VMMethod* NewMethod(VMSymbol*, size_t numberOfBytecodes,

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -94,6 +94,7 @@ class VMTrivialMethod;
 class VMLiteralReturn;
 class VMGlobalReturn;
 class VMGetter;
+class VMSetter;
 class VMString;
 class VMSymbol;
 
@@ -158,6 +159,7 @@ class GCTrivialMethod  : public GCInvokable      { public: typedef VMTrivialMeth
 class GCLiteralReturn  : public GCTrivialMethod  { public: typedef VMLiteralReturn  Loaded; };
 class GCGlobalReturn   : public GCTrivialMethod  { public: typedef VMGlobalReturn   Loaded; };
 class GCGetter         : public GCTrivialMethod  { public: typedef VMGetter         Loaded; };
+class GCSetter         : public GCTrivialMethod  { public: typedef VMSetter         Loaded; };
 class GCString         : public GCAbstractObject { public: typedef VMString         Loaded; };
 class GCSymbol         : public GCString         { public: typedef VMSymbol         Loaded; };
 // clang-format on

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -90,6 +90,8 @@ class VMSafePrimitive;
 class VMSafeUnaryPrimitive;
 class VMSafeBinaryPrimitive;
 class VMSafeTernaryPrimitive;
+class VMTrivialMethod;
+class VMLiteralReturn;
 class VMString;
 class VMSymbol;
 
@@ -150,6 +152,8 @@ class GCSafePrimitive  : public GCInvokable      { public: typedef VMSafePrimiti
 class GCSafeUnaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeUnaryPrimitive  Loaded; };
 class GCSafeBinaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeBinaryPrimitive  Loaded; };
 class GCSafeTernaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeTernaryPrimitive  Loaded; };
+class GCTrivialMethod  : public GCInvokable      { public: typedef VMTrivialMethod  Loaded; };
+class GCLiteralReturn  : public GCTrivialMethod      { public: typedef VMLiteralReturn  Loaded; };
 class GCString         : public GCAbstractObject { public: typedef VMString         Loaded; };
 class GCSymbol         : public GCString         { public: typedef VMSymbol         Loaded; };
 // clang-format on

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -93,6 +93,7 @@ class VMSafeTernaryPrimitive;
 class VMTrivialMethod;
 class VMLiteralReturn;
 class VMGlobalReturn;
+class VMGetter;
 class VMString;
 class VMSymbol;
 
@@ -150,12 +151,13 @@ class GCMethod         : public GCInvokable      { public: typedef VMMethod     
 class GCPrimitive      : public GCInvokable      { public: typedef VMPrimitive      Loaded; };
 class GCEvaluationPrimitive : public GCInvokable { public: typedef VMEvaluationPrimitive Loaded; };
 class GCSafePrimitive  : public GCInvokable      { public: typedef VMSafePrimitive  Loaded; };
-class GCSafeUnaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeUnaryPrimitive  Loaded; };
+class GCSafeUnaryPrimitive   : public GCSafePrimitive { public: typedef VMSafeUnaryPrimitive   Loaded; };
 class GCSafeBinaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeBinaryPrimitive  Loaded; };
-class GCSafeTernaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeTernaryPrimitive  Loaded; };
+class GCSafeTernaryPrimitive : public GCSafePrimitive { public: typedef VMSafeTernaryPrimitive Loaded; };
 class GCTrivialMethod  : public GCInvokable      { public: typedef VMTrivialMethod  Loaded; };
-class GCLiteralReturn  : public GCTrivialMethod      { public: typedef VMLiteralReturn  Loaded; };
-class GCGlobalReturn   : public GCTrivialMethod      { public: typedef VMGlobalReturn  Loaded; };
+class GCLiteralReturn  : public GCTrivialMethod  { public: typedef VMLiteralReturn  Loaded; };
+class GCGlobalReturn   : public GCTrivialMethod  { public: typedef VMGlobalReturn   Loaded; };
+class GCGetter         : public GCTrivialMethod  { public: typedef VMGetter         Loaded; };
 class GCString         : public GCAbstractObject { public: typedef VMString         Loaded; };
 class GCSymbol         : public GCString         { public: typedef VMSymbol         Loaded; };
 // clang-format on

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -92,6 +92,7 @@ class VMSafeBinaryPrimitive;
 class VMSafeTernaryPrimitive;
 class VMTrivialMethod;
 class VMLiteralReturn;
+class VMGlobalReturn;
 class VMString;
 class VMSymbol;
 
@@ -154,6 +155,7 @@ class GCSafeBinaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeBi
 class GCSafeTernaryPrimitive  : public GCSafePrimitive { public: typedef VMSafeTernaryPrimitive  Loaded; };
 class GCTrivialMethod  : public GCInvokable      { public: typedef VMTrivialMethod  Loaded; };
 class GCLiteralReturn  : public GCTrivialMethod      { public: typedef VMLiteralReturn  Loaded; };
+class GCGlobalReturn   : public GCTrivialMethod      { public: typedef VMGlobalReturn  Loaded; };
 class GCString         : public GCAbstractObject { public: typedef VMString         Loaded; };
 class GCSymbol         : public GCString         { public: typedef VMSymbol         Loaded; };
 // clang-format on

--- a/src/vmobjects/VMBlock.cpp
+++ b/src/vmobjects/VMBlock.cpp
@@ -32,12 +32,11 @@
 #include "../misc/defs.h"
 #include "ObjectFormats.h"
 #include "VMEvaluationPrimitive.h"
-#include "VMMethod.h"
 #include "VMObject.h"
 
 const int VMBlock::VMBlockNumberOfFields = 2;
 
-VMBlock::VMBlock(VMMethod* method, VMFrame* context)
+VMBlock::VMBlock(VMInvokable* method, VMFrame* context)
     : VMObject(VMBlockNumberOfFields, sizeof(VMBlock)),
       blockMethod(store_with_separate_barrier(method)),
       context(store_with_separate_barrier(context)) {
@@ -51,7 +50,7 @@ VMBlock* VMBlock::CloneForMovingGC() const {
     return clone;
 }
 
-VMMethod* VMBlock::GetMethod() const {
+VMInvokable* VMBlock::GetMethod() const {
     return load_ptr(blockMethod);
 }
 

--- a/src/vmobjects/VMBlock.h
+++ b/src/vmobjects/VMBlock.h
@@ -33,9 +33,9 @@ class VMBlock : public VMObject {
 public:
     typedef GCBlock Stored;
 
-    VMBlock(VMMethod* method, VMFrame* context);
+    VMBlock(VMInvokable* method, VMFrame* context);
 
-    VMMethod* GetMethod() const;
+    VMInvokable* GetMethod() const;
 
     inline VMFrame* GetContext() const { return load_ptr(context); }
 
@@ -48,7 +48,7 @@ public:
 private:
     make_testable(public);
 
-    GCMethod* blockMethod;
+    GCInvokable* blockMethod;
     GCFrame* context;
 
 private:

--- a/src/vmobjects/VMEvaluationPrimitive.h
+++ b/src/vmobjects/VMEvaluationPrimitive.h
@@ -47,7 +47,13 @@ public:
     void MarkObjectAsInvalid() override;
     bool IsMarkedInvalid() const override;
 
-    void Invoke(Interpreter* interp, VMFrame* frm) override;
+    VMFrame* Invoke(Interpreter* interp, VMFrame* frm) override;
+    void InlineInto(MethodGenerationContext& mgenc,
+                    bool mergeScope = true) final;
+
+    inline size_t GetNumberOfArguments() const final {
+        return numberOfArguments;
+    }
 
 private:
     static VMSymbol* computeSignatureString(long argc);

--- a/src/vmobjects/VMInvokable.cpp
+++ b/src/vmobjects/VMInvokable.cpp
@@ -26,6 +26,9 @@
 
 #include "VMInvokable.h"
 
+#include <cstddef>
+
+#include "../vm/Universe.h"
 #include "ObjectFormats.h"
 #include "VMClass.h"
 #include "VMSymbol.h"
@@ -51,4 +54,9 @@ VMClass* VMInvokable::GetHolder() const {
 
 void VMInvokable::SetHolder(VMClass* hld) {
     store_ptr(holder, hld);
+}
+
+const Variable* VMInvokable::GetArgument(size_t, size_t) {
+    GetUniverse()->ErrorExit(
+        "VMInvokable::GetArgument not supported on anything VMMethod");
 }

--- a/src/vmobjects/VMInvokable.h
+++ b/src/vmobjects/VMInvokable.h
@@ -30,6 +30,10 @@
 #include "VMObject.h"
 #include "VMSymbol.h"
 
+class MethodGenerationContext;
+class Variable;
+class VMFrame;
+
 class VMInvokable : public AbstractVMObject {
 public:
     typedef GCInvokable Stored;
@@ -39,7 +43,18 @@ public:
 
     int64_t GetHash() const override { return hash; }
 
-    virtual void Invoke(Interpreter*, VMFrame*) = 0;
+    virtual VMFrame* Invoke(Interpreter*, VMFrame*) = 0;
+    virtual void InlineInto(MethodGenerationContext& mgenc,
+                            bool mergeScope = true) = 0;
+    virtual void MergeScopeInto(
+        MethodGenerationContext&) { /* NOOP for everything but VMMethods */ }
+    virtual void AdaptAfterOuterInlined(
+        uint8_t removedCtxLevel,
+        MethodGenerationContext&
+            mgencWithInlined) { /* NOOP for everything but VMMethods */ }
+    virtual const Variable* GetArgument(size_t, size_t);
+
+    virtual size_t GetNumberOfArguments() const = 0;
 
     virtual bool IsPrimitive() const;
     VMSymbol* GetSignature() const;
@@ -53,6 +68,7 @@ public:
         holder = (GCClass*)INVALID_GC_POINTER;
     }
 
+protected:
     make_testable(public);
 
     int64_t hash;

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -233,9 +233,7 @@ void VMMethod::inlineInto(MethodGenerationContext& mgenc) {
 
                 if (bytecode == BC_PUSH_FIELD || bytecode == BC_PUSH_FIELD_0 ||
                     bytecode == BC_PUSH_FIELD_1) {
-                    EmitPushFieldWithIndex(
-              mgenc, idx,
-              0 /* dummy, self is looked up dynamically at the moment. */);
+                    EmitPushFieldWithIndex(mgenc, idx);
                 } else {
                     EmitPopFieldWithIndex(
               mgenc, idx,

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -125,9 +125,10 @@ void VMMethod::SetCachedFrame(VMFrame* frame) {
 }
 #endif
 
-void VMMethod::Invoke(Interpreter* interp, VMFrame* frame) {
+VMFrame* VMMethod::Invoke(Interpreter* interp, VMFrame* frame) {
     VMFrame* frm = interp->PushNewFrame(this);
     frm->CopyArgumentsFrom(frame);
+    return frm;
 }
 
 void VMMethod::SetHolder(VMClass* hld) {
@@ -322,7 +323,7 @@ void VMMethod::inlineInto(MethodGenerationContext& mgenc) {
             }
 
             case BC_PUSH_BLOCK: {
-                VMMethod* blockMethod = (VMMethod*)GetConstant(i);
+                VMInvokable* blockMethod = (VMInvokable*)GetConstant(i);
                 blockMethod->AdaptAfterOuterInlined(1, mgenc);
                 EmitPUSHBLOCK(mgenc, blockMethod);
                 break;

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -111,7 +111,9 @@ public:
         return maximumNumberOfStackElements;
     }
 
-    inline size_t GetNumberOfArguments() const { return numberOfArguments; }
+    inline size_t GetNumberOfArguments() const final {
+        return numberOfArguments;
+    }
 
     size_t GetNumberOfBytecodes() const { return bcLength; }
     void SetHolder(VMClass* hld) override;
@@ -147,7 +149,7 @@ public:
         store_ptr(indexableFields[idx], item);
     }
 
-    void Invoke(Interpreter* interp, VMFrame* frame) override;
+    VMFrame* Invoke(Interpreter* interp, VMFrame* frame) override;
 
     void MarkObjectAsInvalid() override {
         VMInvokable::MarkObjectAsInvalid();
@@ -160,13 +162,15 @@ public:
 
     StdString AsDebugString() const override;
 
-    void InlineInto(MethodGenerationContext& mgenc, bool mergeScope = true);
+    void InlineInto(MethodGenerationContext& mgenc,
+                    bool mergeScope = true) final;
 
-    void AdaptAfterOuterInlined(uint8_t removedCtxLevel,
-                                MethodGenerationContext& mgencWithInlined);
+    void AdaptAfterOuterInlined(
+        uint8_t removedCtxLevel,
+        MethodGenerationContext& mgencWithInlined) final;
 
-    void MergeScopeInto(MethodGenerationContext& mgenc);
-    const Variable* GetArgument(size_t index, size_t contextLevel) {
+    void MergeScopeInto(MethodGenerationContext& mgenc) override;
+    const Variable* GetArgument(size_t index, size_t contextLevel) override {
         return lexicalScope->GetArgument(index, contextLevel);
     }
 

--- a/src/vmobjects/VMObject.h
+++ b/src/vmobjects/VMObject.h
@@ -74,6 +74,7 @@ public:
     inline long GetNumberOfFields() const override;
 
     inline vm_oop_t GetField(size_t index) const {
+        assert(numberOfFields > index);
         vm_oop_t result = load_ptr(FIELDS[index]);
         assert(IsValidObject(result));
         return result;

--- a/src/vmobjects/VMPrimitive.cpp
+++ b/src/vmobjects/VMPrimitive.cpp
@@ -28,11 +28,13 @@
 
 #include <string>
 
+#include "../compiler/LexicalScope.h"
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../primitivesCore/Routine.h"
 #include "../vm/Globals.h"  // NOLINT (misc-include-cleaner)
 #include "../vm/Print.h"
+#include "../vm/Universe.h"
 #include "ObjectFormats.h"
 #include "VMClass.h"
 #include "VMFrame.h"
@@ -60,6 +62,11 @@ VMPrimitive* VMPrimitive::CloneForMovingGC() const {
 void VMPrimitive::EmptyRoutine(Interpreter*, VMFrame*) {
     VMSymbol* sig = GetSignature();
     ErrorPrint("undefined primitive called: " + sig->GetStdString() + "\n");
+}
+
+void VMPrimitive::InlineInto(MethodGenerationContext&, bool) {
+    GetUniverse()->ErrorExit(
+        "VMPrimitive::InlineInto is not supported, and should not be reached");
 }
 
 std::string VMPrimitive::AsDebugString() const {

--- a/src/vmobjects/VMPrimitive.h
+++ b/src/vmobjects/VMPrimitive.h
@@ -27,6 +27,7 @@
  */
 
 #include "PrimitiveRoutine.h"
+#include "Signature.h"
 #include "VMInvokable.h"
 #include "VMObject.h"
 
@@ -52,9 +53,13 @@ public:
     void SetEmpty(bool value) { empty = value; };
     VMPrimitive* CloneForMovingGC() const override;
 
-    void Invoke(Interpreter* interp, VMFrame* frm) override {
+    VMFrame* Invoke(Interpreter* interp, VMFrame* frm) override {
         routine->Invoke(interp, frm);
+        return nullptr;
     };
+
+    void InlineInto(MethodGenerationContext& mgenc,
+                    bool mergeScope = true) final;
 
     bool IsPrimitive() const override { return true; };
 
@@ -67,6 +72,10 @@ public:
     }
 
     StdString AsDebugString() const override;
+
+    inline size_t GetNumberOfArguments() const final {
+        return Signature::GetNumberOfArguments(load_ptr(signature));
+    }
 
 private:
     void EmptyRoutine(Interpreter*, VMFrame*);

--- a/src/vmobjects/VMSafePrimitive.cpp
+++ b/src/vmobjects/VMSafePrimitive.cpp
@@ -2,9 +2,11 @@
 
 #include <string>
 
+#include "../compiler/LexicalScope.h"
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../primitivesCore/Primitives.h"
+#include "../vm/Universe.h"
 #include "AbstractObject.h"
 #include "ObjectFormats.h"
 #include "VMClass.h"
@@ -17,10 +19,11 @@ VMSafePrimitive* VMSafePrimitive::GetSafeUnary(VMSymbol* sig, UnaryPrim prim) {
     return p;
 }
 
-void VMSafeUnaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
+VMFrame* VMSafeUnaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
     vm_oop_t receiverObj = frame->Pop();
 
     frame->Push(prim.pointer(receiverObj));
+    return nullptr;
 }
 
 VMSafePrimitive* VMSafePrimitive::GetSafeBinary(VMSymbol* sig,
@@ -30,11 +33,12 @@ VMSafePrimitive* VMSafePrimitive::GetSafeBinary(VMSymbol* sig,
     return p;
 }
 
-void VMSafeBinaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
+VMFrame* VMSafeBinaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj = frame->Pop();
 
     frame->Push(prim.pointer(leftObj, rightObj));
+    return nullptr;
 }
 
 VMSafePrimitive* VMSafePrimitive::GetSafeTernary(VMSymbol* sig,
@@ -44,12 +48,13 @@ VMSafePrimitive* VMSafePrimitive::GetSafeTernary(VMSymbol* sig,
     return p;
 }
 
-void VMSafeTernaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
+VMFrame* VMSafeTernaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
     vm_oop_t arg2 = frame->Pop();
     vm_oop_t arg1 = frame->Pop();
     vm_oop_t self = frame->Pop();
 
     frame->Push(prim.pointer(self, arg1, arg2));
+    return nullptr;
 }
 
 std::string VMSafePrimitive::AsDebugString() const {
@@ -73,4 +78,9 @@ AbstractVMObject* VMSafeTernaryPrimitive::CloneForMovingGC() const {
     VMSafeTernaryPrimitive* prim =
         new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMSafeTernaryPrimitive(*this);
     return prim;
+}
+
+void VMSafePrimitive::InlineInto(MethodGenerationContext&, bool) {
+    GetUniverse()->ErrorExit(
+        "VMPrimitive::InlineInto is not supported, and should not be reached");
 }

--- a/src/vmobjects/VMSafePrimitive.h
+++ b/src/vmobjects/VMSafePrimitive.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../primitivesCore/PrimitiveContainer.h"
+#include "Signature.h"
 
 class VMSafePrimitive : public VMInvokable {
 public:
@@ -10,17 +11,20 @@ public:
 
     VMClass* GetClass() const final { return load_ptr(primitiveClass); }
 
-    inline size_t GetObjectSize() const override {
-        return sizeof(VMSafePrimitive);
-    }
-
     bool IsPrimitive() const final { return true; };
+
+    void InlineInto(MethodGenerationContext& mgenc,
+                    bool mergeScope = true) final;
 
     static VMSafePrimitive* GetSafeUnary(VMSymbol* sig, UnaryPrim prim);
     static VMSafePrimitive* GetSafeBinary(VMSymbol* sig, BinaryPrim prim);
     static VMSafePrimitive* GetSafeTernary(VMSymbol* sig, TernaryPrim prim);
 
     std::string AsDebugString() const final;
+
+    inline size_t GetNumberOfArguments() const final {
+        return Signature::GetNumberOfArguments(load_ptr(signature));
+    }
 };
 
 class VMSafeUnaryPrimitive : public VMSafePrimitive {
@@ -36,7 +40,7 @@ public:
         return sizeof(VMSafeUnaryPrimitive);
     }
 
-    void Invoke(Interpreter*, VMFrame*) override;
+    VMFrame* Invoke(Interpreter*, VMFrame*) override;
 
     AbstractVMObject* CloneForMovingGC() const final;
 
@@ -64,7 +68,7 @@ public:
         return sizeof(VMSafeBinaryPrimitive);
     }
 
-    void Invoke(Interpreter*, VMFrame*) override;
+    VMFrame* Invoke(Interpreter*, VMFrame*) override;
 
     AbstractVMObject* CloneForMovingGC() const final;
 
@@ -92,7 +96,7 @@ public:
         return sizeof(VMSafeTernaryPrimitive);
     }
 
-    void Invoke(Interpreter*, VMFrame*) override;
+    VMFrame* Invoke(Interpreter*, VMFrame*) override;
 
     AbstractVMObject* CloneForMovingGC() const final;
 

--- a/src/vmobjects/VMTrivialMethod.cpp
+++ b/src/vmobjects/VMTrivialMethod.cpp
@@ -1,0 +1,50 @@
+#include "VMTrivialMethod.h"
+
+#include <string>
+#include <vector>
+
+#include "../compiler/BytecodeGenerator.h"
+#include "../compiler/MethodGenerationContext.h"
+#include "../compiler/Variable.h"
+#include "../memory/Heap.h"
+#include "../misc/defs.h"
+#include "../vm/LogAllocation.h"
+#include "AbstractObject.h"
+#include "ObjectFormats.h"
+#include "VMFrame.h"
+
+VMTrivialMethod* MakeLiteralReturn(VMSymbol* sig, vector<Variable>& arguments,
+                                   vm_oop_t literal) {
+    VMLiteralReturn* result =
+        new (GetHeap<HEAP_CLS>(), 0) VMLiteralReturn(sig, arguments, literal);
+    LOG_ALLOCATION("VMLiteralReturn", result->GetObjectSize());
+    return result;
+}
+
+VMFrame* VMLiteralReturn::Invoke(Interpreter*, VMFrame* frame) {
+    for (int i = 0; i < numberOfArguments; i += 1) {
+        frame->Pop();
+    }
+    frame->Push(load_ptr(literal));
+    return nullptr;
+}
+
+AbstractVMObject* VMLiteralReturn::CloneForMovingGC() const {
+    VMLiteralReturn* prim =
+        new (GetHeap<HEAP_CLS>(), 0 ALLOC_MATURE) VMLiteralReturn(*this);
+    return prim;
+}
+
+std::string VMLiteralReturn::AsDebugString() const {
+    return "VMLiteralReturn(" + AS_OBJ(load_ptr(literal))->AsDebugString() +
+           ")";
+}
+
+void VMLiteralReturn::WalkObjects(walk_heap_fn walk) {
+    VMInvokable::WalkObjects(walk);
+    literal = walk(literal);
+}
+
+void VMLiteralReturn::InlineInto(MethodGenerationContext& mgenc, bool) {
+    EmitPUSHCONSTANT(mgenc, load_ptr(literal));
+}

--- a/src/vmobjects/VMTrivialMethod.h
+++ b/src/vmobjects/VMTrivialMethod.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "../compiler/MethodGenerationContext.h"
+#include "../vm/Globals.h"
+#include "Signature.h"
+#include "VMInvokable.h"
+
+class VMTrivialMethod : public VMInvokable {
+public:
+    typedef GCTrivialMethod Stored;
+
+    VMTrivialMethod(VMSymbol* sig, vector<Variable>& arguments)
+        : VMInvokable(sig), arguments(arguments) {}
+
+    VMClass* GetClass() const final { return load_ptr(methodClass); }
+
+    bool IsPrimitive() const final { return false; };
+
+    void MergeScopeInto(MethodGenerationContext& mgenc) final {
+        if (arguments.size() > 0) {
+            mgenc.InlineAsLocals(arguments);
+        }
+    }
+
+    const Variable* GetArgument(size_t index, size_t contextLevel) final {
+        assert(contextLevel == 0);
+        if (contextLevel > 0) {
+            return nullptr;
+        }
+        return &arguments.at(index);
+    }
+
+    inline size_t GetNumberOfArguments() const final {
+        return Signature::GetNumberOfArguments(load_ptr(signature));
+    }
+
+private:
+    vector<Variable> arguments;
+};
+
+VMTrivialMethod* MakeLiteralReturn(VMSymbol* sig, vector<Variable>& arguments,
+                                   vm_oop_t literal);
+
+class VMLiteralReturn : public VMTrivialMethod {
+public:
+    typedef GCLiteralReturn Stored;
+
+    VMLiteralReturn(VMSymbol* sig, vector<Variable>& arguments,
+                    vm_oop_t literal)
+        : VMTrivialMethod(sig, arguments),
+          literal(store_with_separate_barrier(literal)),
+          numberOfArguments(Signature::GetNumberOfArguments(sig)) {
+        write_barrier(this, sig);
+        write_barrier(this, literal);
+    }
+
+    inline size_t GetObjectSize() const override {
+        return sizeof(VMLiteralReturn);
+    }
+
+    VMFrame* Invoke(Interpreter*, VMFrame*) override;
+    void InlineInto(MethodGenerationContext& mgenc,
+                    bool mergeScope = true) final;
+
+    AbstractVMObject* CloneForMovingGC() const final;
+
+    void MarkObjectAsInvalid() final {
+        VMTrivialMethod::MarkObjectAsInvalid();
+        literal = INVALID_GC_POINTER;
+    }
+
+    void WalkObjects(walk_heap_fn) override;
+
+    bool IsMarkedInvalid() const final { return literal == INVALID_GC_POINTER; }
+
+    std::string AsDebugString() const final;
+
+private:
+    gc_oop_t literal;
+    int numberOfArguments;
+};


### PR DESCRIPTION
Trivial methods are special cases of well-known patterns where we avoid the need for a frame.

Currently supported are:
 - methods that return a literal
 - methods that return a global
 - methods that read a field (getter)
 - methods that write a field (setter)

https://rebench.dev/SOMpp/compare/f2e87f82f240732ba0f8dd2bdea489c33edcb713..4d147afeb4e27fb698ff1b89ac6a106b3c0381f7
median -1% (min. -46%, max. 14%)

The implementation uses a `VMTrivial` method and subclasses.

Tests now have a common superclass `TestWithParsing` when they use the parser.