### PR TITLE
Implement RETURN_FIELD_* bytecodes and port more of the tests

### DIFF
--- a/src/compiler/BytecodeGenerator.cpp
+++ b/src/compiler/BytecodeGenerator.cpp
@@ -254,11 +254,32 @@ void EmitRETURNSELF(MethodGenerationContext& mgenc) {
 }
 
 void EmitRETURNLOCAL(MethodGenerationContext& mgenc) {
-    Emit1(mgenc, BC_RETURN_LOCAL, 0);
+    if (!mgenc.OptimizeReturnField()) {
+        Emit1(mgenc, BC_RETURN_LOCAL, 0);
+    }
 }
 
 void EmitRETURNNONLOCAL(MethodGenerationContext& mgenc) {
     Emit1(mgenc, BC_RETURN_NON_LOCAL, 0);
+}
+
+void EmitRETURNFIELD(MethodGenerationContext& mgenc, size_t index) {
+    assert(index <= 2);
+    uint8_t bc = 0;
+    switch (index) {
+        case 0:
+            bc = BC_RETURN_FIELD_0;
+            break;
+
+        case 1:
+            bc = BC_RETURN_FIELD_1;
+            break;
+
+        case 2:
+            bc = BC_RETURN_FIELD_2;
+            break;
+    }
+    Emit1(mgenc, bc, 0);
 }
 
 void EmitINC(MethodGenerationContext& mgenc) {

--- a/src/compiler/BytecodeGenerator.h
+++ b/src/compiler/BytecodeGenerator.h
@@ -58,6 +58,7 @@ void EmitSUPERSEND(MethodGenerationContext& mgenc, VMSymbol* msg);
 void EmitRETURNSELF(MethodGenerationContext& mgenc);
 void EmitRETURNLOCAL(MethodGenerationContext& mgenc);
 void EmitRETURNNONLOCAL(MethodGenerationContext& mgenc);
+void EmitRETURNFIELD(MethodGenerationContext& mgenc, size_t index);
 
 void EmitINC(MethodGenerationContext& mgenc);
 void EmitDupSecond(MethodGenerationContext& mgenc);

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -115,6 +115,7 @@ public:
     void PatchJumpOffsetToPointToNextInstruction(size_t indexOfOffset);
 
     bool OptimizeDupPopPopSequence();
+    bool OptimizeReturnField();
 
     bool LastBytecodeIs(size_t indexFromEnd, uint8_t bytecode);
 
@@ -124,9 +125,7 @@ private:
     VMTrivialMethod* assembleGlobalReturn();
     VMTrivialMethod* assembleFieldGetter(uint8_t pushCandidate);
     VMTrivialMethod* assembleFieldSetter();
-    VMTrivialMethod* assembleFieldGetterFromReturn(uint8_t pushCandidate) {
-        return nullptr;
-    }
+    VMTrivialMethod* assembleFieldGetterFromReturn(uint8_t returnCandidate);
 
     bool optimizeIncFieldPush() {
         // TODO: implement

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -246,6 +246,20 @@ void Interpreter::doPushFieldWithIndex(uint8_t fieldIndex) {
     GetFrame()->Push(o);
 }
 
+void Interpreter::doReturnFieldWithIndex(uint8_t fieldIndex) {
+    vm_oop_t self = GetSelf();
+    vm_oop_t o;
+
+    if (unlikely(IS_TAGGED(self))) {
+        o = nullptr;
+        ErrorExit("Integers do not have fields!");
+    } else {
+        o = ((VMObject*)self)->GetField(fieldIndex);
+    }
+
+    popFrameAndPushResult(o);
+}
+
 void Interpreter::doPushBlock(long bytecodeIndex) {
     vm_oop_t block = method->GetConstant(bytecodeIndex);
     VMInvokable* blockMethod = static_cast<VMInvokable*>(block);

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -87,6 +87,7 @@ private:
     void doDup();
     void doPushLocal(long bytecodeIndex);
     void doPushLocalWithIndex(uint8_t localIndex);
+    void doReturnFieldWithIndex(uint8_t fieldIndex);
     void doPushArgument(long bytecodeIndex);
     void doPushField(long bytecodeIndex);
     void doPushFieldWithIndex(uint8_t fieldIndex);

--- a/src/interpreter/InterpreterLoop.h
+++ b/src/interpreter/InterpreterLoop.h
@@ -42,6 +42,9 @@ vm_oop_t Start() {
                            &&LABEL_BC_RETURN_LOCAL,
                            &&LABEL_BC_RETURN_NON_LOCAL,
                            &&LABEL_BC_RETURN_SELF,
+                           &&LABEL_BC_RETURN_FIELD_0,
+                           &&LABEL_BC_RETURN_FIELD_1,
+                           &&LABEL_BC_RETURN_FIELD_2,
                            &&LABEL_BC_INC,
                            &&LABEL_BC_JUMP,
                            &&LABEL_BC_JUMP_ON_FALSE_POP,
@@ -269,6 +272,21 @@ LABEL_BC_RETURN_SELF: {
     popFrameAndPushResult(GetFrame()->GetArgumentInCurrentContext(0));
     DISPATCH_NOGC();
 }
+
+LABEL_BC_RETURN_FIELD_0:
+    PROLOGUE(1);
+    doReturnFieldWithIndex(0);
+    DISPATCH_NOGC();
+
+LABEL_BC_RETURN_FIELD_1:
+    PROLOGUE(1);
+    doReturnFieldWithIndex(1);
+    DISPATCH_NOGC();
+
+LABEL_BC_RETURN_FIELD_2:
+    PROLOGUE(1);
+    doReturnFieldWithIndex(2);
+    DISPATCH_NOGC();
 
 LABEL_BC_INC:
     PROLOGUE(1);

--- a/src/interpreter/bytecodes.cpp
+++ b/src/interpreter/bytecodes.cpp
@@ -67,6 +67,9 @@ const uint8_t Bytecode::bytecodeLengths[] = {
     1,  // BC_RETURN_LOCAL
     1,  // BC_RETURN_NON_LOCAL
     1,  // BC_RETURN_SELF
+    1,  // BC_RETURN_FIELD_0
+    1,  // BC_RETURN_FIELD_1
+    1,  // BC_RETURN_FIELD_2
     1,  // BC_INC
 
     3,  // BC_JUMP
@@ -124,21 +127,24 @@ const char* Bytecode::bytecodeNames[] = {
     "RETURN_LOCAL    ",        // 34
     "RETURN_NON_LOCAL",        // 35
     "RETURN_SELF     ",        // 36
-    "INC             ",        // 37
-    "JUMP            ",        // 38
-    "JUMP_ON_FALSE_POP",       // 39
-    "JUMP_ON_TRUE_POP",        // 40
-    "JUMP_ON_FALSE_TOP_NIL",   // 41
-    "JUMP_ON_TRUE_TOP_NIL",    // 42
-    "JUMP_IF_GREATER ",        // 43
-    "JUMP_BACKWARD   ",        // 44
-    "JUMP2           ",        // 45
-    "JUMP2_ON_FALSE_POP",      // 46
-    "JUMP2_ON_TRUE_POP",       // 47
-    "JUMP2_ON_FALSE_TOP_NIL",  // 48
-    "JUMP2_ON_TRUE_TOP_NIL",   // 49
-    "JUMP2_IF_GREATER",        // 50
-    "JUMP2_BACKWARD  ",        // 51
+    "RETURN_FIELD_0  ",        // 37
+    "RETURN_FIELD_1  ",        // 38
+    "RETURN_FIELD_2  ",        // 39
+    "INC             ",        // 40
+    "JUMP            ",        // 41
+    "JUMP_ON_FALSE_POP",       // 42
+    "JUMP_ON_TRUE_POP",        // 43
+    "JUMP_ON_FALSE_TOP_NIL",   // 44
+    "JUMP_ON_TRUE_TOP_NIL",    // 45
+    "JUMP_IF_GREATER ",        // 46
+    "JUMP_BACKWARD   ",        // 47
+    "JUMP2           ",        // 48
+    "JUMP2_ON_FALSE_POP",      // 49
+    "JUMP2_ON_TRUE_POP",       // 50
+    "JUMP2_ON_FALSE_TOP_NIL",  // 51
+    "JUMP2_ON_TRUE_TOP_NIL",   // 52
+    "JUMP2_IF_GREATER",        // 53
+    "JUMP2_BACKWARD  ",        // 54
 };
 
 bool IsJumpBytecode(uint8_t bc) {

--- a/src/interpreter/bytecodes.h
+++ b/src/interpreter/bytecodes.h
@@ -70,21 +70,24 @@
 #define BC_RETURN_LOCAL           34
 #define BC_RETURN_NON_LOCAL       35
 #define BC_RETURN_SELF            36
-#define BC_INC                    37
-#define BC_JUMP                   38
-#define BC_JUMP_ON_FALSE_POP      39
-#define BC_JUMP_ON_TRUE_POP       40
-#define BC_JUMP_ON_FALSE_TOP_NIL  41
-#define BC_JUMP_ON_TRUE_TOP_NIL   42
-#define BC_JUMP_IF_GREATER        43
-#define BC_JUMP_BACKWARD          44
-#define BC_JUMP2                  45
-#define BC_JUMP2_ON_FALSE_POP     46
-#define BC_JUMP2_ON_TRUE_POP      47
-#define BC_JUMP2_ON_FALSE_TOP_NIL 48
-#define BC_JUMP2_ON_TRUE_TOP_NIL  49
-#define BC_JUMP2_IF_GREATER       50
-#define BC_JUMP2_BACKWARD         51
+#define BC_RETURN_FIELD_0         37
+#define BC_RETURN_FIELD_1         38
+#define BC_RETURN_FIELD_2         39
+#define BC_INC                    40
+#define BC_JUMP                   41
+#define BC_JUMP_ON_FALSE_POP      42
+#define BC_JUMP_ON_TRUE_POP       43
+#define BC_JUMP_ON_FALSE_TOP_NIL  44
+#define BC_JUMP_ON_TRUE_TOP_NIL   45
+#define BC_JUMP_IF_GREATER        46
+#define BC_JUMP_BACKWARD          47
+#define BC_JUMP2                  48
+#define BC_JUMP2_ON_FALSE_POP     49
+#define BC_JUMP2_ON_TRUE_POP      50
+#define BC_JUMP2_ON_FALSE_TOP_NIL 51
+#define BC_JUMP2_ON_TRUE_TOP_NIL  52
+#define BC_JUMP2_IF_GREATER       53
+#define BC_JUMP2_BACKWARD         54
 
 #define _LAST_BYTECODE BC_JUMP2_BACKWARD
 
@@ -102,9 +105,6 @@
 #define BC_SEND_3            249
 #define BC_SEND_2            248
 #define BC_SEND_1            247
-#define BC_RETURN_FIELD_0    246
-#define BC_RETURN_FIELD_1    245
-#define BC_RETURN_FIELD_2    244
 // clang-format on
 
 // properties of the bytecodes

--- a/src/unitTests/BytecodeGenerationTest.cpp
+++ b/src/unitTests/BytecodeGenerationTest.cpp
@@ -819,154 +819,109 @@ void BytecodeGenerationTest::testNestedIfsAndLocals() {
              (16, BC(Bytecodes.push_argument, 1, 0, note="arg e")),
          ],
      )
+*/
 
+void BytecodeGenerationTest::testBlockIfTrueArg() {
+    auto bytecodes = blockToBytecode(R"""(
+               [:arg | #start.
+                   self method ifTrue: [ arg ].
+                   #end
+               ] )""");
 
- def test_block_if_true_arg(bgenc):
-     bytecodes = block_to_bytecodes(
-         bgenc,
-         """
-         [:arg | #start.
-             self method ifTrue: [ arg ].
-             #end
-         ]""",
-     )
+    check(bytecodes,
+          {BC_PUSH_CONSTANT_0, BC_POP, BC(BC_PUSH_ARGUMENT, 0, 1),
+           BC(BC_SEND, 1), BC(BC_JUMP_ON_FALSE_TOP_NIL, 4, 0), BC_PUSH_ARG_1,
+           BC_POP, BC_PUSH_CONSTANT_2, BC_RETURN_LOCAL});
+}
 
-     assert len(bytecodes) == 17
-     check(
-         bytecodes,
-         [
-             (5, Bytecodes.send_1),
-             BC(Bytecodes.jump_on_false_top_nil, 6),
-             BC(Bytecodes.push_argument, 1, 0),
-             Bytecodes.pop,
-             Bytecodes.push_constant,
-         ],
-     )
+void BytecodeGenerationTest::testBlockIfTrueMethodArg() {
+    ensureMGenC();
+    std::string argName = "arg";
+    _mgenc->AddArgument(argName, {1, 1});
 
+    auto bytecodes = blockToBytecode(R"""(
+               [ #start.
+                   self method ifTrue: [ arg ].
+                   #end
+               ] )""");
 
- def test_block_if_true_method_arg(mgenc, bgenc):
-     mgenc.add_argument("arg", None, None)
-     bytecodes = block_to_bytecodes(
-         bgenc,
-         """
-         [ #start.
-             self method ifTrue: [ arg ].
-             #end
-         ]""",
-     )
+    check(bytecodes, {BC_PUSH_CONSTANT_0, BC_POP, BC(BC_PUSH_ARGUMENT, 0, 1),
+                      BC(BC_SEND, 1), BC(BC_JUMP_ON_FALSE_TOP_NIL, 6, 0),
+                      BC(BC_PUSH_ARGUMENT, 1, 1), BC_POP, BC_PUSH_CONSTANT_2,
+                      BC_RETURN_LOCAL});
+}
 
-     assert len(bytecodes) == 17
-     check(
-         bytecodes,
-         [
-             (7, BC(Bytecodes.jump_on_false_top_nil, 6)),
-             BC(Bytecodes.push_argument, 1, 1),
-             Bytecodes.pop,
-             Bytecodes.push_constant,
-         ],
-     )
+void BytecodeGenerationTest::testIfTrueIfFalseReturn() {
+    ifTrueIfFalseReturn("ifTrue:", "ifFalse:", BC(BC_JUMP_ON_FALSE_POP, 8, 0));
+    ifTrueIfFalseReturn("ifFalse:", "ifTrue:", BC(BC_JUMP_ON_TRUE_POP, 8, 0));
+}
+void BytecodeGenerationTest::ifTrueIfFalseReturn(std::string sel1,
+                                                 std::string sel2, BC bc) {
+    std::string source = "test: arg1 with: arg2 = ( #start. ^ self method " +
+                         sel1 + " [ ^ arg1 ] " + sel2 + " [ arg2 ] )";
+    auto bytecodes = methodToBytecode(source.data());
 
+    check(bytecodes, {BC_PUSH_CONSTANT_0, BC_POP, BC_PUSH_SELF, BC(BC_SEND, 1),
+                      bc, BC_PUSH_ARG_1, BC_RETURN_LOCAL, BC(BC_JUMP, 4, 0),
+                      BC_PUSH_ARG_2, BC_RETURN_LOCAL});
+    tearDown();
+}
 
+void BytecodeGenerationTest::testBlockIfReturnNonLocal() {
+    blockIfReturnNonLocal("ifTrue:", BC(BC_JUMP_ON_FALSE_TOP_NIL, 5, 0));
+    blockIfReturnNonLocal("ifFalse:", BC(BC_JUMP_ON_TRUE_TOP_NIL, 5, 0));
+}
 
- @pytest.mark.parametrize(
-     "sel1,sel2,jump_bytecode",
-     [
-         ("ifTrue:", "ifFalse:", Bytecodes.jump_on_false_pop),
-         ("ifFalse:", "ifTrue:", Bytecodes.jump_on_true_pop),
-     ],
- )
- def test_if_true_if_false_return(mgenc, sel1, sel2, jump_bytecode):
-     bytecodes = method_to_bytecodes(
-         mgenc,
-         """
-         test: arg1 with: arg2 = (
-             #start.
-             ^ self method SEL1 [ ^ arg1 ] SEL2 [ arg2 ]
-         )""".replace(
-             "SEL1", sel1
-         ).replace(
-             "SEL2", sel2
-         ),
-     )
-
-     assert len(bytecodes) == 21
-     check(
-         bytecodes,
-         [
-             (7, BC(jump_bytecode, 10)),
-             (14, BC(Bytecodes.jump, 6)),
-         ],
-     )
-
-
-
-
- @pytest.mark.parametrize(
-     "if_selector,jump_bytecode",
-     [
-         ("ifTrue:", Bytecodes.jump_on_false_top_nil),
-         ("ifFalse:", Bytecodes.jump_on_true_top_nil),
-     ],
- )
- def test_block_if_return_non_local(bgenc, if_selector, jump_bytecode):
-     bytecodes = block_to_bytecodes(
-         bgenc,
-         """
-         [:arg |
+void BytecodeGenerationTest::blockIfReturnNonLocal(std::string sel, BC bc) {
+    std::string source = R"""(      [:arg |
              #start.
              self method IF_SELECTOR [ ^ arg ].
              #end
-         ]""".replace(
-             "IF_SELECTOR", if_selector
-         ),
-     )
+         ] )""";
+    bool wasReplaced = ReplacePattern(source, "IF_SELECTOR", sel);
+    assert(wasReplaced);
 
-     assert len(bytecodes) == 19
-     check(
-         bytecodes,
-         [
-             (5, Bytecodes.send_1),
-             BC(jump_bytecode, 8),
-             BC(Bytecodes.push_argument, 1, 0),
-             BC(Bytecodes.return_non_local, 1),
-             Bytecodes.pop,
-         ],
-     )
+    auto bytecodes = blockToBytecode(source.data());
+    check(bytecodes,
+          {BC_PUSH_CONSTANT_0, BC_POP, BC(BC_PUSH_ARGUMENT, 0, 1),
+           BC(BC_SEND, 1), bc, BC_PUSH_ARG_1, BC_RETURN_NON_LOCAL, BC_POP,
+           BC_PUSH_CONSTANT_2, BC_RETURN_LOCAL});
 
+    tearDown();
+}
 
+void BytecodeGenerationTest::testTrivialMethodInlining() {
+    trivialMethodInlining("0", BC_PUSH_0);
+    trivialMethodInlining("1", BC_PUSH_1);
+    trivialMethodInlining("-10", BC_PUSH_CONSTANT_1);
+    trivialMethodInlining("3333", BC_PUSH_CONSTANT_1);
+    trivialMethodInlining("'str'", BC_PUSH_CONSTANT_1);
+    trivialMethodInlining("#sym", BC_PUSH_CONSTANT_1);
+    trivialMethodInlining("1.1", BC_PUSH_CONSTANT_1);
+    trivialMethodInlining("-2342.234", BC_PUSH_CONSTANT_1);
+    trivialMethodInlining("true", BC_PUSH_CONSTANT_0);
+    trivialMethodInlining("false", BC_PUSH_CONSTANT_1);
+    trivialMethodInlining("nil", BC_PUSH_NIL);
+    trivialMethodInlining("Nil", BC(BC_PUSH_GLOBAL, 1));
+    trivialMethodInlining("UnknownGlobal", BC(BC_PUSH_GLOBAL, 1));
+    trivialMethodInlining("[]", BC(BC_PUSH_BLOCK, 1));
+    trivialMethodInlining("[ self ]", BC(BC_PUSH_BLOCK, 1));
+}
 
+void BytecodeGenerationTest::trivialMethodInlining(std::string literal,
+                                                   BC bytecode) {
+    std::string source = "test = ( true ifTrue: [ " + literal + " ] )";
+    auto bytecodes = methodToBytecode(source.data());
 
- @pytest.mark.parametrize(
-     "source,bytecode",
-     [
-         ("0", Bytecodes.push_0),
-         ("1", Bytecodes.push_1),
-         ("-10", BC_PUSH_CONSTANT_2),
-         ("3333", BC_PUSH_CONSTANT_2),
-         ("'str'", BC_PUSH_CONSTANT_2),
-         ("#sym", BC_PUSH_CONSTANT_2),
-         ("1.1", BC_PUSH_CONSTANT_2),
-         ("-2342.234", BC_PUSH_CONSTANT_2),
-         ("true", Bytecodes.push_constant_0),
-         ("false", BC_PUSH_CONSTANT_2),
-         ("nil", Bytecodes.push_nil),
-         ("Nil", Bytecodes.push_global),
-         ("UnknownGlobal", Bytecodes.push_global),
-         ("[]", Bytecodes.push_block_no_ctx),
-     ],
- )
- def test_trivial_method_inlining(mgenc, source, bytecode):
-     bytecodes = method_to_bytecodes(mgenc, "test = ( true ifTrue: [ " + source
- + " ] )") check( bytecodes,
-         [
-             Bytecodes.push_constant_0,
-             Bytecodes.jump_on_false_top_nil,
-             bytecode,
-             Bytecodes.return_self,
-         ],
-     )
+    bool isLongerBytecode = bytecode.bytecode == BC_PUSH_GLOBAL ||
+                            bytecode.bytecode == BC_PUSH_BLOCK;
+    check(bytecodes, {BC_PUSH_CONSTANT_0,
+                      BC(BC_JUMP_ON_FALSE_TOP_NIL, isLongerBytecode ? 5 : 4, 0),
+                      bytecode, BC_RETURN_SELF});
+    tearDown();
+}
 
-
+/*
  @pytest.mark.parametrize("field_num", range(0, 7))
  def test_inc_field(cgenc, mgenc, field_num):
      add_field(cgenc, "field0")
@@ -1069,38 +1024,41 @@ void BytecodeGenerationTest::testNestedIfsAndLocals() {
      )
 
 
- @pytest.mark.parametrize(
-     "field_num,bytecode",
-     [
-         (0, Bytecodes.return_field_0),
-         (1, Bytecodes.return_field_1),
-         (2, Bytecodes.return_field_2),
-         (3, BC(Bytecodes.push_field, 3)),
-         (4, BC(Bytecodes.push_field, 4)),
-     ],
- )
- def test_return_field(cgenc, mgenc, field_num, bytecode):
-     add_field(cgenc, "field0")
-     add_field(cgenc, "field1")
-     add_field(cgenc, "field2")
-     add_field(cgenc, "field3")
-     add_field(cgenc, "field4")
-     add_field(cgenc, "field5")
-     add_field(cgenc, "field6")
 
-     field_name = "field" + str(field_num)
-     bytecodes = method_to_bytecodes(mgenc, "test = ( 1. ^ " + field_name + "
- )")
-
-     check(
-         bytecodes,
-         [
-             Bytecodes.push_1,
-             Bytecodes.pop,
-             bytecode,
-         ],
-     )
  */
+
+void BytecodeGenerationTest::testReturnField() {
+    returnField(0, BC_RETURN_FIELD_0, true);
+    returnField(1, BC_RETURN_FIELD_1, true);
+    returnField(2, BC_RETURN_FIELD_2, true);
+    returnField(3, BC(BC_PUSH_FIELD, 3), false);
+    returnField(4, BC(BC_PUSH_FIELD, 4), false);
+    returnField(5, BC(BC_PUSH_FIELD, 5), false);
+    returnField(6, BC(BC_PUSH_FIELD, 6), false);
+}
+
+void BytecodeGenerationTest::returnField(size_t fieldNum, BC bytecode,
+                                         bool isReturnFieldBc) {
+    addField("field0");
+    addField("field1");
+    addField("field2");
+    addField("field3");
+    addField("field4");
+    addField("field5");
+    addField("field6");
+
+    std::string fieldName = "field" + to_string(fieldNum);
+    std::string source = "test = ( 1. ^ " + fieldName + ")";
+    auto bytecodes = methodToBytecode(source.data());
+    std::vector<BC> expected = {BC_PUSH_1, BC_POP, bytecode};
+
+    if (!isReturnFieldBc) {
+        expected.push_back(BC_RETURN_LOCAL);
+    }
+
+    check(bytecodes, expected);
+    tearDown();
+}
 
 void BytecodeGenerationTest::testFieldReadInlining() {
     addField("field");

--- a/src/unitTests/BytecodeGenerationTest.h
+++ b/src/unitTests/BytecodeGenerationTest.h
@@ -58,6 +58,12 @@ class BytecodeGenerationTest : public TestWithParsing {
     CPPUNIT_TEST(testNestedIfs);
     CPPUNIT_TEST(testNestedIfsAndLocals);
     CPPUNIT_TEST(testFieldReadInlining);
+    CPPUNIT_TEST(testReturnField);
+    CPPUNIT_TEST(testTrivialMethodInlining);
+    CPPUNIT_TEST(testBlockIfTrueArg);
+    CPPUNIT_TEST(testBlockIfTrueMethodArg);
+    CPPUNIT_TEST(testIfTrueIfFalseReturn);
+    CPPUNIT_TEST(testBlockIfReturnNonLocal);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -137,4 +143,17 @@ private:
     void testNestedIfsAndLocals();
 
     void testFieldReadInlining();
+    void testReturnField();
+    void returnField(size_t fieldNum, BC bytecode, bool isReturnFieldBc);
+
+    void testTrivialMethodInlining();
+    void trivialMethodInlining(std::string literal, BC bytecode);
+
+    void testBlockIfTrueArg();
+    void testBlockIfTrueMethodArg();
+    void testIfTrueIfFalseReturn();
+    void ifTrueIfFalseReturn(std::string sel1, std::string sel2, BC bc);
+
+    void testBlockIfReturnNonLocal();
+    void blockIfReturnNonLocal(std::string sel, BC bc);
 };

--- a/src/unitTests/BytecodeGenerationTest.h
+++ b/src/unitTests/BytecodeGenerationTest.h
@@ -55,6 +55,9 @@ class BytecodeGenerationTest : public TestWithParsing {
     CPPUNIT_TEST(testIfReturnNonLocal);
 
     CPPUNIT_TEST(testJumpQueuesOrdering);
+    CPPUNIT_TEST(testNestedIfs);
+    CPPUNIT_TEST(testNestedIfsAndLocals);
+    CPPUNIT_TEST(testFieldReadInlining);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -129,4 +132,9 @@ private:
     void testInliningOfToDo();
 
     void testJumpQueuesOrdering();
+
+    void testNestedIfs();
+    void testNestedIfsAndLocals();
+
+    void testFieldReadInlining();
 };

--- a/src/unitTests/TestWithParsing.cpp
+++ b/src/unitTests/TestWithParsing.cpp
@@ -102,8 +102,8 @@ void TestWithParsing::check(std::vector<uint8_t> actual,
         BC expectedBc = expected.at(i);
 
         char msg[1000];
-        snprintf(msg, 1000, "Bytecode %zu expected %s but got %s", i,
-                 Bytecode::GetBytecodeName(expectedBc.bytecode),
+        snprintf(msg, 1000, "Bytecode no %zu (at: %zu) expected %s but got %s",
+                 i, bci, Bytecode::GetBytecodeName(expectedBc.bytecode),
                  Bytecode::GetBytecodeName(actualBc));
         if (expectedBc.bytecode != actualBc) {
             dump(_mgenc);

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -390,6 +390,14 @@ void VMMethod::inlineInto(MethodGenerationContext& mgenc) {
                 }
                 break;
             }
+            case BC_RETURN_FIELD_0:
+            case BC_RETURN_FIELD_1:
+            case BC_RETURN_FIELD_2: {
+                uint8_t index = bytecode - BC_RETURN_FIELD_0;
+                EmitPushFieldWithIndex(mgenc, index);
+                break;
+            }
+
             case BC_JUMP:
             case BC_JUMP_ON_TRUE_TOP_NIL:
             case BC_JUMP_ON_FALSE_TOP_NIL:
@@ -430,10 +438,7 @@ void VMMethod::inlineInto(MethodGenerationContext& mgenc) {
 
             case BC_HALT:
             case BC_PUSH_SELF:
-            case BC_RETURN_SELF:
-            case BC_RETURN_FIELD_0:
-            case BC_RETURN_FIELD_1:
-            case BC_RETURN_FIELD_2: {
+            case BC_RETURN_SELF: {
                 char msg[120];
                 snprintf(
                     msg, 120,


### PR DESCRIPTION
Performance is a bit unclear whether this is noice: median -3% (min. -25%, max. 10%)
https://rebench.dev/SOMpp/compare/e1feaf1782d3b1f51263a5a52ddf7898d7403812..57cae1ae59d0cbfadf8c5ee9af41ae0dd1ed01c3