### PR TITLE
Avoid nil-ing VMArray twice and improve strEqual and VMString inlining

### DIFF
--- a/src/primitives/String.cpp
+++ b/src/primitives/String.cpp
@@ -29,6 +29,7 @@
 #include <cctype>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <string>
 
 #include "../misc/defs.h"
@@ -74,7 +75,7 @@ static vm_oop_t strLength(vm_oop_t rcvr) {
 }
 
 static vm_oop_t strEqual(vm_oop_t leftObj, vm_oop_t op1) {
-    VMString* op2 = static_cast<VMString*>(leftObj);
+    VMString* left = static_cast<VMString*>(leftObj);
 
     if (IS_TAGGED(op1)) {
         return load_ptr(falseObject);
@@ -85,14 +86,18 @@ static vm_oop_t strEqual(vm_oop_t leftObj, vm_oop_t op1) {
     }
 
     VMClass* otherClass = CLASS_OF(op1);
-    if (otherClass == load_ptr(stringClass) ||
-        otherClass == load_ptr(symbolClass)) {
-        StdString s1 = static_cast<VMString*>(op1)->GetStdString();
-        StdString s2 = op2->GetStdString();
+    if (otherClass != load_ptr(stringClass) &&
+        otherClass != load_ptr(symbolClass)) {
+        return load_ptr(falseObject);
+    }
 
-        if (s1 == s2) {
-            return load_ptr(trueObject);
-        }
+    VMString* right = static_cast<VMString*>(op1);
+    if (left->length != right->length) {
+        return load_ptr(falseObject);
+    }
+
+    if (strncmp(left->chars, right->chars, left->length) == 0) {
+        return load_ptr(trueObject);
     }
     return load_ptr(falseObject);
 }

--- a/src/vmobjects/VMArray.cpp
+++ b/src/vmobjects/VMArray.cpp
@@ -40,14 +40,6 @@
 
 const size_t VMArray::VMArrayNumberOfFields = 0;
 
-VMArray::VMArray(size_t arraySize, size_t additionalBytes)
-    : VMObject(
-          arraySize + 0 /* VMArray is not allowed to have any fields itself */,
-          additionalBytes + sizeof(VMArray)) {
-    assert(VMArrayNumberOfFields == 0);
-    nilInitializeFields();
-}
-
 VMArray* VMArray::Copy() const {
     VMArray* copy = Universe::NewArray(GetNumberOfIndexableFields());
 

--- a/src/vmobjects/VMArray.h
+++ b/src/vmobjects/VMArray.h
@@ -39,7 +39,12 @@ class VMArray : public VMObject {
 public:
     typedef GCArray Stored;
 
-    explicit VMArray(size_t arraySize, size_t additionalBytes);
+    explicit VMArray(size_t arraySize, size_t additionalBytes)
+        : VMObject(arraySize +
+                       0 /* VMArray is not allowed to have any fields itself */,
+                   additionalBytes + sizeof(VMArray)) {
+        assert(VMArrayNumberOfFields == 0);
+    }
 
     // VMArray doesn't need to customize `void WalkObjects(walk_heap_fn)`,
     // because it doesn't need anything special.

--- a/src/vmobjects/VMString.cpp
+++ b/src/vmobjects/VMString.cpp
@@ -43,21 +43,6 @@ VMString* VMString::CloneForMovingGC() const {
         VMString(length, chars);
 }
 
-void VMString::MarkObjectAsInvalid() {
-    for (size_t i = 0; i < length; i++) {
-        chars[i] = 'z';
-    }
-    chars = (char*)INVALID_GC_POINTER;
-}
-
-bool VMString::IsMarkedInvalid() const {
-    return chars == (char*)INVALID_GC_POINTER;
-}
-
-void VMString::WalkObjects(walk_heap_fn) {
-    // nothing to do
-}
-
 size_t VMString::GetObjectSize() const {
     size_t size = sizeof(VMString) + PADDED_SIZE(length);
     return size;
@@ -65,10 +50,6 @@ size_t VMString::GetObjectSize() const {
 
 VMClass* VMString::GetClass() const {
     return load_ptr(stringClass);
-}
-
-size_t VMString::GetStringLength() const {
-    return length;
 }
 
 std::string VMString::GetStdString() const {

--- a/src/vmobjects/VMString.h
+++ b/src/vmobjects/VMString.h
@@ -52,17 +52,30 @@ public:
         return (int64_t)hash;
     }
 
-    inline char* GetRawChars() const;
+    inline char* GetRawChars() const { return chars; }
+
     StdString GetStdString() const;
-    size_t GetStringLength() const;
+
+    inline size_t GetStringLength() const { return length; }
 
     VMString* CloneForMovingGC() const override;
     VMClass* GetClass() const override;
     size_t GetObjectSize() const override;
-    void WalkObjects(walk_heap_fn) override;
 
-    void MarkObjectAsInvalid() override;
-    bool IsMarkedInvalid() const override;
+    inline void WalkObjects(walk_heap_fn) override {
+        // nothing to do
+    }
+
+    void MarkObjectAsInvalid() override {
+        for (size_t i = 0; i < length; i++) {
+            chars[i] = 'z';
+        }
+        chars = (char*)INVALID_GC_POINTER;
+    }
+
+    bool IsMarkedInvalid() const override {
+        return chars == (char*)INVALID_GC_POINTER;
+    }
 
     StdString AsDebugString() const override;
 
@@ -80,7 +93,3 @@ protected:
           length(length),
           chars(adaptedCharsPointer) {};  // constructor to use by VMSymbol
 };
-
-char* VMString::GetRawChars() const {
-    return chars;
-}


### PR DESCRIPTION
median 0% (min. -15%, max. 26%)
https://rebench.dev/SOMpp/compare/8a8617cb121513096e3b87244c8899ac6251be2c..1e17f763dd1f34d0f99c14eb403d0eedd6e27452