### PR TITLE
Make Universe and Interpreter static

### DIFF
--- a/src/compiler/ClassGenerationContext.cpp
+++ b/src/compiler/ClassGenerationContext.cpp
@@ -99,26 +99,25 @@ VMClass* ClassGenerationContext::Assemble() {
     std::string ccname = string(name->GetStdString()) + " class";
 
     // Load the super class
-    VMClass* superClass = GetUniverse()->LoadClass(superName);
+    VMClass* superClass = Universe::LoadClass(superName);
 
     // Allocate the class of the resulting class
-    VMClass* resultClass = GetUniverse()->NewClass(load_ptr(metaClassClass));
+    VMClass* resultClass = Universe::NewClass(load_ptr(metaClassClass));
 
     // Initialize the class of the resulting class
-    resultClass->SetInstanceFields(GetUniverse()->NewArrayList(classFields));
-    resultClass->SetInstanceInvokables(
-        GetUniverse()->NewArrayList(classMethods));
+    resultClass->SetInstanceFields(Universe::NewArrayList(classFields));
+    resultClass->SetInstanceInvokables(Universe::NewArrayList(classMethods));
     resultClass->SetName(SymbolFor(ccname));
 
     VMClass* superMClass = superClass->GetClass();
     resultClass->SetSuperClass(superMClass);
 
     // Allocate the resulting class
-    VMClass* result = GetUniverse()->NewClass(resultClass);
+    VMClass* result = Universe::NewClass(resultClass);
 
     // Initialize the resulting class
-    result->SetInstanceFields(GetUniverse()->NewArrayList(instanceFields));
-    result->SetInstanceInvokables(GetUniverse()->NewArrayList(instanceMethods));
+    result->SetInstanceFields(Universe::NewArrayList(instanceFields));
+    result->SetInstanceInvokables(Universe::NewArrayList(instanceMethods));
     result->SetName(name);
     result->SetSuperClass(superClass);
 
@@ -126,12 +125,10 @@ VMClass* ClassGenerationContext::Assemble() {
 }
 
 void ClassGenerationContext::AssembleSystemClass(VMClass* systemClass) {
-    systemClass->SetInstanceInvokables(
-        GetUniverse()->NewArrayList(instanceMethods));
-    systemClass->SetInstanceFields(GetUniverse()->NewArrayList(instanceFields));
+    systemClass->SetInstanceInvokables(Universe::NewArrayList(instanceMethods));
+    systemClass->SetInstanceFields(Universe::NewArrayList(instanceFields));
     // class-bound == class-instance-bound
     VMClass* superMClass = systemClass->GetClass();
-    superMClass->SetInstanceInvokables(
-        GetUniverse()->NewArrayList(classMethods));
-    superMClass->SetInstanceFields(GetUniverse()->NewArrayList(classFields));
+    superMClass->SetInstanceInvokables(Universe::NewArrayList(classMethods));
+    superMClass->SetInstanceFields(Universe::NewArrayList(classFields));
 }

--- a/src/compiler/Disassembler.cpp
+++ b/src/compiler/Disassembler.cpp
@@ -63,7 +63,7 @@ void Disassembler::dispatch(vm_oop_t o) {
         DebugPrint("{System Class object}");
     } else if (o == load_ptr(blockClass)) {
         DebugPrint("{Block Class object}");
-    } else if (o == GetUniverse()->GetGlobal(SymbolFor("system"))) {
+    } else if (o == Universe::GetGlobal(SymbolFor("system"))) {
         DebugPrint("{System}");
     } else {
         VMClass* c = CLASS_OF(o);
@@ -489,7 +489,7 @@ void Disassembler::DumpBytecode(VMFrame* frame, VMMethod* method, long bc_idx) {
         case BC_PUSH_GLOBAL: {
             VMSymbol* name =
                 static_cast<VMSymbol*>(method->GetConstant(bc_idx));
-            vm_oop_t o = GetUniverse()->GetGlobal(name);
+            vm_oop_t o = Universe::GetGlobal(name);
             VMSymbol* cname;
 
             const char* c_cname;

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -70,9 +70,9 @@ VMInvokable* MethodGenerationContext::Assemble() {
     // create a method instance with the given number of bytecodes and literals
     size_t numLiterals = literals.size();
     size_t numLocals = locals.size();
-    VMMethod* meth = GetUniverse()->NewMethod(
-        signature, bytecode.size(), numLiterals, numLocals, maxStackDepth,
-        lexicalScope, inlinedLoops);
+    VMMethod* meth =
+        Universe::NewMethod(signature, bytecode.size(), numLiterals, numLocals,
+                            maxStackDepth, lexicalScope, inlinedLoops);
 
     // copy literals into the method
     for (size_t i = 0; i < numLiterals; i++) {

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -247,7 +247,7 @@ void Parser::superclass(ClassGenerationContext& cgenc) {
 
     // Load the super class, if it is not nil (break the dependency cycle)
     if (superName != SymbolFor("nil")) {
-        VMClass* superClass = GetUniverse()->LoadClass(superName);
+        VMClass* superClass = Universe::LoadClass(superName);
         cgenc.SetInstanceFieldsOfSuper(superClass->GetInstanceFields());
         cgenc.SetClassFieldsOfSuper(
             superClass->GetClass()->GetInstanceFields());
@@ -260,7 +260,7 @@ void Parser::superclass(ClassGenerationContext& cgenc) {
         vector<StdString> fieldNamesOfClass{"class", "name", "instanceFields",
                                             "instanceInvokables", "superClass"};
         VMArray* fieldNames =
-            GetUniverse()->NewArrayOfSymbolsFromStrings(fieldNamesOfClass);
+            Universe::NewArrayOfSymbolsFromStrings(fieldNamesOfClass);
         cgenc.SetClassFieldsOfSuper(fieldNames);
     }
 }
@@ -748,7 +748,7 @@ vm_oop_t Parser::literalDouble(bool negateValue) {
         d = 0 - d;
     }
     expect(Double);
-    return GetUniverse()->NewDouble(d);
+    return Universe::NewDouble(d);
 }
 
 void Parser::literalSymbol(MethodGenerationContext& mgenc) {
@@ -801,7 +801,7 @@ void Parser::literalArray(MethodGenerationContext& mgenc) {
 void Parser::literalString(MethodGenerationContext& mgenc) {
     StdString s = _string();
 
-    VMString* str = GetUniverse()->NewString(s);
+    VMString* str = Universe::NewString(s);
     EmitPUSHCONSTANT(mgenc, str);
 }
 

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -81,7 +81,7 @@ vm_oop_t Interpreter::Start() {
 }
 
 VMFrame* Interpreter::PushNewFrame(VMMethod* method) {
-    SetFrame(GetUniverse()->NewFrame(GetFrame(), method));
+    SetFrame(Universe::NewFrame(GetFrame(), method));
     return GetFrame();
 }
 
@@ -135,13 +135,12 @@ void Interpreter::send(VMSymbol* signature, VMClass* receiverClass) {
     if (invokable != nullptr) {
 #ifdef LOG_RECEIVER_TYPES
         std::string name = receiverClass->GetName()->GetStdString();
-        if (GetUniverse()->callStats.find(name) ==
-            GetUniverse()->callStats.end()) {
-            GetUniverse()->callStats[name] = {0, 0};
+        if (Universe::callStats.find(name) == Universe::callStats.end()) {
+            Universe::callStats[name] = {0, 0};
         }
-        GetUniverse()->callStats[name].noCalls++;
+        Universe::callStats[name].noCalls++;
         if (invokable->IsPrimitive()) {
-            GetUniverse()->callStats[name].noPrimitiveCalls++;
+            Universe::callStats[name].noPrimitiveCalls++;
         }
 #endif
         // since an invokable is able to change/use the frame, we have to write
@@ -160,7 +159,7 @@ void Interpreter::triggerDoesNotUnderstand(VMSymbol* signature) {
     vm_oop_t receiver = GetFrame()->GetStackElement(numberOfArgs - 1);
 
     VMArray* argumentsArray =
-        GetUniverse()->NewArray(numberOfArgs - 1);  // without receiver
+        Universe::NewArray(numberOfArgs - 1);  // without receiver
 
     // the receiver should not go into the argumentsArray
     // so, numberOfArgs - 2
@@ -266,14 +265,13 @@ void Interpreter::doPushBlock(long bytecodeIndex) {
 
     long numOfArgs = blockMethod->GetNumberOfArguments();
 
-    GetFrame()->Push(
-        GetUniverse()->NewBlock(blockMethod, GetFrame(), numOfArgs));
+    GetFrame()->Push(Universe::NewBlock(blockMethod, GetFrame(), numOfArgs));
 }
 
 void Interpreter::doPushGlobal(long bytecodeIndex) {
     VMSymbol* globalName =
         static_cast<VMSymbol*>(method->GetConstant(bytecodeIndex));
-    vm_oop_t global = GetUniverse()->GetGlobal(globalName);
+    vm_oop_t global = Universe::GetGlobal(globalName);
 
     if (global != nullptr) {
         GetFrame()->Push(global);
@@ -358,7 +356,7 @@ void Interpreter::doSend(long bytecodeIndex) {
     assert(IsValidObject(receiverClass));
 
 #ifdef LOG_RECEIVER_TYPES
-    GetUniverse()->receiverTypes[receiverClass->GetName()->GetStdString()]++;
+    Universe::receiverTypes[receiverClass->GetName()->GetStdString()]++;
 #endif
 
     send(signature, receiverClass);
@@ -381,7 +379,7 @@ void Interpreter::doSuperSend(long bytecodeIndex) {
     } else {
         long numOfArgs = Signature::GetNumberOfArguments(signature);
         vm_oop_t receiver = GetFrame()->GetStackElement(numOfArgs - 1);
-        VMArray* argumentsArray = GetUniverse()->NewArray(numOfArgs);
+        VMArray* argumentsArray = Universe::NewArray(numOfArgs);
 
         for (long i = numOfArgs - 1; i >= 0; --i) {
             vm_oop_t o = GetFrame()->Pop();
@@ -449,7 +447,7 @@ void Interpreter::doInc() {
         val = NEW_INT(result);
     } else if (CLASS_OF(val) == load_ptr(doubleClass)) {
         double d = static_cast<VMDouble*>(val)->GetEmbeddedDouble();
-        val = GetUniverse()->NewDouble(d + 1.0);
+        val = Universe::NewDouble(d + 1.0);
     } else {
         ErrorExit("unsupported");
     }

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -44,75 +44,70 @@
 
 class Interpreter {
 public:
-    Interpreter();
-    ~Interpreter();
+    static vm_oop_t StartAndPrintBytecodes();
+    static vm_oop_t Start();
 
-    vm_oop_t StartAndPrintBytecodes();
-    vm_oop_t Start();
+    static VMFrame* PushNewFrame(VMMethod* method);
+    static void SetFrame(VMFrame* frame);
 
-    VMFrame* PushNewFrame(VMMethod* method);
-    void SetFrame(VMFrame* frame);
-    inline VMFrame* GetFrame() const;
-    VMMethod* GetMethod() const;
-    uint8_t* GetBytecodes() const;
-    void WalkGlobals(walk_heap_fn);
+    static inline VMFrame* GetFrame() { return frame; }
 
-    void SendUnknownGlobal(VMSymbol* globalName);
+    static VMMethod* GetMethod();
+    static uint8_t* GetBytecodes();
+    static void WalkGlobals(walk_heap_fn);
+
+    static void SendUnknownGlobal(VMSymbol* globalName);
 
 private:
-    vm_oop_t GetSelf() const;
+    static vm_oop_t GetSelf();
 
-    VMFrame* frame;
-    VMMethod* method;
+    static VMFrame* frame;
+    static VMMethod* method;
 
     // The following three variables are used to cache main parts of the
     // current execution context
-    long bytecodeIndexGlobal;
-    uint8_t* currentBytecodes;
+    static long bytecodeIndexGlobal;
+    static uint8_t* currentBytecodes;
 
     static const StdString unknownGlobal;
     static const StdString doesNotUnderstand;
     static const StdString escapedBlock;
 
-    void startGC();
-    void disassembleMethod() const;
+    static void startGC();
+    static void disassembleMethod();
 
-    VMFrame* popFrame();
-    void popFrameAndPushResult(vm_oop_t result);
+    static VMFrame* popFrame();
+    static void popFrameAndPushResult(vm_oop_t result);
 
-    void send(VMSymbol* signature, VMClass* receiverClass);
+    static void send(VMSymbol* signature, VMClass* receiverClass);
 
-    void triggerDoesNotUnderstand(VMSymbol* signature);
+    static void triggerDoesNotUnderstand(VMSymbol* signature);
 
-    void doDup();
-    void doPushLocal(long bytecodeIndex);
-    void doPushLocalWithIndex(uint8_t localIndex);
-    void doReturnFieldWithIndex(uint8_t fieldIndex);
-    void doPushArgument(long bytecodeIndex);
-    void doPushField(long bytecodeIndex);
-    void doPushFieldWithIndex(uint8_t fieldIndex);
-    void doPushBlock(long bytecodeIndex);
+    static void doDup();
+    static void doPushLocal(long bytecodeIndex);
+    static void doPushLocalWithIndex(uint8_t localIndex);
+    static void doReturnFieldWithIndex(uint8_t fieldIndex);
+    static void doPushArgument(long bytecodeIndex);
+    static void doPushField(long bytecodeIndex);
+    static void doPushFieldWithIndex(uint8_t fieldIndex);
+    static void doPushBlock(long bytecodeIndex);
 
-    inline void doPushConstant(long bytecodeIndex) {
+    static inline void doPushConstant(long bytecodeIndex) {
         vm_oop_t constant = method->GetConstant(bytecodeIndex);
         GetFrame()->Push(constant);
     }
 
-    void doPushGlobal(long bytecodeIndex);
-    void doPop(void);
-    void doPopLocal(long bytecodeIndex);
-    void doPopLocalWithIndex(uint8_t localIndex);
-    void doPopArgument(long bytecodeIndex);
-    void doPopField(long bytecodeIndex);
-    void doPopFieldWithIndex(uint8_t fieldIndex);
-    void doSend(long bytecodeIndex);
-    void doSuperSend(long bytecodeIndex);
-    void doReturnLocal();
-    void doReturnNonLocal();
-    void doInc();
-    bool checkIsGreater();
+    static void doPushGlobal(long bytecodeIndex);
+    static void doPop(void);
+    static void doPopLocal(long bytecodeIndex);
+    static void doPopLocalWithIndex(uint8_t localIndex);
+    static void doPopArgument(long bytecodeIndex);
+    static void doPopField(long bytecodeIndex);
+    static void doPopFieldWithIndex(uint8_t fieldIndex);
+    static void doSend(long bytecodeIndex);
+    static void doSuperSend(long bytecodeIndex);
+    static void doReturnLocal();
+    static void doReturnNonLocal();
+    static void doInc();
+    static bool checkIsGreater();
 };
-
-inline VMFrame* Interpreter::GetFrame() const {
-    return frame;
-}

--- a/src/memory/CopyingCollector.cpp
+++ b/src/memory/CopyingCollector.cpp
@@ -60,7 +60,7 @@ void CopyingCollector::Collect() {
     heap->switchBuffers(increaseMemory);
     increaseMemory = false;
 
-    GetUniverse()->WalkGlobals(copy_if_necessary);
+    Universe::WalkGlobals(copy_if_necessary);
 
     // now copy all objects that are referenced by the objects we have moved so
     // far

--- a/src/memory/DebugCopyingCollector.cpp
+++ b/src/memory/DebugCopyingCollector.cpp
@@ -59,7 +59,7 @@ void DebugCopyingCollector::Collect() {
     heap->switchBuffers(increaseMemory);
     increaseMemory = false;
 
-    GetUniverse()->WalkGlobals(copy_if_necessary);
+    Universe::WalkGlobals(copy_if_necessary);
 
     // now copy all objects that are referenced by the objects we have moved so
     // far

--- a/src/memory/GenerationalCollector.cpp
+++ b/src/memory/GenerationalCollector.cpp
@@ -86,7 +86,7 @@ void GenerationalCollector::MinorCollection() {
     DebugLog("GenGC MinorCollection\n");
 
     // walk all globals of universe, and implicily the interpreter
-    GetUniverse()->WalkGlobals(&copy_if_necessary);
+    Universe::WalkGlobals(&copy_if_necessary);
 
     // and also all objects that have been detected by the write barriers
     for (vector<size_t>::iterator objIter =
@@ -108,7 +108,7 @@ void GenerationalCollector::MajorCollection() {
     DebugLog("GenGC MajorCollection\n");
 
     // first we have to mark all objects (globals and current frame recursively)
-    GetUniverse()->WalkGlobals(&mark_object);
+    Universe::WalkGlobals(&mark_object);
 
     // now that all objects are marked we can safely delete all allocated
     // objects that are not marked

--- a/src/memory/MarkSweepCollector.cpp
+++ b/src/memory/MarkSweepCollector.cpp
@@ -68,5 +68,5 @@ static gc_oop_t mark_object(gc_oop_t oop) {
 
 void MarkSweepCollector::markReachableObjects() {
     // This walks the globals of the universe, and the interpreter
-    GetUniverse()->WalkGlobals(mark_object);
+    Universe::WalkGlobals(mark_object);
 }

--- a/src/primitives/Array.cpp
+++ b/src/primitives/Array.cpp
@@ -53,7 +53,7 @@ static vm_oop_t arrLength(vm_oop_t leftObj) {
 
 static vm_oop_t arrNew(vm_oop_t, vm_oop_t arg) {
     int64_t size = INT_VAL(arg);
-    return GetUniverse()->NewArray(size);
+    return Universe::NewArray(size);
 }
 
 static vm_oop_t arrCopy(vm_oop_t rcvr) {

--- a/src/primitives/Class.cpp
+++ b/src/primitives/Class.cpp
@@ -35,7 +35,7 @@
 
 static vm_oop_t clsNew(vm_oop_t rcvr) {
     VMClass* self = static_cast<VMClass*>(rcvr);
-    return GetUniverse()->NewInstance(self);
+    return Universe::NewInstance(self);
 }
 
 static vm_oop_t clsName(vm_oop_t rcvr) {

--- a/src/primitives/Double.cpp
+++ b/src/primitives/Double.cpp
@@ -76,39 +76,39 @@ double coerceDouble(vm_oop_t x) {
 
 static vm_oop_t dblPlus(vm_oop_t leftPtr, vm_oop_t rightObj) {
     PREPARE_OPERANDS;
-    return GetUniverse()->NewDouble(left + right);
+    return Universe::NewDouble(left + right);
 }
 
 static vm_oop_t dblMinus(vm_oop_t leftPtr, vm_oop_t rightObj) {
     PREPARE_OPERANDS;
-    return GetUniverse()->NewDouble(left - right);
+    return Universe::NewDouble(left - right);
 }
 
 static vm_oop_t dblStar(vm_oop_t leftPtr, vm_oop_t rightObj) {
     PREPARE_OPERANDS;
-    return GetUniverse()->NewDouble(left * right);
+    return Universe::NewDouble(left * right);
 }
 
 static vm_oop_t dblCos(vm_oop_t rcvr) {
     VMDouble* self = (VMDouble*)rcvr;
     double result = cos(self->GetEmbeddedDouble());
-    return GetUniverse()->NewDouble(result);
+    return Universe::NewDouble(result);
 }
 
 static vm_oop_t dblSin(vm_oop_t rcvr) {
     VMDouble* self = (VMDouble*)rcvr;
     double result = sin(self->GetEmbeddedDouble());
-    return GetUniverse()->NewDouble(result);
+    return Universe::NewDouble(result);
 }
 
 static vm_oop_t dblSlashslash(vm_oop_t leftPtr, vm_oop_t rightObj) {
     PREPARE_OPERANDS;
-    return GetUniverse()->NewDouble(left / right);
+    return Universe::NewDouble(left / right);
 }
 
 vm_oop_t dblPercent(vm_oop_t leftPtr, vm_oop_t rightObj) {
     PREPARE_OPERANDS;
-    return GetUniverse()->NewDouble((double)((int64_t)left % (int64_t)right));
+    return Universe::NewDouble((double)((int64_t)left % (int64_t)right));
 }
 
 /*
@@ -140,13 +140,12 @@ static vm_oop_t dblAsString(vm_oop_t rcvr) {
     ostringstream Str;
     Str.precision(17);
     Str << dbl;
-    return GetUniverse()->NewString(Str.str().c_str());
+    return Universe::NewString(Str.str().c_str());
 }
 
 static vm_oop_t dblSqrt(vm_oop_t rcvr) {
     VMDouble* self = static_cast<VMDouble*>(rcvr);
-    VMDouble* result =
-        GetUniverse()->NewDouble(sqrt(self->GetEmbeddedDouble()));
+    VMDouble* result = Universe::NewDouble(sqrt(self->GetEmbeddedDouble()));
     return result;
 }
 
@@ -165,14 +164,14 @@ static vm_oop_t dblAsInteger(vm_oop_t rcvr) {
 }
 
 static vm_oop_t dblPositiveInfinity(vm_oop_t) {
-    return GetUniverse()->NewDouble(INFINITY);
+    return Universe::NewDouble(INFINITY);
 }
 
 static vm_oop_t dblFromString(vm_oop_t, vm_oop_t rightObj) {
     VMString* self = (VMString*)rightObj;
     double value =
         stod(std::string(self->GetRawChars(), self->GetStringLength()));
-    return GetUniverse()->NewDouble(value);
+    return Universe::NewDouble(value);
 }
 
 static vm_oop_t dblLowerThanEqual(vm_oop_t leftPtr, vm_oop_t rightObj) {

--- a/src/primitives/Integer.cpp
+++ b/src/primitives/Integer.cpp
@@ -49,14 +49,14 @@
 
 double coerceDouble(vm_oop_t x);
 
-#define doDoubleOpIfNeeded(leftInt, rightObj, op)                 \
-    {                                                             \
-        VMClass* cl = CLASS_OF(rightObj);                         \
-        if (cl == load_ptr(doubleClass)) {                        \
-            double leftDbl = (double)leftInt;                     \
-            double rightDbl = coerceDouble(rightObj);             \
-            return GetUniverse()->NewDouble(leftDbl op rightDbl); \
-        }                                                         \
+#define doDoubleOpIfNeeded(leftInt, rightObj, op)            \
+    {                                                        \
+        VMClass* cl = CLASS_OF(rightObj);                    \
+        if (cl == load_ptr(doubleClass)) {                   \
+            double leftDbl = (double)leftInt;                \
+            double rightDbl = coerceDouble(rightObj);        \
+            return Universe::NewDouble(leftDbl op rightDbl); \
+        }                                                    \
     }
 
 static vm_oop_t intPlus(vm_oop_t leftObj, vm_oop_t rightObj) {
@@ -106,7 +106,7 @@ static vm_oop_t intSlashslash(vm_oop_t leftObj, vm_oop_t rightObj) {
     doDoubleOpIfNeeded(left, rightObj, /);
 
     double result = (double)left / (double)INT_VAL(rightObj);
-    return GetUniverse()->NewDouble(result);
+    return Universe::NewDouble(result);
 }
 
 static vm_oop_t intSlash(vm_oop_t leftObj, vm_oop_t rightObj) {
@@ -237,12 +237,12 @@ static vm_oop_t intAsString(vm_oop_t self) {
     long integer = INT_VAL(self);
     ostringstream Str;
     Str << integer;
-    return GetUniverse()->NewString(Str.str());
+    return Universe::NewString(Str.str());
 }
 
 static vm_oop_t intAsDouble(vm_oop_t self) {
     long integer = INT_VAL(self);
-    return GetUniverse()->NewDouble((double)integer);
+    return Universe::NewDouble((double)integer);
 }
 
 static vm_oop_t intAs32BitSigned(vm_oop_t self) {
@@ -261,7 +261,7 @@ static vm_oop_t intSqrt(vm_oop_t self) {
     if (result == rint(result)) {
         return NEW_INT((int64_t)result);
     } else {
-        return GetUniverse()->NewDouble(result);
+        return Universe::NewDouble(result);
     }
 }
 
@@ -333,7 +333,7 @@ static vm_oop_t intRange(vm_oop_t leftObj, vm_oop_t rightObj) {
     int64_t right = INT_VAL(rightObj);
 
     int64_t numInteger = right - left + 1;
-    VMArray* arr = GetUniverse()->NewArray(numInteger);
+    VMArray* arr = Universe::NewArray(numInteger);
 
     size_t index = 0;
     for (int64_t i = left; i <= right; i += 1, index += 1) {

--- a/src/primitives/Method.cpp
+++ b/src/primitives/Method.cpp
@@ -21,7 +21,7 @@ static vm_oop_t mSignature(vm_oop_t rcvr) {
     return self->GetSignature();
 }
 
-void _Method::InvokeOn_With_(Interpreter* interp, VMFrame* frame) {
+void _Method::InvokeOn_With_(VMFrame* frame) {
     // REM: this is a clone with _Primitive::InvokeOn_With_
     VMArray* args = static_cast<VMArray*>(frame->Pop());
     vm_oop_t rcvr = static_cast<vm_oop_t>(frame->Pop());
@@ -34,7 +34,7 @@ void _Method::InvokeOn_With_(Interpreter* interp, VMFrame* frame) {
         vm_oop_t arg = args->GetIndexableField(i);
         frame->Push(arg);
     }
-    mthd->Invoke(interp, frame);
+    mthd->Invoke(frame);
 }
 
 _Method::_Method() : PrimitiveContainer() {

--- a/src/primitives/Method.h
+++ b/src/primitives/Method.h
@@ -7,5 +7,5 @@ class _Method : public PrimitiveContainer {
 public:
     _Method(void);
 
-    void InvokeOn_With_(Interpreter*, VMFrame*);
+    void InvokeOn_With_(VMFrame*);
 };

--- a/src/primitives/Object.cpp
+++ b/src/primitives/Object.cpp
@@ -66,26 +66,26 @@ vm_oop_t objHalt(vm_oop_t) {
     return load_ptr(falseObject);
 }
 
-void _Object::Perform(Interpreter* interp, VMFrame* frame) {
+void _Object::Perform(VMFrame* frame) {
     VMSymbol* selector = (VMSymbol*)frame->Pop();
     vm_oop_t self = frame->GetStackElement(0);
 
     VMClass* clazz = CLASS_OF(self);
     VMInvokable* invokable = clazz->LookupInvokable(selector);
 
-    invokable->Invoke(interp, frame);
+    invokable->Invoke(frame);
 }
 
-void _Object::PerformInSuperclass(Interpreter* interp, VMFrame* frame) {
+void _Object::PerformInSuperclass(VMFrame* frame) {
     VMClass* clazz = (VMClass*)frame->Pop();
     VMSymbol* selector = (VMSymbol*)frame->Pop();
 
     VMInvokable* invokable = clazz->LookupInvokable(selector);
 
-    invokable->Invoke(interp, frame);
+    invokable->Invoke(frame);
 }
 
-void _Object::PerformWithArguments(Interpreter* interp, VMFrame* frame) {
+void _Object::PerformWithArguments(VMFrame* frame) {
     VMArray* args = (VMArray*)frame->Pop();
     VMSymbol* selector = (VMSymbol*)frame->Pop();
     vm_oop_t self = frame->GetStackElement(0);
@@ -99,11 +99,10 @@ void _Object::PerformWithArguments(Interpreter* interp, VMFrame* frame) {
     VMClass* clazz = CLASS_OF(self);
     VMInvokable* invokable = clazz->LookupInvokable(selector);
 
-    invokable->Invoke(interp, frame);
+    invokable->Invoke(frame);
 }
 
-void _Object::PerformWithArgumentsInSuperclass(Interpreter* interp,
-                                               VMFrame* frame) {
+void _Object::PerformWithArgumentsInSuperclass(VMFrame* frame) {
     VMClass* clazz = (VMClass*)frame->Pop();
     VMArray* args = (VMArray*)frame->Pop();
     VMSymbol* selector = (VMSymbol*)frame->Pop();
@@ -116,7 +115,7 @@ void _Object::PerformWithArgumentsInSuperclass(Interpreter* interp,
 
     VMInvokable* invokable = clazz->LookupInvokable(selector);
 
-    invokable->Invoke(interp, frame);
+    invokable->Invoke(frame);
 }
 
 vm_oop_t objInstVarAt(vm_oop_t self, vm_oop_t idx) {

--- a/src/primitives/Object.h
+++ b/src/primitives/Object.h
@@ -32,8 +32,8 @@
 class _Object : public PrimitiveContainer {
 public:
     _Object();
-    void Perform(Interpreter*, VMFrame*);
-    void PerformWithArguments(Interpreter*, VMFrame*);
-    void PerformInSuperclass(Interpreter*, VMFrame*);
-    void PerformWithArgumentsInSuperclass(Interpreter*, VMFrame*);
+    void Perform(VMFrame*);
+    void PerformWithArguments(VMFrame*);
+    void PerformInSuperclass(VMFrame*);
+    void PerformWithArgumentsInSuperclass(VMFrame*);
 };

--- a/src/primitives/Primitive.cpp
+++ b/src/primitives/Primitive.cpp
@@ -7,7 +7,6 @@
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMClass.h"  // NOLINT(misc-include-cleaner) it's required to make the types complete
 #include "../vmobjects/VMFrame.h"
-#include "../vmobjects/VMMethod.h"
 #include "../vmobjects/VMSymbol.h"  // NOLINT(misc-include-cleaner) it's required to make the types complete
 
 static vm_oop_t pHolder(vm_oop_t rcvr) {
@@ -20,7 +19,7 @@ static vm_oop_t pSignature(vm_oop_t rcvr) {
     return self->GetSignature();
 }
 
-void _Primitive::InvokeOn_With_(Interpreter* interp, VMFrame* frame) {
+void _Primitive::InvokeOn_With_(VMFrame* frame) {
     // REM: this is a clone with _Primitive::InvokeOn_With_
     VMArray* args = static_cast<VMArray*>(frame->Pop());
     vm_oop_t rcvr = static_cast<vm_oop_t>(frame->Pop());
@@ -33,7 +32,7 @@ void _Primitive::InvokeOn_With_(Interpreter* interp, VMFrame* frame) {
         vm_oop_t arg = args->GetIndexableField(i);
         frame->Push(arg);
     }
-    mthd->Invoke(interp, frame);
+    mthd->Invoke(frame);
 }
 
 _Primitive::_Primitive() : PrimitiveContainer() {

--- a/src/primitives/Primitive.h
+++ b/src/primitives/Primitive.h
@@ -7,5 +7,5 @@ class _Primitive : public PrimitiveContainer {
 public:
     _Primitive(void);
 
-    void InvokeOn_With_(Interpreter*, VMFrame*);
+    void InvokeOn_With_(VMFrame*);
 };

--- a/src/primitives/String.cpp
+++ b/src/primitives/String.cpp
@@ -52,7 +52,7 @@ static vm_oop_t strConcatenate_(vm_oop_t leftObj, vm_oop_t rightObj) {
 
     StdString result = s + a;
 
-    return GetUniverse()->NewString(result);
+    return Universe::NewString(result);
 }
 
 static vm_oop_t strAsSymbol(vm_oop_t rcvr) {
@@ -107,7 +107,7 @@ static vm_oop_t strPrimSubstringFromTo(vm_oop_t rcvr,
     int64_t e = INT_VAL(end) - 1;
 
     std::string result = str.substr(s, e - s + 1);
-    return GetUniverse()->NewString(result);
+    return Universe::NewString(result);
 }
 
 static vm_oop_t strCharAt(vm_oop_t rcvr, vm_oop_t indexPtr) {
@@ -115,10 +115,10 @@ static vm_oop_t strCharAt(vm_oop_t rcvr, vm_oop_t indexPtr) {
     int64_t index = INT_VAL(indexPtr) - 1;
 
     if (unlikely(index < 0 || (size_t)index >= self->GetStringLength())) {
-        return GetUniverse()->NewString("Error - index out of bounds");
+        return Universe::NewString("Error - index out of bounds");
     }
 
-    return GetUniverse()->NewString(1, &self->GetRawChars()[index]);
+    return Universe::NewString(1, &self->GetRawChars()[index]);
 }
 
 static vm_oop_t strIsWhiteSpace(vm_oop_t rcvr) {

--- a/src/primitives/Symbol.cpp
+++ b/src/primitives/Symbol.cpp
@@ -38,7 +38,7 @@ static vm_oop_t symAsString(vm_oop_t rcvr) {
     VMSymbol* sym = static_cast<VMSymbol*>(rcvr);
 
     std::string str = sym->GetStdString();
-    return GetUniverse()->NewString(str);
+    return Universe::NewString(str);
 }
 
 _Symbol::_Symbol() : PrimitiveContainer() {

--- a/src/primitives/System.cpp
+++ b/src/primitives/System.cpp
@@ -58,21 +58,21 @@ _System* System_;
 
 static vm_oop_t sysGlobal_(vm_oop_t, vm_oop_t rightObj) {
     VMSymbol* arg = static_cast<VMSymbol*>(rightObj);
-    vm_oop_t result = GetUniverse()->GetGlobal(arg);
+    vm_oop_t result = Universe::GetGlobal(arg);
 
     return result ? result : load_ptr(nilObject);
 }
 
 static vm_oop_t sysGlobalPut(vm_oop_t sys, vm_oop_t sym, vm_oop_t val) {
     VMSymbol* arg = static_cast<VMSymbol*>(sym);
-    GetUniverse()->SetGlobal(arg, val);
+    Universe::SetGlobal(arg, val);
     return sys;
 }
 
 static vm_oop_t sysHasGlobal_(vm_oop_t, vm_oop_t rightObj) {
     VMSymbol* arg = static_cast<VMSymbol*>(rightObj);
 
-    if (GetUniverse()->HasGlobal(arg)) {
+    if (Universe::HasGlobal(arg)) {
         return load_ptr(trueObject);
     } else {
         return load_ptr(falseObject);
@@ -81,7 +81,7 @@ static vm_oop_t sysHasGlobal_(vm_oop_t, vm_oop_t rightObj) {
 
 static vm_oop_t sysLoad_(vm_oop_t, vm_oop_t rightObj) {
     VMSymbol* arg = static_cast<VMSymbol*>(rightObj);
-    VMClass* result = GetUniverse()->LoadClass(arg);
+    VMClass* result = Universe::LoadClass(arg);
     if (result) {
         return result;
     } else {
@@ -160,7 +160,7 @@ static vm_oop_t sysLoadFile_(vm_oop_t, vm_oop_t rightObj) {
         std::stringstream buffer;
         buffer << file.rdbuf();
 
-        VMString* result = GetUniverse()->NewString(buffer.str());
+        VMString* result = Universe::NewString(buffer.str());
         return result;
     } else {
         return load_ptr(nilObject);

--- a/src/primitives/System.cpp
+++ b/src/primitives/System.cpp
@@ -167,7 +167,7 @@ static vm_oop_t sysLoadFile_(vm_oop_t, vm_oop_t rightObj) {
     }
 }
 
-void _System::PrintStackTrace(Interpreter*, VMFrame* frame) {
+void _System::PrintStackTrace(VMFrame* frame) {
     frame->PrintStackTrace();
 }
 

--- a/src/primitives/System.h
+++ b/src/primitives/System.h
@@ -36,5 +36,5 @@ public:
     _System(void);
     virtual ~_System();
 
-    void PrintStackTrace(Interpreter*, VMFrame*);
+    void PrintStackTrace(VMFrame*);
 };

--- a/src/primitivesCore/Routine.h
+++ b/src/primitivesCore/Routine.h
@@ -36,20 +36,20 @@ class Interpreter;
 template <class TClass>
 class Routine : public PrimitiveRoutine {
 private:
-    void (TClass::*func)(Interpreter*, VMFrame*);  // pointer to member function
+    void (TClass::*func)(VMFrame*);  // pointer to member function
     TClass* primContainerObj;
     const bool classSide;
 
 public:
     // takes pointer to an object, pointer to a member, and a bool indicating
     // whether it is a class-side primitive or not
-    Routine(TClass* primContainerObj,
-            void (TClass::*_fpt)(Interpreter*, VMFrame*), bool classSide)
+    Routine(TClass* primContainerObj, void (TClass::*_fpt)(VMFrame*),
+            bool classSide)
         : PrimitiveRoutine(), func(_fpt), primContainerObj(primContainerObj),
           classSide(classSide) {};
 
-    void Invoke(Interpreter* interp, VMFrame* frm) override {
-        (*primContainerObj.*func)(interp, frm);  // execute member function
+    void Invoke(VMFrame* frm) override {
+        (*primContainerObj.*func)(frm);  // execute member function
     }
 
     bool isClassSide() override { return classSide; }

--- a/src/unitTests/BasicInterpreterTests.h
+++ b/src/unitTests/BasicInterpreterTests.h
@@ -197,8 +197,7 @@ private:
     void testBasic(TestData data) {
         // The Unit Test harness will initialize Universe for a standard run.
         // This is different from other SOMs.
-        vm_oop_t result =
-            GetUniverse()->interpret(data.className, data.methodName);
+        vm_oop_t result = Universe::interpret(data.className, data.methodName);
         CPPUNIT_ASSERT(result != nullptr);
         assertEqualsSOMValue(result, data);
     }

--- a/src/unitTests/CloneObjectsTest.cpp
+++ b/src/unitTests/CloneObjectsTest.cpp
@@ -150,9 +150,8 @@ void CloneObjectsTest::testCloneBlock() {
     VMMethod* method =
         Universe::NewMethod(methodSymbol, 0, 0, 0, 0,
                             new LexicalScope(nullptr, {}, {}), inlinedLoops);
-    VMBlock* orig =
-        Universe::NewBlock(method, Universe::GetInterpreter()->GetFrame(),
-                           method->GetNumberOfArguments());
+    VMBlock* orig = Universe::NewBlock(method, Interpreter::GetFrame(),
+                                       method->GetNumberOfArguments());
     VMBlock* clone = orig->CloneForMovingGC();
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);

--- a/src/unitTests/CloneObjectsTest.cpp
+++ b/src/unitTests/CloneObjectsTest.cpp
@@ -47,7 +47,7 @@ void CloneObjectsTest::testCloneObject() {
 }
 
 void CloneObjectsTest::testCloneInteger() {
-    VMInteger* orig = GetUniverse()->NewInteger(42);
+    VMInteger* orig = Universe::NewInteger(42);
     VMInteger* clone = orig->CloneForMovingGC();
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
@@ -61,7 +61,7 @@ void CloneObjectsTest::testCloneInteger() {
 }
 
 void CloneObjectsTest::testCloneDouble() {
-    VMDouble* orig = GetUniverse()->NewDouble(123.4);
+    VMDouble* orig = Universe::NewDouble(123.4);
     VMDouble* clone = orig->CloneForMovingGC();
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
@@ -75,7 +75,7 @@ void CloneObjectsTest::testCloneDouble() {
 }
 
 void CloneObjectsTest::testCloneString() {
-    VMString* orig = GetUniverse()->NewString("foobar");
+    VMString* orig = Universe::NewString("foobar");
     VMString* clone = orig->CloneForMovingGC();
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
@@ -116,10 +116,10 @@ void CloneObjectsTest::testCloneSymbol() {
 }
 
 void CloneObjectsTest::testCloneArray() {
-    VMArray* orig = GetUniverse()->NewArray(3);
-    orig->SetIndexableField(0, GetUniverse()->NewString("foobar42"));
-    orig->SetIndexableField(1, GetUniverse()->NewString("foobar43"));
-    orig->SetIndexableField(2, GetUniverse()->NewString("foobar44"));
+    VMArray* orig = Universe::NewArray(3);
+    orig->SetIndexableField(0, Universe::NewString("foobar42"));
+    orig->SetIndexableField(1, Universe::NewString("foobar43"));
+    orig->SetIndexableField(2, Universe::NewString("foobar44"));
     VMArray* clone = orig->CloneForMovingGC();
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
@@ -147,12 +147,12 @@ void CloneObjectsTest::testCloneBlock() {
     VMSymbol* methodSymbol = NewSymbol("someMethod");
 
     vector<BackJump> inlinedLoops;
-    VMMethod* method = GetUniverse()->NewMethod(
-        methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}),
-        inlinedLoops);
-    VMBlock* orig = GetUniverse()->NewBlock(
-        method, GetUniverse()->GetInterpreter()->GetFrame(),
-        method->GetNumberOfArguments());
+    VMMethod* method =
+        Universe::NewMethod(methodSymbol, 0, 0, 0, 0,
+                            new LexicalScope(nullptr, {}, {}), inlinedLoops);
+    VMBlock* orig =
+        Universe::NewBlock(method, Universe::GetInterpreter()->GetFrame(),
+                           method->GetNumberOfArguments());
     VMBlock* clone = orig->CloneForMovingGC();
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
@@ -203,14 +203,14 @@ void CloneObjectsTest::testCloneFrame() {
     VMSymbol* methodSymbol = NewSymbol("frameMethod");
 
     vector<BackJump> inlinedLoops;
-    VMMethod* method = GetUniverse()->NewMethod(
-        methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}),
-        inlinedLoops);
+    VMMethod* method =
+        Universe::NewMethod(methodSymbol, 0, 0, 0, 0,
+                            new LexicalScope(nullptr, {}, {}), inlinedLoops);
 
-    VMFrame* orig = GetUniverse()->NewFrame(nullptr, method);
+    VMFrame* orig = Universe::NewFrame(nullptr, method);
     VMFrame* context = orig->CloneForMovingGC();
     orig->SetContext(context);
-    VMInteger* dummyArg = GetUniverse()->NewInteger(1111);
+    VMInteger* dummyArg = Universe::NewInteger(1111);
     orig->SetArgument(0, 0, dummyArg);
     VMFrame* clone = orig->CloneForMovingGC();
 
@@ -237,9 +237,9 @@ void CloneObjectsTest::testCloneMethod() {
     VMSymbol* methodSymbol = NewSymbol("myMethod");
 
     vector<BackJump> inlinedLoops;
-    VMMethod* orig = GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0,
-                                              new LexicalScope(nullptr, {}, {}),
-                                              inlinedLoops);
+    VMMethod* orig =
+        Universe::NewMethod(methodSymbol, 0, 0, 0, 0,
+                            new LexicalScope(nullptr, {}, {}), inlinedLoops);
     VMMethod* clone = orig->CloneForMovingGC();
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);
@@ -266,11 +266,11 @@ void CloneObjectsTest::testCloneMethod() {
 }
 
 void CloneObjectsTest::testCloneClass() {
-    VMClass* orig = GetUniverse()->NewClass(load_ptr(integerClass));
+    VMClass* orig = Universe::NewClass(load_ptr(integerClass));
     orig->SetName(NewSymbol("MyClass"));
     orig->SetSuperClass(load_ptr(doubleClass));
-    orig->SetInstanceFields(GetUniverse()->NewArray(2));
-    orig->SetInstanceInvokables(GetUniverse()->NewArray(4));
+    orig->SetInstanceFields(Universe::NewArray(2));
+    orig->SetInstanceInvokables(Universe::NewArray(4));
     VMClass* clone = orig->CloneForMovingGC();
 
     CPPUNIT_ASSERT((intptr_t)orig != (intptr_t)clone);

--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -227,9 +227,8 @@ void WalkObjectsTest::testWalkBlock() {
         Universe::NewMethod(methodSymbol, 0, 0, 0, 0,
                             new LexicalScope(nullptr, {}, {}), inlinedLoops);
 
-    VMBlock* block =
-        Universe::NewBlock(method, Universe::GetInterpreter()->GetFrame(),
-                           method->GetNumberOfArguments());
+    VMBlock* block = Universe::NewBlock(method, Interpreter::GetFrame(),
+                                        method->GetNumberOfArguments());
     block->WalkObjects(collectMembers);
     CPPUNIT_ASSERT_EQUAL(NoOfFields_Block, walkedObjects.size());
     CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(block->GetClass())));

--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -62,7 +62,7 @@ bool WalkerHasFound(gc_oop_t obj) {
 
 void WalkObjectsTest::testWalkInteger() {
     walkedObjects.clear();
-    VMInteger* int1 = GetUniverse()->NewInteger(42);
+    VMInteger* int1 = Universe::NewInteger(42);
     int1->WalkObjects(collectMembers);
 
     // Integers have no additional members
@@ -71,7 +71,7 @@ void WalkObjectsTest::testWalkInteger() {
 
 void WalkObjectsTest::testWalkDouble() {
     walkedObjects.clear();
-    VMDouble* d1 = GetUniverse()->NewDouble(432.1);
+    VMDouble* d1 = Universe::NewDouble(432.1);
     d1->WalkObjects(collectMembers);
 
     // Doubles have no additional members
@@ -104,7 +104,7 @@ void WalkObjectsTest::testWalkObject() {
 
 void WalkObjectsTest::testWalkString() {
     walkedObjects.clear();
-    VMString* str1 = GetUniverse()->NewString("str1");
+    VMString* str1 = Universe::NewString("str1");
     str1->WalkObjects(collectMembers);
 
     CPPUNIT_ASSERT_EQUAL(NoOfFields_String, walkedObjects.size());
@@ -120,7 +120,7 @@ void WalkObjectsTest::testWalkSymbol() {
 
 void WalkObjectsTest::testWalkClass() {
     walkedObjects.clear();
-    VMClass* meta = GetUniverse()->NewMetaclassClass();
+    VMClass* meta = Universe::NewMetaclassClass();
     meta->superClass = stringClass;
     meta->WalkObjects(collectMembers);
 
@@ -150,14 +150,14 @@ void WalkObjectsTest::testWalkFrame() {
     VMSymbol* methodSymbol = NewSymbol("frameMethod");
 
     vector<BackJump> inlinedLoops;
-    VMMethod* method = GetUniverse()->NewMethod(
-        methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}),
-        inlinedLoops);
+    VMMethod* method =
+        Universe::NewMethod(methodSymbol, 0, 0, 0, 0,
+                            new LexicalScope(nullptr, {}, {}), inlinedLoops);
 
-    VMFrame* frame = GetUniverse()->NewFrame(nullptr, method);
+    VMFrame* frame = Universe::NewFrame(nullptr, method);
     frame->SetPreviousFrame(frame->CloneForMovingGC());
     frame->SetContext(frame->CloneForMovingGC());
-    VMInteger* dummyArg = GetUniverse()->NewInteger(1111);
+    VMInteger* dummyArg = Universe::NewInteger(1111);
     frame->SetArgument(0, 0, dummyArg);
     frame->WalkObjects(collectMembers);
 
@@ -205,7 +205,7 @@ void WalkObjectsTest::testWalkMethod() {
 
     vector<BackJump> inlinedLoops;
     VMMethod* method =
-        GetUniverse()->NewMethod(methodSymbol, 0, 0, 0, 0, scope, inlinedLoops);
+        Universe::NewMethod(methodSymbol, 0, 0, 0, 0, scope, inlinedLoops);
 
     method->SetHolder(load_ptr(symbolClass));
     method->WalkObjects(collectMembers);
@@ -223,13 +223,13 @@ void WalkObjectsTest::testWalkBlock() {
     VMSymbol* methodSymbol = NewSymbol("someMethod");
 
     vector<BackJump> inlinedLoops;
-    VMMethod* method = GetUniverse()->NewMethod(
-        methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}),
-        inlinedLoops);
+    VMMethod* method =
+        Universe::NewMethod(methodSymbol, 0, 0, 0, 0,
+                            new LexicalScope(nullptr, {}, {}), inlinedLoops);
 
-    VMBlock* block = GetUniverse()->NewBlock(
-        method, GetUniverse()->GetInterpreter()->GetFrame(),
-        method->GetNumberOfArguments());
+    VMBlock* block =
+        Universe::NewBlock(method, Universe::GetInterpreter()->GetFrame(),
+                           method->GetNumberOfArguments());
     block->WalkObjects(collectMembers);
     CPPUNIT_ASSERT_EQUAL(NoOfFields_Block, walkedObjects.size());
     CPPUNIT_ASSERT(WalkerHasFound(tmp_ptr(block->GetClass())));
@@ -239,9 +239,9 @@ void WalkObjectsTest::testWalkBlock() {
 
 void WalkObjectsTest::testWalkArray() {
     walkedObjects.clear();
-    VMString* str1 = GetUniverse()->NewString("str1");
-    VMInteger* int1 = GetUniverse()->NewInteger(42);
-    VMArray* a = GetUniverse()->NewArray(2);
+    VMString* str1 = Universe::NewString("str1");
+    VMInteger* int1 = Universe::NewInteger(42);
+    VMArray* a = Universe::NewArray(2);
     a->SetIndexableField(0, str1);
     a->SetIndexableField(1, int1);
     a->WalkObjects(collectMembers);

--- a/src/unitTests/WriteBarrierTest.cpp
+++ b/src/unitTests/WriteBarrierTest.cpp
@@ -84,9 +84,8 @@ void WriteBarrierTest::testWriteBlock() {
         Universe::NewMethod(methodSymbol, 0, 0, 0, 0,
                             new LexicalScope(nullptr, {}, {}), inlinedLoops);
 
-    VMBlock* block =
-        Universe::NewBlock(method, Universe::GetInterpreter()->GetFrame(),
-                           method->GetNumberOfArguments());
+    VMBlock* block = Universe::NewBlock(method, Interpreter::GetFrame(),
+                                        method->GetNumberOfArguments());
     TEST_WB_CALLED("VMBlock failed to call writeBarrier when creating", block,
                    block->GetClass());
     TEST_WB_CALLED("VMBlock failed to call writeBarrier when creating", block,
@@ -104,12 +103,12 @@ void WriteBarrierTest::testWriteFrame() {
     // reset set...
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
 
-    VMFrame* frame = Universe::GetInterpreter()->GetFrame()->CloneForMovingGC();
+    VMFrame* frame = Interpreter::GetFrame()->CloneForMovingGC();
     frame->SetContext(frame->CloneForMovingGC());
 
-    frame->SetPreviousFrame(Universe::GetInterpreter()->GetFrame());
+    frame->SetPreviousFrame(Interpreter::GetFrame());
     TEST_WB_CALLED("VMFrame failed to call writeBarrier on SetPreviousFrame",
-                   frame, Universe::GetInterpreter()->GetFrame());
+                   frame, Interpreter::GetFrame());
     frame->SetContext(frame->GetContext()->CloneForMovingGC());
     TEST_WB_CALLED("VMFrame failed to call writeBarrier on SetContext", frame,
                    frame->GetContext());
@@ -126,8 +125,7 @@ void WriteBarrierTest::testWriteMethod() {
 
     // reset set...
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
-    VMMethod* method =
-        Universe::GetInterpreter()->GetFrame()->GetMethod()->CloneForMovingGC();
+    VMMethod* method = Interpreter::GetFrame()->GetMethod()->CloneForMovingGC();
     method->SetHolder(load_ptr(integerClass));
     TEST_WB_CALLED("VMMethod failed to call writeBarrier on SetHolder", method,
                    load_ptr(integerClass));

--- a/src/unitTests/WriteBarrierTest.cpp
+++ b/src/unitTests/WriteBarrierTest.cpp
@@ -38,10 +38,10 @@ void WriteBarrierTest::testWriteArray() {
 
     // reset set...
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
-    VMArray* arr = GetUniverse()->NewArray(3);
-    VMInteger* newInt = GetUniverse()->NewInteger(12345);
-    VMString* str = GetUniverse()->NewString("asdfghjkl");
-    VMDouble* doub = GetUniverse()->NewDouble(9876.654);
+    VMArray* arr = Universe::NewArray(3);
+    VMInteger* newInt = Universe::NewInteger(12345);
+    VMString* str = Universe::NewString("asdfghjkl");
+    VMDouble* doub = Universe::NewDouble(9876.654);
     VMClass* cloneClass = load_ptr(arrayClass)->CloneForMovingGC();
     VMClass* clone2Class = cloneClass->CloneForMovingGC();
     arr->SetClass(cloneClass);
@@ -80,13 +80,13 @@ void WriteBarrierTest::testWriteBlock() {
     VMSymbol* methodSymbol = NewSymbol("someMethod");
 
     vector<BackJump> inlinedLoops;
-    VMMethod* method = GetUniverse()->NewMethod(
-        methodSymbol, 0, 0, 0, 0, new LexicalScope(nullptr, {}, {}),
-        inlinedLoops);
+    VMMethod* method =
+        Universe::NewMethod(methodSymbol, 0, 0, 0, 0,
+                            new LexicalScope(nullptr, {}, {}), inlinedLoops);
 
-    VMBlock* block = GetUniverse()->NewBlock(
-        method, GetUniverse()->GetInterpreter()->GetFrame(),
-        method->GetNumberOfArguments());
+    VMBlock* block =
+        Universe::NewBlock(method, Universe::GetInterpreter()->GetFrame(),
+                           method->GetNumberOfArguments());
     TEST_WB_CALLED("VMBlock failed to call writeBarrier when creating", block,
                    block->GetClass());
     TEST_WB_CALLED("VMBlock failed to call writeBarrier when creating", block,
@@ -104,13 +104,12 @@ void WriteBarrierTest::testWriteFrame() {
     // reset set...
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
 
-    VMFrame* frame =
-        GetUniverse()->GetInterpreter()->GetFrame()->CloneForMovingGC();
+    VMFrame* frame = Universe::GetInterpreter()->GetFrame()->CloneForMovingGC();
     frame->SetContext(frame->CloneForMovingGC());
 
-    frame->SetPreviousFrame(GetUniverse()->GetInterpreter()->GetFrame());
+    frame->SetPreviousFrame(Universe::GetInterpreter()->GetFrame());
     TEST_WB_CALLED("VMFrame failed to call writeBarrier on SetPreviousFrame",
-                   frame, GetUniverse()->GetInterpreter()->GetFrame());
+                   frame, Universe::GetInterpreter()->GetFrame());
     frame->SetContext(frame->GetContext()->CloneForMovingGC());
     TEST_WB_CALLED("VMFrame failed to call writeBarrier on SetContext", frame,
                    frame->GetContext());
@@ -127,11 +126,8 @@ void WriteBarrierTest::testWriteMethod() {
 
     // reset set...
     GetHeap<HEAP_CLS>()->writeBarrierCalledOn.clear();
-    VMMethod* method = GetUniverse()
-                           ->GetInterpreter()
-                           ->GetFrame()
-                           ->GetMethod()
-                           ->CloneForMovingGC();
+    VMMethod* method =
+        Universe::GetInterpreter()->GetFrame()->GetMethod()->CloneForMovingGC();
     method->SetHolder(load_ptr(integerClass));
     TEST_WB_CALLED("VMMethod failed to call writeBarrier on SetHolder", method,
                    load_ptr(integerClass));

--- a/src/vm/Shell.cpp
+++ b/src/vm/Shell.cpp
@@ -108,7 +108,7 @@ void Shell::Start(Interpreter* interp) {
         statement = ss.str();
 
         ++counter;
-        runClass = GetUniverse()->LoadShellClass(statement);
+        runClass = Universe::LoadShellClass(statement);
         // Compile and load the newly generated class
         if (runClass == nullptr) {
             cout << "can't compile statement.";
@@ -122,7 +122,7 @@ void Shell::Start(Interpreter* interp) {
         currentFrame->SetBytecodeIndex(bytecodeIndex);
 
         // Create and push a new instance of our class on the stack
-        currentFrame->Push(GetUniverse()->NewInstance(runClass));
+        currentFrame->Push(Universe::NewInstance(runClass));
 
         // Push the old value of "it" on the stack
         currentFrame->Push(it);

--- a/src/vm/Shell.cpp
+++ b/src/vm/Shell.cpp
@@ -61,7 +61,7 @@ Shell::~Shell() {
     // TODO
 }
 
-void Shell::Start(Interpreter* interp) {
+void Shell::Start() {
 #define QUIT_CMD "system exit"
 #define QUIT_CMD_L 11 + 1
 
@@ -78,7 +78,7 @@ void Shell::Start(Interpreter* interp) {
     cout << "SOM Shell. Type \"" << QUIT_CMD << "\" to exit.\n";
 
     // Create a fake bootstrap frame
-    currentFrame = interp->PushNewFrame(GetBootstrapMethod());
+    currentFrame = Interpreter::PushNewFrame(GetBootstrapMethod());
     // Remember the first bytecode index, e.g. index of the halt instruction
     bytecodeIndex = currentFrame->GetBytecodeIndex();
 
@@ -115,7 +115,7 @@ void Shell::Start(Interpreter* interp) {
             continue;
         }
 
-        currentFrame = interp->GetFrame();
+        currentFrame = Interpreter::GetFrame();
 
         // Go back, so we will evaluate the bootstrap frames halt
         // instruction again
@@ -131,14 +131,14 @@ void Shell::Start(Interpreter* interp) {
         VMInvokable* initialize = runClass->LookupInvokable(SymbolFor("run:"));
 
         // Invoke the run method
-        initialize->Invoke(interp, currentFrame);
+        initialize->Invoke(currentFrame);
 
         // Start the Interpreter
 
         if (dumpBytecodes > 1) {
-            interp->StartAndPrintBytecodes();
+            Interpreter::StartAndPrintBytecodes();
         } else {
-            interp->Start();
+            Interpreter::Start();
         }
 
         // Save the result of the run method

--- a/src/vm/Shell.h
+++ b/src/vm/Shell.h
@@ -36,7 +36,7 @@ public:
     ~Shell();
     void SetBootstrapMethod(VMMethod* bsm) { bootstrapMethod = bsm; };
     VMMethod* GetBootstrapMethod() const { return bootstrapMethod; };
-    void Start(Interpreter*);
+    void Start();
 
 private:
     VMMethod* bootstrapMethod;

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -44,7 +44,6 @@
 #include "../interpreter/bytecodes.h"
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
-#include "../vmobjects/AbstractObject.h"
 #include "../vmobjects/IntegerBox.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMArray.h"
@@ -80,7 +79,6 @@ std::string bm_name;
 
 map<int64_t, int64_t> integerHist;
 
-Interpreter Universe::interpreter;
 map<GCSymbol*, gc_oop_t> Universe::globals;
 map<long, GCClass*> Universe::blockClassesByNoOfArgs;
 vector<StdString> Universe::classPath;
@@ -303,14 +301,14 @@ vm_oop_t Universe::interpretMethod(VMObject* receiver, VMInvokable* initialize,
 
     VMMethod* bootstrapMethod = createBootstrapMethod(load_ptr(systemClass), 2);
 
-    VMFrame* bootstrapFrame = interpreter.PushNewFrame(bootstrapMethod);
+    VMFrame* bootstrapFrame = Interpreter::PushNewFrame(bootstrapMethod);
     bootstrapFrame->Push(receiver);
 
     if (argumentsArray != nullptr) {
         bootstrapFrame->Push(argumentsArray);
     }
 
-    initialize->Invoke(&interpreter, bootstrapFrame);
+    initialize->Invoke(bootstrapFrame);
 
     // reset "-d" indicator
     if (!(trace > 0)) {
@@ -318,9 +316,9 @@ vm_oop_t Universe::interpretMethod(VMObject* receiver, VMInvokable* initialize,
     }
 
     if (dumpBytecodes > 1) {
-        return interpreter.StartAndPrintBytecodes();
+        return Interpreter::StartAndPrintBytecodes();
     }
-    return interpreter.Start();
+    return Interpreter::Start();
 }
 
 void Universe::initialize(long _argc, char** _argv) {
@@ -351,7 +349,7 @@ void Universe::initialize(long _argc, char** _argv) {
         VMMethod* bootstrapMethod =
             createBootstrapMethod(load_ptr(systemClass), 2);
         Shell* shell = new Shell(bootstrapMethod);
-        shell->Start(&interpreter);
+        shell->Start();
         return;
     }
 
@@ -835,7 +833,7 @@ void Universe::WalkGlobals(walk_heap_fn walk) {
         bcIter->second = static_cast<GCClass*>(walk(bcIter->second));
     }
 
-    interpreter.WalkGlobals(walk);
+    Interpreter::WalkGlobals(walk);
 }
 
 VMMethod* Universe::NewMethod(VMSymbol* signature, size_t numberOfBytecodes,

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -76,20 +76,23 @@ gc_oop_t prebuildInts[INT_CACHE_MAX_VALUE - INT_CACHE_MIN_VALUE + 1];
 short dumpBytecodes;
 short gcVerbosity;
 
-Universe* Universe::theUniverse = nullptr;
-
 std::string bm_name;
 
 map<int64_t, int64_t> integerHist;
 
+Interpreter Universe::interpreter;
+map<GCSymbol*, gc_oop_t> Universe::globals;
+map<long, GCClass*> Universe::blockClassesByNoOfArgs;
+vector<StdString> Universe::classPath;
+long Universe::heapSize;
+
 void Universe::Start(long argc, char** argv) {
     BasicInit();
-    theUniverse->initialize(argc, argv);
+    Universe::initialize(argc, argv);
 }
 
 void Universe::BasicInit() {
     assert(Bytecode::BytecodeDefinitionsAreConsistent());
-    theUniverse = new Universe();
 }
 
 void Universe::Shutdown() {
@@ -135,10 +138,6 @@ void Universe::Shutdown() {
                   << it->second.noCalls - it->second.noPrimitiveCalls << endl;
     }
 #endif
-
-    if (theUniverse) {
-        delete (theUniverse);
-    }
 }
 
 vector<StdString> Universe::handleArguments(long argc, char** argv) {
@@ -194,7 +193,7 @@ vector<StdString> Universe::handleArguments(long argc, char** argv) {
 }
 
 long Universe::getClassPathExt(vector<StdString>& tokens,
-                               const StdString& arg) const {
+                               const StdString& arg) {
 #define EXT_TOKENS 2
     long result = ERR_SUCCESS;
     size_t fpIndex = arg.find_last_of(fileSeparator);
@@ -241,7 +240,7 @@ long Universe::addClassPath(const StdString& cp) {
     return ERR_SUCCESS;
 }
 
-void Universe::printUsageAndExit(char* executable) const {
+void Universe::printUsageAndExit(char* executable) {
     cout << "Usage: " << executable << " [-options] [args...]" << endl << endl;
     cout << "where options include:" << endl;
     cout << "    -cp <directories separated by " << pathSeparator << ">"
@@ -258,10 +257,6 @@ void Universe::printUsageAndExit(char* executable) const {
     cout << "    -h  show this help" << endl;
 
     Quit(ERR_SUCCESS);
-}
-
-Universe::Universe() {
-    interpreter = nullptr;
 }
 
 VMMethod* Universe::createBootstrapMethod(VMClass* holder,
@@ -282,8 +277,6 @@ vm_oop_t Universe::interpret(StdString className, StdString methodName) {
     // Hello World program as part of the unittest main.
 
     bm_name = "BasicInterpreterTests";
-
-    interpreter = new Interpreter();
 
     VMSymbol* classNameSym = SymbolFor(className);
     VMClass* clazz = LoadClass(classNameSym);
@@ -310,14 +303,14 @@ vm_oop_t Universe::interpretMethod(VMObject* receiver, VMInvokable* initialize,
 
     VMMethod* bootstrapMethod = createBootstrapMethod(load_ptr(systemClass), 2);
 
-    VMFrame* bootstrapFrame = interpreter->PushNewFrame(bootstrapMethod);
+    VMFrame* bootstrapFrame = interpreter.PushNewFrame(bootstrapMethod);
     bootstrapFrame->Push(receiver);
 
     if (argumentsArray != nullptr) {
         bootstrapFrame->Push(argumentsArray);
     }
 
-    initialize->Invoke(interpreter, bootstrapFrame);
+    initialize->Invoke(&interpreter, bootstrapFrame);
 
     // reset "-d" indicator
     if (!(trace > 0)) {
@@ -325,9 +318,9 @@ vm_oop_t Universe::interpretMethod(VMObject* receiver, VMInvokable* initialize,
     }
 
     if (dumpBytecodes > 1) {
-        return interpreter->StartAndPrintBytecodes();
+        return interpreter.StartAndPrintBytecodes();
     }
-    return interpreter->Start();
+    return interpreter.Start();
 }
 
 void Universe::initialize(long _argc, char** _argv) {
@@ -344,8 +337,6 @@ void Universe::initialize(long _argc, char** _argv) {
 
     Heap<HEAP_CLS>::InitializeHeap(heapSize);
 
-    interpreter = new Interpreter();
-
 #if CACHE_INTEGER
     // create prebuilt integers
     for (long it = INT_CACHE_MIN_VALUE; it <= INT_CACHE_MAX_VALUE; ++it) {
@@ -360,7 +351,7 @@ void Universe::initialize(long _argc, char** _argv) {
         VMMethod* bootstrapMethod =
             createBootstrapMethod(load_ptr(systemClass), 2);
         Shell* shell = new Shell(bootstrapMethod);
-        shell->Start(interpreter);
+        shell->Start(&interpreter);
         return;
     }
 
@@ -372,10 +363,6 @@ void Universe::initialize(long _argc, char** _argv) {
 }
 
 Universe::~Universe() {
-    if (interpreter) {
-        delete (interpreter);
-    }
-
     // check done inside
     Heap<HEAP_CLS>::DestroyHeap();
 }
@@ -471,13 +458,13 @@ VMObject* Universe::InitializeGlobals() {
     return systemObject;
 }
 
-void Universe::Assert(bool value) const {
+void Universe::Assert(bool value) {
     if (!value) {
         ErrorPrint("Universe::Assert Assertion failed\n");
     }
 }
 
-VMClass* Universe::GetBlockClass() const {
+VMClass* Universe::GetBlockClass() {
     return load_ptr(blockClass);
 }
 
@@ -618,7 +605,7 @@ void Universe::LoadSystemClass(VMClass* systemClass) {
     }
 }
 
-VMArray* Universe::NewArray(size_t size) const {
+VMArray* Universe::NewArray(size_t size) {
     size_t additionalBytes = size * sizeof(VMObject*);
 
     bool outsideNursery;
@@ -644,8 +631,7 @@ VMArray* Universe::NewArray(size_t size) const {
     return result;
 }
 
-VMArray* Universe::NewArrayFromStrings(
-    const vector<std::string>& strings) const {
+VMArray* Universe::NewArrayFromStrings(const vector<std::string>& strings) {
     VMArray* result = NewArray(strings.size());
     size_t j = 0;
     for (const std::string& str : strings) {
@@ -656,7 +642,7 @@ VMArray* Universe::NewArrayFromStrings(
 }
 
 VMArray* Universe::NewArrayOfSymbolsFromStrings(
-    const vector<std::string>& strings) const {
+    const vector<std::string>& strings) {
     VMArray* result = NewArray(strings.size());
     size_t j = 0;
     for (const std::string& str : strings) {
@@ -666,17 +652,17 @@ VMArray* Universe::NewArrayOfSymbolsFromStrings(
     return result;
 }
 
-VMArray* Universe::NewArrayList(std::vector<VMSymbol*>& list) const {
+VMArray* Universe::NewArrayList(std::vector<VMSymbol*>& list) {
     std::vector<vm_oop_t>& objList = (std::vector<vm_oop_t>&)list;
     return NewArrayList(objList);
 }
 
-VMArray* Universe::NewArrayList(std::vector<VMInvokable*>& list) const {
+VMArray* Universe::NewArrayList(std::vector<VMInvokable*>& list) {
     std::vector<vm_oop_t>& objList = (std::vector<vm_oop_t>&)list;
     return NewArrayList(objList);
 }
 
-VMArray* Universe::NewArrayList(std::vector<vm_oop_t>& list) const {
+VMArray* Universe::NewArrayList(std::vector<vm_oop_t>& list) {
     size_t size = list.size();
     VMArray* result = NewArray(size);
 
@@ -698,7 +684,7 @@ VMBlock* Universe::NewBlock(VMInvokable* method, VMFrame* context,
     return result;
 }
 
-VMClass* Universe::NewClass(VMClass* classOfClass) const {
+VMClass* Universe::NewClass(VMClass* classOfClass) {
     size_t numFields = classOfClass->GetNumberOfInstanceFields();
     VMClass* result = nullptr;
 
@@ -716,12 +702,12 @@ VMClass* Universe::NewClass(VMClass* classOfClass) const {
     return result;
 }
 
-VMDouble* Universe::NewDouble(double value) const {
+VMDouble* Universe::NewDouble(double value) {
     LOG_ALLOCATION("VMDouble", sizeof(VMDouble));
     return new (GetHeap<HEAP_CLS>(), 0) VMDouble(value);
 }
 
-VMFrame* Universe::NewFrame(VMFrame* previousFrame, VMMethod* method) const {
+VMFrame* Universe::NewFrame(VMFrame* previousFrame, VMMethod* method) {
     VMFrame* result = nullptr;
 #ifdef UNSAFE_FRAME_OPTIMIZATION
     result = method->GetCachedFrame();
@@ -746,7 +732,7 @@ VMFrame* Universe::NewFrame(VMFrame* previousFrame, VMMethod* method) const {
     return result;
 }
 
-VMObject* Universe::NewInstance(VMClass* classOfInstance) const {
+VMObject* Universe::NewInstance(VMClass* classOfInstance) {
     long numOfFields = classOfInstance->GetNumberOfInstanceFields();
     // the additional space needed is calculated from the number of fields
     long additionalBytes = numOfFields * sizeof(VMObject*);
@@ -759,13 +745,13 @@ VMObject* Universe::NewInstance(VMClass* classOfInstance) const {
     return result;
 }
 
-VMObject* Universe::NewInstanceWithoutFields() const {
+VMObject* Universe::NewInstanceWithoutFields() {
     VMObject* result =
         new (GetHeap<HEAP_CLS>(), 0) VMObject(0, sizeof(VMObject));
     return result;
 }
 
-VMInteger* Universe::NewInteger(int64_t value) const {
+VMInteger* Universe::NewInteger(int64_t value) {
 #ifdef GENERATE_INTEGER_HISTOGRAM
     integerHist[value / INT_HIST_SIZE] = integerHist[value / INT_HIST_SIZE] + 1;
 #endif
@@ -781,7 +767,7 @@ VMInteger* Universe::NewInteger(int64_t value) const {
     return new (GetHeap<HEAP_CLS>(), 0) VMInteger(value);
 }
 
-VMClass* Universe::NewMetaclassClass() const {
+VMClass* Universe::NewMetaclassClass() {
     VMClass* result = new (GetHeap<HEAP_CLS>(), 0) VMClass;
     VMClass* mclass = new (GetHeap<HEAP_CLS>(), 0) VMClass;
     result->SetClass(mclass);
@@ -849,13 +835,13 @@ void Universe::WalkGlobals(walk_heap_fn walk) {
         bcIter->second = static_cast<GCClass*>(walk(bcIter->second));
     }
 
-    interpreter->WalkGlobals(walk);
+    interpreter.WalkGlobals(walk);
 }
 
 VMMethod* Universe::NewMethod(VMSymbol* signature, size_t numberOfBytecodes,
                               size_t numberOfConstants, size_t numLocals,
                               size_t maxStackDepth, LexicalScope* lexicalScope,
-                              vector<BackJump>& inlinedLoops) const {
+                              vector<BackJump>& inlinedLoops) {
     assert(lexicalScope != nullptr &&
            "A method is expected to have a lexical scope");
 
@@ -884,11 +870,11 @@ VMMethod* Universe::NewMethod(VMSymbol* signature, size_t numberOfBytecodes,
     return result;
 }
 
-VMString* Universe::NewString(const StdString& str) const {
+VMString* Universe::NewString(const StdString& str) {
     return NewString(str.length(), str.c_str());
 }
 
-VMString* Universe::NewString(const size_t length, const char* str) const {
+VMString* Universe::NewString(const size_t length, const char* str) {
     VMString* result =
         new (GetHeap<HEAP_CLS>(), PADDED_SIZE(length)) VMString(length, str);
 
@@ -896,7 +882,7 @@ VMString* Universe::NewString(const size_t length, const char* str) const {
     return result;
 }
 
-VMClass* Universe::NewSystemClass() const {
+VMClass* Universe::NewSystemClass() {
     VMClass* systemClass = new (GetHeap<HEAP_CLS>(), 0) VMClass();
     VMClass* mclass = new (GetHeap<HEAP_CLS>(), 0) VMClass();
 

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -45,114 +45,95 @@ extern short gcVerbosity;
 using namespace std;
 class Universe {
 public:
-    inline Universe* operator->();
-
     // static methods
     static void Start(long argc, char** argv);
     static void BasicInit();
 
-    vm_oop_t interpret(StdString className, StdString methodName);
+    static vm_oop_t interpret(StdString className, StdString methodName);
 
-    long setupClassPath(const StdString& cp);
+    static long setupClassPath(const StdString& cp);
 
-    Interpreter* GetInterpreter() { return interpreter; }
+    static Interpreter* GetInterpreter() { return &interpreter; }
 
-    void Assert(bool) const;
+    static void Assert(bool);
 
     // VMObject instanciation methods. These should probably be refactored to a
     // new class
-    VMArray* NewArray(size_t) const;
+    static VMArray* NewArray(size_t);
 
-    VMArray* NewArrayList(std::vector<vm_oop_t>& list) const;
-    VMArray* NewArrayList(std::vector<VMInvokable*>& list) const;
-    VMArray* NewArrayList(std::vector<VMSymbol*>& list) const;
+    static VMArray* NewArrayList(std::vector<vm_oop_t>& list);
+    static VMArray* NewArrayList(std::vector<VMInvokable*>& list);
+    static VMArray* NewArrayList(std::vector<VMSymbol*>& list);
 
-    VMArray* NewArrayFromStrings(const vector<StdString>&) const;
-    VMArray* NewArrayOfSymbolsFromStrings(const vector<StdString>&) const;
+    static VMArray* NewArrayFromStrings(const vector<StdString>&);
+    static VMArray* NewArrayOfSymbolsFromStrings(const vector<StdString>&);
 
-    VMBlock* NewBlock(VMInvokable*, VMFrame*, long);
-    VMClass* NewClass(VMClass*) const;
-    VMFrame* NewFrame(VMFrame*, VMMethod*) const;
-    VMMethod* NewMethod(VMSymbol*, size_t numberOfBytecodes,
-                        size_t numberOfConstants, size_t numLocals,
-                        size_t maxStackDepth, LexicalScope*,
-                        vector<BackJump>& inlinedLoops) const;
-    VMObject* NewInstance(VMClass*) const;
-    VMObject* NewInstanceWithoutFields() const;
-    VMInteger* NewInteger(int64_t) const;
-    void WalkGlobals(walk_heap_fn);
-    VMDouble* NewDouble(double) const;
-    VMClass* NewMetaclassClass(void) const;
-    VMString* NewString(const StdString&) const;
-    VMString* NewString(const size_t, const char*) const;
-    VMClass* NewSystemClass(void) const;
+    static VMBlock* NewBlock(VMInvokable*, VMFrame*, long);
+    static VMClass* NewClass(VMClass*);
+    static VMFrame* NewFrame(VMFrame*, VMMethod*);
+    static VMMethod* NewMethod(VMSymbol*, size_t numberOfBytecodes,
+                               size_t numberOfConstants, size_t numLocals,
+                               size_t maxStackDepth, LexicalScope*,
+                               vector<BackJump>& inlinedLoops);
+    static VMObject* NewInstance(VMClass*);
+    static VMObject* NewInstanceWithoutFields();
+    static VMInteger* NewInteger(int64_t);
+    static void WalkGlobals(walk_heap_fn);
+    static VMDouble* NewDouble(double);
+    static VMClass* NewMetaclassClass();
+    static VMString* NewString(const StdString&);
+    static VMString* NewString(const size_t, const char*);
+    static VMClass* NewSystemClass();
 
-    void InitializeSystemClass(VMClass*, VMClass*, const char*);
+    static void InitializeSystemClass(VMClass*, VMClass*, const char*);
 
-    vm_oop_t GetGlobal(VMSymbol*);
-    void SetGlobal(VMSymbol* name, vm_oop_t val);
-    bool HasGlobal(VMSymbol*);
-    VMObject* InitializeGlobals();
-    VMClass* GetBlockClass(void) const;
-    VMClass* GetBlockClassWithArgs(long);
+    static vm_oop_t GetGlobal(VMSymbol*);
+    static void SetGlobal(VMSymbol* name, vm_oop_t val);
+    static bool HasGlobal(VMSymbol*);
+    static VMObject* InitializeGlobals();
+    static VMClass* GetBlockClass();
+    static VMClass* GetBlockClassWithArgs(long);
 
-    VMClass* LoadClass(VMSymbol*);
-    void LoadSystemClass(VMClass*);
-    VMClass* LoadClassBasic(VMSymbol*, VMClass*);
-    VMClass* LoadShellClass(StdString&);
+    static VMClass* LoadClass(VMSymbol*);
+    static void LoadSystemClass(VMClass*);
+    static VMClass* LoadClassBasic(VMSymbol*, VMClass*);
+    static VMClass* LoadShellClass(StdString&);
 
-    Universe();
+    Universe() {}
     ~Universe();
 #ifdef LOG_RECEIVER_TYPES
     struct stat_data {
         long noCalls;
         long noPrimitiveCalls;
     };
-    map<StdString, long> receiverTypes;
-    map<StdString, stat_data> callStats;
+    static map<StdString, long> receiverTypes;
+    static map<StdString, stat_data> callStats;
 #endif
     //
 
     static void Shutdown();
 
 private:
-    vm_oop_t interpretMethod(VMObject* receiver, VMInvokable* initialize,
-                             VMArray* argumentsArray);
+    static vm_oop_t interpretMethod(VMObject* receiver, VMInvokable* initialize,
+                                    VMArray* argumentsArray);
 
-    vector<StdString> handleArguments(long argc, char** argv);
-    long getClassPathExt(vector<StdString>& tokens, const StdString& arg) const;
+    static vector<StdString> handleArguments(long argc, char** argv);
+    static long getClassPathExt(vector<StdString>& tokens,
+                                const StdString& arg);
 
-    VMMethod* createBootstrapMethod(VMClass* holder, long numArgsOfMsgSend);
+    static VMMethod* createBootstrapMethod(VMClass* holder,
+                                           long numArgsOfMsgSend);
 
-    friend Universe* GetUniverse();
-    static Universe* theUniverse;
+    static long addClassPath(const StdString& cp);
+    static void printUsageAndExit(char* executable);
 
-    long addClassPath(const StdString& cp);
-    void printUsageAndExit(char* executable) const;
+    static void initialize(long, char**);
 
-    void initialize(long, char**);
+    static long heapSize;
+    static map<GCSymbol*, gc_oop_t> globals;
 
-    long heapSize;
-    map<GCSymbol*, gc_oop_t> globals;
+    static map<long, GCClass*> blockClassesByNoOfArgs;
+    static vector<StdString> classPath;
 
-    map<long, GCClass*> blockClassesByNoOfArgs;
-    vector<StdString> classPath;
-
-    Interpreter* interpreter;
+    static Interpreter interpreter;
 };
-
-// Singleton accessor
-inline Universe* GetUniverse() __attribute__((always_inline));
-Universe* GetUniverse() {
-    if (DEBUG && Universe::theUniverse == nullptr) {
-        ErrorExit("Trying to access uninitialized Universe, exiting.");
-    }
-    return Universe::theUniverse;
-}
-
-Universe* Universe::operator->() {
-    if (DEBUG && theUniverse == nullptr) {
-        ErrorExit("Trying to access uninitialized Universe, exiting.");
-    }
-    return theUniverse;
-}

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -53,8 +53,6 @@ public:
 
     static long setupClassPath(const StdString& cp);
 
-    static Interpreter* GetInterpreter() { return &interpreter; }
-
     static void Assert(bool);
 
     // VMObject instanciation methods. These should probably be refactored to a
@@ -134,6 +132,4 @@ private:
 
     static map<long, GCClass*> blockClassesByNoOfArgs;
     static vector<StdString> classPath;
-
-    static Interpreter interpreter;
 };

--- a/src/vmobjects/AbstractObject.cpp
+++ b/src/vmobjects/AbstractObject.cpp
@@ -17,9 +17,9 @@
 #include "VMInvokable.h"
 #include "VMSymbol.h"
 
-void AbstractVMObject::Send(Interpreter* interp, std::string selectorString,
-                            vm_oop_t* arguments, long argc) {
-    VMFrame* frame = interp->GetFrame();
+void AbstractVMObject::Send(std::string selectorString, vm_oop_t* arguments,
+                            long argc) {
+    VMFrame* frame = Interpreter::GetFrame();
     VMSymbol* selector = SymbolFor(selectorString);
     frame->Push(this);
 
@@ -29,7 +29,7 @@ void AbstractVMObject::Send(Interpreter* interp, std::string selectorString,
 
     VMClass* cl = GetClass();
     VMInvokable* invokable = cl->LookupInvokable(selector);
-    invokable->Invoke(interp, frame);
+    invokable->Invoke(frame);
 }
 
 long AbstractVMObject::GetFieldIndex(VMSymbol* fieldName) const {

--- a/src/vmobjects/AbstractObject.h
+++ b/src/vmobjects/AbstractObject.h
@@ -21,8 +21,6 @@
 
 using namespace std;
 
-class Interpreter;
-
 // this is the base class for all VMObjects
 class AbstractVMObject : public VMObjectBase {
 public:
@@ -31,7 +29,7 @@ public:
     virtual int64_t GetHash() const = 0;
     virtual VMClass* GetClass() const = 0;
     virtual AbstractVMObject* CloneForMovingGC() const = 0;
-    void Send(Interpreter*, StdString, vm_oop_t*, long);
+    void Send(StdString, vm_oop_t*, long);
 
     /** Size in bytes of the object. */
     virtual size_t GetObjectSize() const = 0;

--- a/src/vmobjects/ObjectFormats.h
+++ b/src/vmobjects/ObjectFormats.h
@@ -44,14 +44,14 @@
 #if ADDITIONAL_ALLOCATION
   #define TAG_INTEGER(X)                                            \
       (((X) >= VMTAGGEDINTEGER_MIN && (X) <= VMTAGGEDINTEGER_MAX && \
-        GetUniverse()->NewInteger(0))                               \
+        Universe::NewInteger(0))                                    \
            ? ((vm_oop_t)(((X) << 1) | 1))                           \
-           : (GetUniverse()->NewInteger(X)))
+           : (Universe::NewInteger(X)))
 #else
   #define TAG_INTEGER(X)                                          \
       (((X) >= VMTAGGEDINTEGER_MIN && (X) <= VMTAGGEDINTEGER_MAX) \
            ? ((vm_oop_t)((((uint64_t)(X)) << 1) | 1U))            \
-           : (GetUniverse()->NewInteger(X)))
+           : (Universe::NewInteger(X)))
 #endif
 
 #if USE_TAGGING
@@ -67,7 +67,7 @@
       (IS_TAGGED(X) ? GlobalBox::IntegerBox() : ((AbstractVMObject*)(X)))
 #else
   #define INT_VAL(X) (static_cast<VMInteger*>(X)->GetEmbeddedInteger())
-  #define NEW_INT(X) (GetUniverse()->NewInteger(X))
+  #define NEW_INT(X) (Universe::NewInteger(X))
   #define IS_TAGGED(X) false
   #define CLASS_OF(X) (AS_OBJ(X)->GetClass())
   #define AS_OBJ(X) ((AbstractVMObject*)(X))

--- a/src/vmobjects/PrimitiveRoutine.h
+++ b/src/vmobjects/PrimitiveRoutine.h
@@ -34,7 +34,7 @@ class PrimitiveRoutine {
 public:
     PrimitiveRoutine() {};
 
-    virtual void Invoke(Interpreter*, VMFrame*) = 0;  // call using operator
+    virtual void Invoke(VMFrame*) = 0;  // call using operator
     virtual bool isClassSide() = 0;
 };
 

--- a/src/vmobjects/VMArray.cpp
+++ b/src/vmobjects/VMArray.cpp
@@ -69,7 +69,7 @@ void VMArray::SetIndexableField(size_t idx, vm_oop_t value) {
 }
 
 VMArray* VMArray::Copy() const {
-    VMArray* copy = GetUniverse()->NewArray(GetNumberOfIndexableFields());
+    VMArray* copy = Universe::NewArray(GetNumberOfIndexableFields());
 
     const size_t additionalSpace = totalObjectSize - sizeof(VMArray);
     void* destination = SHIFTED_PTR(copy, sizeof(VMArray));
@@ -81,7 +81,7 @@ VMArray* VMArray::Copy() const {
 
 VMArray* VMArray::CopyAndExtendWith(vm_oop_t item) const {
     const size_t fields = GetNumberOfIndexableFields();
-    VMArray* result = GetUniverse()->NewArray(fields + 1);
+    VMArray* result = Universe::NewArray(fields + 1);
     CopyIndexableFieldsTo(result);
     result->SetIndexableField(fields, item);
     return result;

--- a/src/vmobjects/VMEvaluationPrimitive.cpp
+++ b/src/vmobjects/VMEvaluationPrimitive.cpp
@@ -33,7 +33,6 @@
 #include "../compiler/LexicalScope.h"
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
-#include "../primitivesCore/Routine.h"
 #include "../vm/Print.h"
 #include "../vm/Symbols.h"
 #include "../vm/Universe.h"  // NOLINT(misc-include-cleaner) it's required to make the types complete
@@ -84,7 +83,7 @@ VMSymbol* VMEvaluationPrimitive::computeSignatureString(long argc) {
     return SymbolFor(signatureString);
 }
 
-VMFrame* VMEvaluationPrimitive::Invoke(Interpreter* interp, VMFrame* frame) {
+VMFrame* VMEvaluationPrimitive::Invoke(VMFrame* frame) {
     // Get the block (the receiver) from the stack
     VMBlock* block =
         static_cast<VMBlock*>(frame->GetStackElement(numberOfArguments - 1));
@@ -94,7 +93,7 @@ VMFrame* VMEvaluationPrimitive::Invoke(Interpreter* interp, VMFrame* frame) {
 
     VMInvokable* method = block->GetMethod();
 
-    VMFrame* newFrame = method->Invoke(interp, frame);
+    VMFrame* newFrame = method->Invoke(frame);
 
     // Push set its context to be the one specified in the block
     if (newFrame != nullptr) {

--- a/src/vmobjects/VMEvaluationPrimitive.h
+++ b/src/vmobjects/VMEvaluationPrimitive.h
@@ -47,7 +47,7 @@ public:
     void MarkObjectAsInvalid() override;
     bool IsMarkedInvalid() const override;
 
-    VMFrame* Invoke(Interpreter* interp, VMFrame* frm) override;
+    VMFrame* Invoke(VMFrame* frm) override;
     void InlineInto(MethodGenerationContext& mgenc,
                     bool mergeScope = true) final;
 
@@ -57,7 +57,7 @@ public:
 
 private:
     static VMSymbol* computeSignatureString(long argc);
-    void evaluationRoutine(Interpreter*, VMFrame*);
+    void evaluationRoutine(VMFrame*);
 
     make_testable(public);
 

--- a/src/vmobjects/VMInvokable.h
+++ b/src/vmobjects/VMInvokable.h
@@ -43,7 +43,7 @@ public:
 
     int64_t GetHash() const override { return hash; }
 
-    virtual VMFrame* Invoke(Interpreter*, VMFrame*) = 0;
+    virtual VMFrame* Invoke(VMFrame*) = 0;
     virtual void InlineInto(MethodGenerationContext& mgenc,
                             bool mergeScope = true) = 0;
     virtual void MergeScopeInto(

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -126,8 +126,8 @@ void VMMethod::SetCachedFrame(VMFrame* frame) {
 }
 #endif
 
-VMFrame* VMMethod::Invoke(Interpreter* interp, VMFrame* frame) {
-    VMFrame* frm = interp->PushNewFrame(this);
+VMFrame* VMMethod::Invoke(VMFrame* frame) {
+    VMFrame* frm = Interpreter::PushNewFrame(this);
     frm->CopyArgumentsFrom(frame);
     return frm;
 }

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -149,7 +149,7 @@ public:
         store_ptr(indexableFields[idx], item);
     }
 
-    VMFrame* Invoke(Interpreter* interp, VMFrame* frame) override;
+    VMFrame* Invoke(VMFrame* frame) override;
 
     void MarkObjectAsInvalid() override {
         VMInvokable::MarkObjectAsInvalid();

--- a/src/vmobjects/VMObject.cpp
+++ b/src/vmobjects/VMObject.cpp
@@ -81,7 +81,7 @@ VMSymbol* VMObject::GetFieldName(long index) const {
 }
 
 void VMObject::Assert(bool value) const {
-    GetUniverse()->Assert(value);
+    Universe::Assert(value);
 }
 
 void VMObject::WalkObjects(walk_heap_fn walk) {

--- a/src/vmobjects/VMPrimitive.cpp
+++ b/src/vmobjects/VMPrimitive.cpp
@@ -58,7 +58,7 @@ VMPrimitive* VMPrimitive::CloneForMovingGC() const {
     return prim;
 }
 
-void VMPrimitive::EmptyRoutine(Interpreter*, VMFrame*) {
+void VMPrimitive::EmptyRoutine(VMFrame*) {
     VMSymbol* sig = GetSignature();
     ErrorPrint("undefined primitive called: " + sig->GetStdString() + "\n");
 }

--- a/src/vmobjects/VMPrimitive.h
+++ b/src/vmobjects/VMPrimitive.h
@@ -53,8 +53,8 @@ public:
     void SetEmpty(bool value) { empty = value; };
     VMPrimitive* CloneForMovingGC() const override;
 
-    VMFrame* Invoke(Interpreter* interp, VMFrame* frm) override {
-        routine->Invoke(interp, frm);
+    VMFrame* Invoke(VMFrame* frm) override {
+        routine->Invoke(frm);
         return nullptr;
     };
 
@@ -78,7 +78,7 @@ public:
     }
 
 private:
-    void EmptyRoutine(Interpreter*, VMFrame*);
+    void EmptyRoutine(VMFrame*);
 
 public:
     PrimitiveRoutine* routine;

--- a/src/vmobjects/VMSafePrimitive.cpp
+++ b/src/vmobjects/VMSafePrimitive.cpp
@@ -19,7 +19,7 @@ VMSafePrimitive* VMSafePrimitive::GetSafeUnary(VMSymbol* sig, UnaryPrim prim) {
     return p;
 }
 
-VMFrame* VMSafeUnaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
+VMFrame* VMSafeUnaryPrimitive::Invoke(VMFrame* frame) {
     vm_oop_t receiverObj = frame->Pop();
 
     frame->Push(prim.pointer(receiverObj));
@@ -33,7 +33,7 @@ VMSafePrimitive* VMSafePrimitive::GetSafeBinary(VMSymbol* sig,
     return p;
 }
 
-VMFrame* VMSafeBinaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
+VMFrame* VMSafeBinaryPrimitive::Invoke(VMFrame* frame) {
     vm_oop_t rightObj = frame->Pop();
     vm_oop_t leftObj = frame->Pop();
 
@@ -48,7 +48,7 @@ VMSafePrimitive* VMSafePrimitive::GetSafeTernary(VMSymbol* sig,
     return p;
 }
 
-VMFrame* VMSafeTernaryPrimitive::Invoke(Interpreter*, VMFrame* frame) {
+VMFrame* VMSafeTernaryPrimitive::Invoke(VMFrame* frame) {
     vm_oop_t arg2 = frame->Pop();
     vm_oop_t arg1 = frame->Pop();
     vm_oop_t self = frame->Pop();

--- a/src/vmobjects/VMSafePrimitive.h
+++ b/src/vmobjects/VMSafePrimitive.h
@@ -40,7 +40,7 @@ public:
         return sizeof(VMSafeUnaryPrimitive);
     }
 
-    VMFrame* Invoke(Interpreter*, VMFrame*) override;
+    VMFrame* Invoke(VMFrame*) override;
 
     AbstractVMObject* CloneForMovingGC() const final;
 
@@ -68,7 +68,7 @@ public:
         return sizeof(VMSafeBinaryPrimitive);
     }
 
-    VMFrame* Invoke(Interpreter*, VMFrame*) override;
+    VMFrame* Invoke(VMFrame*) override;
 
     AbstractVMObject* CloneForMovingGC() const final;
 
@@ -96,7 +96,7 @@ public:
         return sizeof(VMSafeTernaryPrimitive);
     }
 
-    VMFrame* Invoke(Interpreter*, VMFrame*) override;
+    VMFrame* Invoke(VMFrame*) override;
 
     AbstractVMObject* CloneForMovingGC() const final;
 

--- a/src/vmobjects/VMTrivialMethod.cpp
+++ b/src/vmobjects/VMTrivialMethod.cpp
@@ -82,7 +82,7 @@ VMFrame* VMGlobalReturn::Invoke(Interpreter* interpreter, VMFrame* frame) {
         frame->Pop();
     }
 
-    vm_oop_t value = GetUniverse()->GetGlobal(load_ptr(globalName));
+    vm_oop_t value = Universe::GetGlobal(load_ptr(globalName));
     if (value != nullptr) {
         frame->Push(value);
     } else {

--- a/src/vmobjects/VMTrivialMethod.cpp
+++ b/src/vmobjects/VMTrivialMethod.cpp
@@ -8,6 +8,7 @@
 #include "../compiler/BytecodeGenerator.h"
 #include "../compiler/MethodGenerationContext.h"
 #include "../compiler/Variable.h"
+#include "../interpreter/Interpreter.h"
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../vm/LogAllocation.h"
@@ -49,7 +50,7 @@ VMTrivialMethod* MakeSetter(VMSymbol* sig, vector<Variable>& arguments,
     return result;
 }
 
-VMFrame* VMLiteralReturn::Invoke(Interpreter*, VMFrame* frame) {
+VMFrame* VMLiteralReturn::Invoke(VMFrame* frame) {
     for (int i = 0; i < numberOfArguments; i += 1) {
         frame->Pop();
     }
@@ -77,7 +78,7 @@ void VMLiteralReturn::InlineInto(MethodGenerationContext& mgenc, bool) {
     EmitPUSHCONSTANT(mgenc, load_ptr(literal));
 }
 
-VMFrame* VMGlobalReturn::Invoke(Interpreter* interpreter, VMFrame* frame) {
+VMFrame* VMGlobalReturn::Invoke(VMFrame* frame) {
     for (int i = 0; i < numberOfArguments; i += 1) {
         frame->Pop();
     }
@@ -86,7 +87,7 @@ VMFrame* VMGlobalReturn::Invoke(Interpreter* interpreter, VMFrame* frame) {
     if (value != nullptr) {
         frame->Push(value);
     } else {
-        interpreter->SendUnknownGlobal(load_ptr(globalName));
+        Interpreter::SendUnknownGlobal(load_ptr(globalName));
     }
 
     return nullptr;
@@ -112,7 +113,7 @@ AbstractVMObject* VMGlobalReturn::CloneForMovingGC() const {
     return prim;
 }
 
-VMFrame* VMGetter::Invoke(Interpreter*, VMFrame* frame) {
+VMFrame* VMGetter::Invoke(VMFrame* frame) {
     vm_oop_t self = nullptr;
     for (int i = 0; i < numberOfArguments; i += 1) {
         self = frame->Pop();
@@ -150,7 +151,7 @@ std::string VMGetter::AsDebugString() const {
     return "VMGetter(fieldIndex: " + to_string(fieldIndex) + ")";
 }
 
-VMFrame* VMSetter::Invoke(Interpreter*, VMFrame* frame) {
+VMFrame* VMSetter::Invoke(VMFrame* frame) {
     vm_oop_t value = nullptr;
     vm_oop_t self = nullptr;
 

--- a/src/vmobjects/VMTrivialMethod.h
+++ b/src/vmobjects/VMTrivialMethod.h
@@ -66,7 +66,7 @@ public:
         return sizeof(VMLiteralReturn);
     }
 
-    VMFrame* Invoke(Interpreter*, VMFrame*) override;
+    VMFrame* Invoke(VMFrame*) override;
     void InlineInto(MethodGenerationContext& mgenc,
                     bool mergeScope = true) final;
 
@@ -105,7 +105,7 @@ public:
         return sizeof(VMGlobalReturn);
     }
 
-    VMFrame* Invoke(Interpreter*, VMFrame*) override;
+    VMFrame* Invoke(VMFrame*) override;
     void InlineInto(MethodGenerationContext& mgenc,
                     bool mergeScope = true) final;
 
@@ -141,7 +141,7 @@ public:
 
     inline size_t GetObjectSize() const override { return sizeof(VMGetter); }
 
-    VMFrame* Invoke(Interpreter*, VMFrame*) override;
+    VMFrame* Invoke(VMFrame*) override;
     void InlineInto(MethodGenerationContext& mgenc,
                     bool mergeScope = true) final;
 
@@ -176,7 +176,7 @@ public:
 
     inline size_t GetObjectSize() const override { return sizeof(VMSetter); }
 
-    VMFrame* Invoke(Interpreter*, VMFrame*) override;
+    VMFrame* Invoke(VMFrame*) override;
     void InlineInto(MethodGenerationContext& mgenc,
                     bool mergeScope = true) final;
 


### PR DESCRIPTION
This is intended to simplify the code but also to avoid unnecessary memory accesses and virtual dispatches.

It has some performance benefit:
median -4% (min. -23%, max. 25%)
https://rebench.dev/SOMpp/compare/64a86da76aaa57d8b794260bce9f8396e7ecc072..ede98d3b1d401e170e4ebe3ac6e50f31c4be2065