### PR TITLE
Micro optimizations of interpreter loop

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -67,5 +67,5 @@ int main(int argc, char** argv) {
 
     Universe::Start(argc, argv);
 
-    Universe::Quit(ERR_SUCCESS);
+    Quit(ERR_SUCCESS);
 }

--- a/src/compiler/Lexer.cpp
+++ b/src/compiler/Lexer.cpp
@@ -33,7 +33,7 @@
 #include <string>
 
 #include "../misc/defs.h"
-#include "../vm/Universe.h"
+#include "../vm/Print.h"
 
 Lexer::Lexer(istream& file) : infile(file), peekDone(false) {}
 
@@ -322,7 +322,7 @@ Symbol Lexer::Peek() {
     const LexerState old = state;
 
     if (peekDone) {
-        Universe::ErrorExit("Cannot Peek twice!\n");
+        ErrorExit("Cannot Peek twice!\n");
     }
     GetSym();
     const Symbol nextSym = state.sym;

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -38,6 +38,7 @@
 #include "../interpreter/bytecodes.h"
 #include "../misc/VectorUtil.h"
 #include "../vm/Globals.h"
+#include "../vm/Print.h"
 #include "../vm/Universe.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMMethod.h"
@@ -147,7 +148,7 @@ VMTrivialMethod* MethodGenerationContext::assembleLiteralReturn(
         }
     }
 
-    GetUniverse()->ErrorExit(
+    ErrorExit(
         "Unexpected situation when trying to create trivial method that "
         "returns a literal");
 }
@@ -159,7 +160,7 @@ VMTrivialMethod* MethodGenerationContext::assembleGlobalReturn() {
     }
 
     if (literals.size() != 1) {
-        GetUniverse()->ErrorExit(
+        ErrorExit(
             "Unexpected situation when trying to create trivial method that "
             "reads a global. New Bytecode?");
     }
@@ -228,7 +229,7 @@ VMTrivialMethod* MethodGenerationContext::assembleFieldSetter() {
             break;
         }
         default: {
-            GetUniverse()->ErrorExit("Unexpected bytecode");
+            ErrorExit("Unexpected bytecode");
         }
     }
 
@@ -246,7 +247,7 @@ VMTrivialMethod* MethodGenerationContext::assembleFieldSetter() {
             break;
         }
         default: {
-            GetUniverse()->ErrorExit("Unexpected bytecode");
+            ErrorExit("Unexpected bytecode");
         }
     }
 
@@ -708,7 +709,7 @@ uint8_t MethodGenerationContext::GetInlinedLocalIdx(const Variable* var) const {
         "Unexpected issue trying to find an inlined variable. %s could not "
         "be found.",
         qualifiedName.data());
-    Universe::ErrorExit(msg);
+    ErrorExit(msg);
 }
 
 void MethodGenerationContext::checkJumpOffset(size_t jumpOffset,
@@ -718,7 +719,7 @@ void MethodGenerationContext::checkJumpOffset(size_t jumpOffset,
         snprintf(msg, 100,
                  "The jumpOffset for the %s bytecode is out of range: %zu\n",
                  Bytecode::GetBytecodeName(bytecode), jumpOffset);
-        Universe::ErrorExit(msg);
+        ErrorExit(msg);
     }
 }
 
@@ -786,7 +787,7 @@ size_t MethodGenerationContext::getOffsetOfLastBytecode(size_t indexFromEnd) {
     for (size_t i = 0; i < indexFromEnd + 1; i += 1) {
         uint8_t actual = last4Bytecodes.at(NUM_LAST_BYTECODES - 1 - i);
         if (actual == BC_INVALID) {
-            GetUniverse()->ErrorExit("The requested bytecode is invalid");
+            ErrorExit("The requested bytecode is invalid");
         }
 
         bcOffset -= Bytecode::GetBytecodeLength(actual);

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -908,7 +908,7 @@ __attribute__((noreturn)) void Parser::parseError(const char* msg,
     ReplacePattern(msgWithMeta, "%(found)s", foundStr);
 
     ErrorPrint(msgWithMeta);
-    GetUniverse()->Quit(ERR_FAIL);
+    Quit(ERR_FAIL);
 }
 
 __attribute__((noreturn)) void Parser::parseError(const char* msg,

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -36,6 +36,7 @@
 #include "../misc/defs.h"
 #include "../vm/Globals.h"
 #include "../vm/IsValidObject.h"
+#include "../vm/Print.h"
 #include "../vm/Universe.h"
 #include "../vmobjects/IntegerBox.h"
 #include "../vmobjects/ObjectFormats.h"
@@ -237,7 +238,7 @@ void Interpreter::doPushFieldWithIndex(uint8_t fieldIndex) {
 
     if (unlikely(IS_TAGGED(self))) {
         o = nullptr;
-        Universe()->ErrorExit("Integers do not have fields!");
+        ErrorExit("Integers do not have fields!");
     } else {
         o = ((VMObject*)self)->GetField(fieldIndex);
     }
@@ -320,7 +321,7 @@ void Interpreter::doPopFieldWithIndex(uint8_t fieldIndex) {
     vm_oop_t o = GetFrame()->Pop();
 
     if (unlikely(IS_TAGGED(self))) {
-        GetUniverse()->ErrorExit("Integers do not have fields that can be set");
+        ErrorExit("Integers do not have fields that can be set");
     } else {
         ((VMObject*)self)->SetField(fieldIndex, o);
     }
@@ -436,7 +437,7 @@ void Interpreter::doInc() {
         double d = static_cast<VMDouble*>(val)->GetEmbeddedDouble();
         val = GetUniverse()->NewDouble(d + 1.0);
     } else {
-        GetUniverse()->ErrorExit("unsupported");
+        ErrorExit("unsupported");
     }
 
     GetFrame()->SetTop(store_root(val));

--- a/src/memory/CopyingHeap.cpp
+++ b/src/memory/CopyingHeap.cpp
@@ -7,7 +7,6 @@
 
 #include "../misc/defs.h"
 #include "../vm/Print.h"
-#include "../vm/Universe.h"
 #include "../vmobjects/AbstractObject.h"
 #include "CopyingCollector.h"
 #include "Heap.h"
@@ -52,7 +51,7 @@ void CopyingHeap::switchBuffers(bool increaseMemory) {
         currentBuffer = malloc(newSize);
 
         if (currentBuffer == nullptr) {
-            Universe::ErrorExit("unable to allocate heap memory");
+            ErrorExit("unable to allocate heap memory");
         }
 
         currentBufferEnd = (void*)((size_t)currentBuffer + newSize);
@@ -91,7 +90,7 @@ void CopyingHeap::invalidateOldBuffer() {
         oldBuffer = malloc(currentBufSize);
 
         if (oldBuffer == nullptr) {
-            Universe::ErrorExit("unable to allocate heap memory");
+            ErrorExit("unable to allocate heap memory");
         }
 
         oldBufferEnd = (void*)((size_t)oldBuffer + currentBufSize);
@@ -103,7 +102,7 @@ AbstractVMObject* CopyingHeap::AllocateObject(size_t size) {
     nextFreePosition = (void*)((size_t)nextFreePosition + size);
     if (nextFreePosition > currentBufferEnd) {
         ErrorPrint("\nFailed to allocate " + to_string(size) + " Bytes.\n");
-        Universe::Quit(-1);
+        Quit(-1);
     }
 
     // let's see if we have to trigger the GC

--- a/src/memory/DebugCopyingHeap.cpp
+++ b/src/memory/DebugCopyingHeap.cpp
@@ -7,7 +7,6 @@
 #include <string>
 
 #include "../vm/Print.h"
-#include "../vm/Universe.h"
 #include "../vmobjects/AbstractObject.h"
 
 void DebugCopyingHeap::switchBuffers(bool increaseMemory) {
@@ -57,7 +56,7 @@ AbstractVMObject* DebugCopyingHeap::AllocateObject(size_t size) {
 
     if (currentHeapUsage > currentHeapSize) {
         ErrorPrint("\nFailed to allocate " + to_string(size) + " Bytes.\n");
-        Universe::Quit(-1);
+        Quit(-1);
     }
 
     // let's see if we have to trigger the GC

--- a/src/memory/GenerationalHeap.cpp
+++ b/src/memory/GenerationalHeap.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "../vm/Print.h"
-#include "../vm/Universe.h"
 #include "../vmobjects/AbstractObject.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMObjectBase.h"
@@ -39,7 +38,7 @@ AbstractVMObject* GenerationalHeap::AllocateNurseryObject(size_t size) {
     if ((size_t)nextFreePosition > nursery_end) {
         ErrorPrint("\nFailed to allocate " + to_string(size) +
                    " Bytes in nursery.\n");
-        GetUniverse()->Quit(-1);
+        Quit(-1);
     }
     // let's see if we have to trigger the GC
     if (nextFreePosition > collectionLimit) {
@@ -52,7 +51,7 @@ AbstractVMObject* GenerationalHeap::AllocateMatureObject(size_t size) {
     AbstractVMObject* newObject = (AbstractVMObject*)malloc(size);
     if (newObject == nullptr) {
         ErrorPrint("\nFailed to allocate " + to_string(size) + " Bytes.\n");
-        GetUniverse()->Quit(-1);
+        Quit(-1);
     }
     allocatedObjects->push_back(newObject);
     matureObjectsSize += size;

--- a/src/memory/MarkSweepHeap.cpp
+++ b/src/memory/MarkSweepHeap.cpp
@@ -7,7 +7,6 @@
 
 #include "../memory/Heap.h"
 #include "../vm/Print.h"
-#include "../vm/Universe.h"
 #include "../vmobjects/AbstractObject.h"
 #include "MarkSweepCollector.h"
 
@@ -23,7 +22,7 @@ AbstractVMObject* MarkSweepHeap::AllocateObject(size_t size) {
     AbstractVMObject* newObject = (AbstractVMObject*)malloc(size);
     if (newObject == nullptr) {
         ErrorPrint("\nFailed to allocate " + to_string(size) + " Bytes.\n");
-        Universe::Quit(-1);
+        Quit(-1);
     }
     spcAlloc += size;
     memset((void*)newObject, 0, size);

--- a/src/primitives/Double.cpp
+++ b/src/primitives/Double.cpp
@@ -34,6 +34,7 @@
 
 #include "../primitivesCore/PrimitiveContainer.h"
 #include "../vm/Globals.h"
+#include "../vm/Print.h"
 #include "../vm/Universe.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMDouble.h"
@@ -56,8 +57,7 @@ double coerceDouble(vm_oop_t x) {
     } else if (cl == load_ptr(integerClass)) {
         return (double)static_cast<VMInteger*>(x)->GetEmbeddedInteger();
     } else {
-        GetUniverse()->ErrorExit(
-            "Attempt to apply Double operation to non-number.");
+        ErrorExit("Attempt to apply Double operation to non-number.");
     }
 
     return 0.0f;

--- a/src/primitives/System.cpp
+++ b/src/primitives/System.cpp
@@ -91,7 +91,7 @@ static vm_oop_t sysLoad_(vm_oop_t, vm_oop_t rightObj) {
 
 static vm_oop_t sysExit_(vm_oop_t, vm_oop_t err) {
     long err_no = INT_VAL(err);
-    GetUniverse()->Quit(err_no);
+    Quit(err_no);
 }
 
 static vm_oop_t sysPrintString_(vm_oop_t leftObj, vm_oop_t rightObj) {

--- a/src/vm/Print.cpp
+++ b/src/vm/Print.cpp
@@ -1,20 +1,50 @@
 #include "Print.h"
 
+#include <cstdlib>
 #include <iostream>
 #include <mutex>
+#include <string>
 
 #include "../misc/defs.h"
+#include "LogAllocation.h"
+#include "Universe.h"
 
 using namespace std;
 
 static mutex output_mutex;
 
-void Print(StdString str) {
+void Print(std::string str) {
     lock_guard<mutex> lock(output_mutex);
     cout << str << flush;
 }
 
-void ErrorPrint(StdString str) {
+void ErrorPrint(std::string str) {
     lock_guard<mutex> lock(output_mutex);
     cerr << str << flush;
+}
+
+void Print(const char* str) {
+    lock_guard<mutex> lock(output_mutex);
+    cout << str << flush;
+}
+
+void ErrorPrint(const char* str) {
+    lock_guard<mutex> lock(output_mutex);
+    cerr << str << flush;
+}
+
+__attribute__((noreturn)) __attribute__((noinline)) void ErrorExit(
+    const char* err) {
+    ErrorPrint("Runtime error: " + StdString(err) + "\n");
+    Quit(ERR_FAIL);
+}
+
+__attribute__((noreturn)) __attribute__((noinline)) void Quit(long err) {
+    ErrorPrint("Time spent in GC: [" +
+               to_string(Timer::GCTimer->GetTotalTime()) + "] msec\n");
+
+    Universe::Shutdown();
+
+    OutputAllocationLogFile();
+    exit((int)err);
 }

--- a/src/vm/Print.h
+++ b/src/vm/Print.h
@@ -1,6 +1,11 @@
 #pragma once
 
-#include "../misc/defs.h"
+#include <string>
 
-void Print(StdString str);
-void ErrorPrint(StdString str);
+void Print(std::string str);
+void Print(const char* str);
+void ErrorPrint(std::string str);
+void ErrorPrint(const char* str);
+
+__attribute__((noreturn)) __attribute__((noinline)) void Quit(long);
+__attribute__((noreturn)) __attribute__((noinline)) void ErrorExit(const char*);

--- a/src/vm/Shell.cpp
+++ b/src/vm/Shell.cpp
@@ -37,6 +37,7 @@
 #include "../vmobjects/VMInvokable.h"
 #include "../vmobjects/VMMethod.h"
 #include "Globals.h"
+#include "Print.h"
 #include "Symbols.h"
 #include "Universe.h"
 
@@ -65,7 +66,7 @@ void Shell::Start(Interpreter* interp) {
 #define QUIT_CMD_L 11 + 1
 
     if (bootstrapMethod == nullptr) {
-        GetUniverse()->ErrorExit("Shell needs bootstrap method!");
+        ErrorExit("Shell needs bootstrap method!");
     }
     // the statement to evaluate
     char inbuf[INPUT_MAX_SIZE];

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -92,7 +92,7 @@ void Universe::BasicInit() {
     theUniverse = new Universe();
 }
 
-__attribute__((noreturn)) void Universe::Quit(long err) {
+void Universe::Shutdown() {
     ErrorPrint("Time spent in GC: [" +
                to_string(Timer::GCTimer->GetTotalTime()) + "] msec\n");
 #ifdef GENERATE_INTEGER_HISTOGRAM
@@ -136,18 +136,9 @@ __attribute__((noreturn)) void Universe::Quit(long err) {
     }
 #endif
 
-    OutputAllocationLogFile();
-
     if (theUniverse) {
         delete (theUniverse);
     }
-
-    exit((int)err);
-}
-
-__attribute__((noreturn)) void Universe::ErrorExit(const char* err) {
-    ErrorPrint("Runtime error: " + StdString(err) + "\n");
-    Quit(ERR_FAIL);
 }
 
 vector<StdString> Universe::handleArguments(long argc, char** argv) {
@@ -619,7 +610,7 @@ void Universe::LoadSystemClass(VMClass* systemClass) {
 
     if (!result) {
         ErrorPrint("Can't load system class: " + s + "\n");
-        Universe::Quit(ERR_FAIL);
+        Quit(ERR_FAIL);
     }
 
     if (result->HasPrimitives() || result->GetClass()->HasPrimitives()) {

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -34,6 +34,7 @@
 #include "../misc/Timer.h"
 #include "../misc/defs.h"
 #include "../vmobjects/ObjectFormats.h"
+#include "Print.h"
 
 class SourcecodeCompiler;
 
@@ -49,8 +50,6 @@ public:
     // static methods
     static void Start(long argc, char** argv);
     static void BasicInit();
-    __attribute__((noreturn)) static void Quit(long);
-    __attribute__((noreturn)) static void ErrorExit(const char*);
 
     vm_oop_t interpret(StdString className, StdString methodName);
 
@@ -114,6 +113,8 @@ public:
 #endif
     //
 
+    static void Shutdown();
+
 private:
     vm_oop_t interpretMethod(VMObject* receiver, VMInvokable* initialize,
                              VMArray* argumentsArray);
@@ -144,8 +145,7 @@ private:
 inline Universe* GetUniverse() __attribute__((always_inline));
 Universe* GetUniverse() {
     if (DEBUG && Universe::theUniverse == nullptr) {
-        Universe::ErrorExit(
-            "Trying to access uninitialized Universe, exiting.");
+        ErrorExit("Trying to access uninitialized Universe, exiting.");
     }
     return Universe::theUniverse;
 }

--- a/src/vmobjects/VMArray.cpp
+++ b/src/vmobjects/VMArray.cpp
@@ -33,6 +33,7 @@
 
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
+#include "../vm/Print.h"
 #include "../vm/Universe.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMObject.h"
@@ -49,20 +50,20 @@ VMArray::VMArray(size_t arraySize, size_t additionalBytes)
 
 vm_oop_t VMArray::GetIndexableField(size_t idx) const {
     if (unlikely(idx > GetNumberOfIndexableFields())) {
-        Universe::ErrorExit(("Array index out of bounds: Accessing " +
-                             to_string(idx) + ", but array size is only " +
-                             to_string(GetNumberOfIndexableFields()) + "\n")
-                                .c_str());
+        ErrorExit(("Array index out of bounds: Accessing " + to_string(idx) +
+                   ", but array size is only " +
+                   to_string(GetNumberOfIndexableFields()) + "\n")
+                      .c_str());
     }
     return GetField(idx);
 }
 
 void VMArray::SetIndexableField(size_t idx, vm_oop_t value) {
     if (unlikely(idx > GetNumberOfIndexableFields())) {
-        Universe::ErrorExit(("Array index out of bounds: Accessing " +
-                             to_string(idx) + ", but array size is only " +
-                             to_string(GetNumberOfIndexableFields()) + "\n")
-                                .c_str());
+        ErrorExit(("Array index out of bounds: Accessing " + to_string(idx) +
+                   ", but array size is only " +
+                   to_string(GetNumberOfIndexableFields()) + "\n")
+                      .c_str());
     }
     SetField(idx, value);
 }

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -35,7 +35,7 @@
 #include "../primitivesCore/PrimitiveLoader.h"
 #include "../vm/Globals.h"
 #include "../vm/IsValidObject.h"
-#include "../vm/Universe.h"
+#include "../vm/Print.h"
 #include "ObjectFormats.h"
 #include "VMArray.h"
 #include "VMInvokable.h"
@@ -65,8 +65,7 @@ VMClass::VMClass(size_t numberOfFields, size_t additionalBytes)
 
 bool VMClass::AddInstanceInvokable(VMInvokable* ptr) {
     if (ptr == nullptr) {
-        GetUniverse()->ErrorExit(
-            "Error: trying to add non-invokable to invokables array");
+        ErrorExit("Error: trying to add non-invokable to invokables array");
         return false;
     }
     // Check whether an invokable with the same signature exists and replace it
@@ -82,7 +81,7 @@ bool VMClass::AddInstanceInvokable(VMInvokable* ptr) {
                 return false;
             }
         } else {
-            GetUniverse()->ErrorExit(
+            ErrorExit(
                 "Invokables array corrupted. "
                 "Either NULL pointer added or pointer to non-invokable.");
             return false;

--- a/src/vmobjects/VMEvaluationPrimitive.cpp
+++ b/src/vmobjects/VMEvaluationPrimitive.cpp
@@ -34,6 +34,7 @@
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../primitivesCore/Routine.h"
+#include "../vm/Print.h"
 #include "../vm/Symbols.h"
 #include "../vm/Universe.h"  // NOLINT(misc-include-cleaner) it's required to make the types complete
 #include "ObjectFormats.h"
@@ -118,7 +119,7 @@ bool VMEvaluationPrimitive::IsMarkedInvalid() const {
 }
 
 void VMEvaluationPrimitive::InlineInto(MethodGenerationContext&, bool) {
-    GetUniverse()->ErrorExit(
+    ErrorExit(
         "VMEvaluationPrimitive::InlineInto is not supported, and should not be "
         "reached");
 }

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -185,14 +185,6 @@ void VMFrame::WalkObjects(walk_heap_fn walk) {
     }
 }
 
-long VMFrame::RemainingStackSize() const {
-    // - 1 because the stack pointer points at the top entry,
-    // so the next entry would be put at stackPointer+1
-    size_t size = ((size_t)this + totalObjectSize - size_t(stack_ptr)) /
-                  sizeof(VMObject*);
-    return size - 1;
-}
-
 void VMFrame::PrintBytecode() const {
     Disassembler::DumpMethod(GetMethod(), "  ");
 }

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -130,7 +130,13 @@ public:
     void PrintStack() const;
     void PrintBytecode() const;
 
-    long RemainingStackSize() const;
+    long RemainingStackSize() const {
+        // - 1 because the stack pointer points at the top entry,
+        // so the next entry would be put at stackPointer+1
+        size_t size = ((size_t)this + totalObjectSize - size_t(stack_ptr)) /
+                      sizeof(VMObject*);
+        return size - 1;
+    }
 
     StdString AsDebugString() const override;
 

--- a/src/vmobjects/VMInvokable.cpp
+++ b/src/vmobjects/VMInvokable.cpp
@@ -28,7 +28,7 @@
 
 #include <cstddef>
 
-#include "../vm/Universe.h"
+#include "../vm/Print.h"
 #include "ObjectFormats.h"
 #include "VMClass.h"
 #include "VMSymbol.h"
@@ -57,6 +57,5 @@ void VMInvokable::SetHolder(VMClass* hld) {
 }
 
 const Variable* VMInvokable::GetArgument(size_t, size_t) {
-    GetUniverse()->ErrorExit(
-        "VMInvokable::GetArgument not supported on anything VMMethod");
+    ErrorExit("VMInvokable::GetArgument not supported on anything VMMethod");
 }

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -42,6 +42,7 @@
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../vm/Globals.h"
+#include "../vm/Print.h"
 #include "../vm/Universe.h"  // NOLINT(misc-include-cleaner) it's required to make the types complete
 #include "ObjectFormats.h"
 #include "Signature.h"
@@ -439,7 +440,7 @@ void VMMethod::inlineInto(MethodGenerationContext& mgenc) {
                     "inlineInto: Found %s bytecode, but it's not expected in a "
                     "block method",
                     Bytecode::GetBytecodeName(bytecode));
-                Universe::ErrorExit(msg);
+                ErrorExit(msg);
                 break;
             }
             default: {
@@ -449,7 +450,7 @@ void VMMethod::inlineInto(MethodGenerationContext& mgenc) {
                          "not yet "
                          "supported.",
                          Bytecode::GetBytecodeName(bytecode));
-                Universe::ErrorExit(msg);
+                ErrorExit(msg);
                 break;
             }
         }
@@ -605,7 +606,7 @@ void VMMethod::AdaptAfterOuterInlined(
                     "AdaptAfterOuterInlined: Found %s bytecode, but it's not "
                     "expected in a block method",
                     Bytecode::GetBytecodeName(bytecode));
-                Universe::ErrorExit(msg);
+                ErrorExit(msg);
             }
 
             default: {
@@ -615,7 +616,7 @@ void VMMethod::AdaptAfterOuterInlined(
                          "not yet "
                          "support it.",
                          Bytecode::GetBytecodeName(bytecode));
-                Universe::ErrorExit(msg);
+                ErrorExit(msg);
             }
         }
 

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -121,7 +121,7 @@ public:
 
     inline vm_oop_t GetConstant(size_t bytecodeIndex) const {
         const uint8_t bc = bytecodes[bytecodeIndex + 1];
-        if (bc >= GetNumberOfIndexableFields()) {
+        if (unlikely(bc >= GetNumberOfIndexableFields())) {
             ErrorPrint("Error: Constant index out of range\n");
             return nullptr;
         }

--- a/src/vmobjects/VMPrimitive.cpp
+++ b/src/vmobjects/VMPrimitive.cpp
@@ -34,7 +34,6 @@
 #include "../primitivesCore/Routine.h"
 #include "../vm/Globals.h"  // NOLINT (misc-include-cleaner)
 #include "../vm/Print.h"
-#include "../vm/Universe.h"
 #include "ObjectFormats.h"
 #include "VMClass.h"
 #include "VMFrame.h"
@@ -65,7 +64,7 @@ void VMPrimitive::EmptyRoutine(Interpreter*, VMFrame*) {
 }
 
 void VMPrimitive::InlineInto(MethodGenerationContext&, bool) {
-    GetUniverse()->ErrorExit(
+    ErrorExit(
         "VMPrimitive::InlineInto is not supported, and should not be reached");
 }
 

--- a/src/vmobjects/VMSafePrimitive.cpp
+++ b/src/vmobjects/VMSafePrimitive.cpp
@@ -6,7 +6,7 @@
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../primitivesCore/Primitives.h"
-#include "../vm/Universe.h"
+#include "../vm/Print.h"
 #include "AbstractObject.h"
 #include "ObjectFormats.h"
 #include "VMClass.h"
@@ -81,6 +81,6 @@ AbstractVMObject* VMSafeTernaryPrimitive::CloneForMovingGC() const {
 }
 
 void VMSafePrimitive::InlineInto(MethodGenerationContext&, bool) {
-    GetUniverse()->ErrorExit(
+    ErrorExit(
         "VMPrimitive::InlineInto is not supported, and should not be reached");
 }

--- a/src/vmobjects/VMTrivialMethod.cpp
+++ b/src/vmobjects/VMTrivialMethod.cpp
@@ -11,6 +11,7 @@
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../vm/LogAllocation.h"
+#include "../vm/Print.h"
 #include "../vm/Universe.h"
 #include "AbstractObject.h"
 #include "ObjectFormats.h"
@@ -122,7 +123,7 @@ VMFrame* VMGetter::Invoke(Interpreter*, VMFrame* frame) {
     vm_oop_t result;
     if (unlikely(IS_TAGGED(self))) {
         result = nullptr;
-        Universe()->ErrorExit("Integers do not have fields!");
+        ErrorExit("Integers do not have fields!");
     } else {
         result = ((VMObject*)self)->GetField(fieldIndex);
     }
@@ -166,7 +167,7 @@ VMFrame* VMSetter::Invoke(Interpreter*, VMFrame* frame) {
     assert(value != nullptr);
 
     if (unlikely(IS_TAGGED(self))) {
-        Universe()->ErrorExit("Integers do not have fields!");
+        ErrorExit("Integers do not have fields!");
     } else {
         ((VMObject*)self)->SetField(fieldIndex, value);
     }
@@ -175,8 +176,7 @@ VMFrame* VMSetter::Invoke(Interpreter*, VMFrame* frame) {
 }
 
 void VMSetter::InlineInto(MethodGenerationContext& mgenc, bool) {
-    GetUniverse()->ErrorExit(
-        "We don't currently support blocks for trivial setters");
+    ErrorExit("We don't currently support blocks for trivial setters");
 }
 
 AbstractVMObject* VMSetter::CloneForMovingGC() const {


### PR DESCRIPTION
- make RemainingStackSize inlinable
- mark an out-of-bounds check as unlikely
- make ErrorExit and Quit non-inlinable

This seem to give a surprising amount of speed: median -3% (min. -25%, max. 10%)
https://rebench.dev/SOMpp/compare/4ba47cfe11c5e5b4d5379c36de923faf601ffc93..8866a58999526c54a50fc5d4e4c948ee94176a89