### PR TITLE
Optimize VMFrame Creation

### DIFF
--- a/src/unitTests/WalkObjectsTest.cpp
+++ b/src/unitTests/WalkObjectsTest.cpp
@@ -154,8 +154,8 @@ void WalkObjectsTest::testWalkFrame() {
         Universe::NewMethod(methodSymbol, 0, 0, 0, 0,
                             new LexicalScope(nullptr, {}, {}), inlinedLoops);
 
-    VMFrame* frame = Universe::NewFrame(nullptr, method);
-    frame->SetPreviousFrame(frame->CloneForMovingGC());
+    VMFrame* prev = Universe::NewFrame(nullptr, method);
+    VMFrame* frame = Universe::NewFrame(prev, method);
     frame->SetContext(frame->CloneForMovingGC());
     VMInteger* dummyArg = Universe::NewInteger(1111);
     frame->SetArgument(0, 0, dummyArg);

--- a/src/unitTests/WriteBarrierTest.cpp
+++ b/src/unitTests/WriteBarrierTest.cpp
@@ -106,9 +106,6 @@ void WriteBarrierTest::testWriteFrame() {
     VMFrame* frame = Interpreter::GetFrame()->CloneForMovingGC();
     frame->SetContext(frame->CloneForMovingGC());
 
-    frame->SetPreviousFrame(Interpreter::GetFrame());
-    TEST_WB_CALLED("VMFrame failed to call writeBarrier on SetPreviousFrame",
-                   frame, Interpreter::GetFrame());
     frame->SetContext(frame->GetContext()->CloneForMovingGC());
     TEST_WB_CALLED("VMFrame failed to call writeBarrier on SetContext", frame,
                    frame->GetContext());

--- a/src/vm/IsValidObject.cpp
+++ b/src/vm/IsValidObject.cpp
@@ -182,9 +182,6 @@ void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
         new (GetHeap<HEAP_CLS>(), 0) VMEvaluationPrimitive(1);
     vt_eval_primitive = get_vtable(ev);
 
-    VMFrame* frm = new (GetHeap<HEAP_CLS>(), 0) VMFrame(0, 0);
-    vt_frame = get_vtable(frm);
-
     VMInteger* i = new (GetHeap<HEAP_CLS>(), 0) VMInteger(0);
     vt_integer = get_vtable(i);
 
@@ -192,6 +189,9 @@ void obtain_vtables_of_known_classes(VMSymbol* someValidSymbol) {
         VMMethod(nullptr, 0, 0, 0, 0, nullptr, nullptr);
     vt_method = get_vtable(mth);
     vt_object = get_vtable(load_ptr(nilObject));
+
+    VMFrame* frm = new (GetHeap<HEAP_CLS>(), 0) VMFrame(0, mth, nullptr);
+    vt_frame = get_vtable(frm);
 
     VMPrimitive* prm =
         new (GetHeap<HEAP_CLS>(), 0) VMPrimitive(someValidSymbol, FramePrim());

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -720,11 +720,7 @@ VMFrame* Universe::NewFrame(VMFrame* previousFrame, VMMethod* method) {
                     method->GetMaximumNumberOfStackElements();
 
     size_t additionalBytes = length * sizeof(VMObject*);
-    result = new (GetHeap<HEAP_CLS>(), additionalBytes)
-        VMFrame(length, additionalBytes);
-    result->method = store_root(method);
-    result->previousFrame = store_root(previousFrame);
-    result->ResetStackPointer();
+    result = new (GetHeap<HEAP_CLS>(), additionalBytes) VMFrame(additionalBytes, method, previousFrame);
 
     LOG_ALLOCATION("VMFrame", result->GetObjectSize());
     return result;

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -302,6 +302,11 @@ vm_oop_t Universe::interpretMethod(VMObject* receiver, VMInvokable* initialize,
     VMMethod* bootstrapMethod = createBootstrapMethod(load_ptr(systemClass), 2);
 
     VMFrame* bootstrapFrame = Interpreter::PushNewFrame(bootstrapMethod);
+    for (size_t argIdx = 0; argIdx < bootstrapMethod->GetNumberOfArguments();
+         argIdx += 1) {
+        bootstrapFrame->SetArgument((long)argIdx, (long)0, load_ptr(nilObject));
+    }
+
     bootstrapFrame->Push(receiver);
 
     if (argumentsArray != nullptr) {
@@ -720,7 +725,8 @@ VMFrame* Universe::NewFrame(VMFrame* previousFrame, VMMethod* method) {
                     method->GetMaximumNumberOfStackElements();
 
     size_t additionalBytes = length * sizeof(VMObject*);
-    result = new (GetHeap<HEAP_CLS>(), additionalBytes) VMFrame(additionalBytes, method, previousFrame);
+    result = new (GetHeap<HEAP_CLS>(), additionalBytes)
+        VMFrame(additionalBytes, method, previousFrame);
 
     LOG_ALLOCATION("VMFrame", result->GetObjectSize());
     return result;

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -53,13 +53,11 @@ VMFrame* VMFrame::EmergencyFrameFrom(VMFrame* from, long extraLength) {
 
     size_t additionalBytes = length * sizeof(VMObject*);
     VMFrame* result = new (GetHeap<HEAP_CLS>(), additionalBytes)
-        VMFrame(length, additionalBytes);
+        VMFrame(additionalBytes, method, from->GetPreviousFrame());
 
     result->clazz = nullptr;  // result->SetClass(from->GetClass());
 
     // set Frame members
-    result->SetPreviousFrame(from->GetPreviousFrame());
-    result->SetMethod(method);
     result->SetContext(from->GetContext());
     result->stack_ptr =
         (gc_oop_t*)SHIFTED_PTR(result, (size_t)from->stack_ptr - (size_t)from);
@@ -123,27 +121,6 @@ VMFrame* VMFrame::CloneForMovingGC() const {
 }
 
 const long VMFrame::VMFrameNumberOfFields = 0;
-
-VMFrame::VMFrame(size_t, size_t additionalBytes)
-    : VMObject(0, additionalBytes + sizeof(VMFrame)), bytecodeIndex(0),
-      previousFrame(nullptr), context(nullptr), method(nullptr) {
-    arguments = (gc_oop_t*)&(stack_ptr) + 1;
-    locals = arguments;
-    stack_ptr = locals;
-
-    // initilize all other fields
-    // --> until end of Frame
-    gc_oop_t* end = (gc_oop_t*)SHIFTED_PTR(this, totalObjectSize);
-    size_t i = 0;
-    while (arguments + i < end) {
-        arguments[i] = nilObject;
-        i++;
-    }
-}
-
-void VMFrame::SetMethod(VMMethod* method) {
-    store_ptr(this->method, method);
-}
 
 VMFrame* VMFrame::GetContextLevel(long lvl) {
     VMFrame* current = this;

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -54,8 +54,8 @@ public:
         // --> until end of Frame
         gc_oop_t* end = (gc_oop_t*)SHIFTED_PTR(this, totalObjectSize);
         size_t i = 0;
-        while (arguments + i < end) {
-            arguments[i] = nilObject;
+        while (locals + i < end) {
+            locals[i] = nilObject;
             i++;
         }
     }


### PR DESCRIPTION
 - move most bits to the constructor
 - do not initialize arguments with nil since they will be set during the call