### PR TITLE
Restore block restart

### DIFF
--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -26,6 +26,8 @@
  THE SOFTWARE.
  */
 
+#include <assert.h>
+
 #include "../misc/defs.h"
 #include "../vmobjects/ObjectFormats.h"
 #include "../vmobjects/VMFrame.h"
@@ -61,6 +63,12 @@ public:
     static void SendUnknownGlobal(VMSymbol* globalName);
 
     static inline size_t GetBytecodeIndex() { return bytecodeIndexGlobal; }
+
+    static void ResetBytecodeIndex(VMFrame* forFrame) {
+        assert(frame == forFrame);
+        assert(forFrame != nullptr);
+        bytecodeIndexGlobal = 0;
+    }
 
 private:
     static vm_oop_t GetSelf();

--- a/src/primitives/Block.cpp
+++ b/src/primitives/Block.cpp
@@ -23,3 +23,16 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  */
+
+#include "Block.h"
+
+#include "../vmobjects/VMFrame.h"
+
+static void bRestart(VMFrame* frame) {
+    frame->ResetBytecodeIndex();
+    frame->ResetStackPointer();
+}
+
+_Block::_Block() {
+    Add("restart", &bRestart, false);
+}

--- a/src/primitives/Block.h
+++ b/src/primitives/Block.h
@@ -31,5 +31,5 @@
 
 class _Block : public PrimitiveContainer {
 public:
-    _Block() = default;
+    _Block();
 };

--- a/src/primitives/Method.cpp
+++ b/src/primitives/Method.cpp
@@ -20,7 +20,7 @@ static vm_oop_t mSignature(vm_oop_t rcvr) {
 }
 
 static void mInvokeOnWith(VMFrame* frame) {
-    // REM: this is a clone with _Primitive::InvokeOn_With_
+    // REM: this is a clone with _Primitive pInvokeOnWith
     auto* args = static_cast<VMArray*>(frame->Pop());
     auto* rcvr = frame->Pop();
     auto* mthd = static_cast<VMMethod*>(frame->Pop());

--- a/src/primitives/Method.h
+++ b/src/primitives/Method.h
@@ -6,6 +6,4 @@
 class _Method : public PrimitiveContainer {
 public:
     _Method();
-
-    void InvokeOn_With_(VMFrame*);
 };

--- a/src/primitives/Primitive.cpp
+++ b/src/primitives/Primitive.cpp
@@ -18,7 +18,7 @@ static vm_oop_t pSignature(vm_oop_t rcvr) {
 }
 
 static void pInvokeOnWith(VMFrame* frame) {
-    // REM: this is a clone with _Primitive::InvokeOn_With_
+    // REM: this is a clone with _Method mInvokeOnWith
     auto* args = static_cast<VMArray*>(frame->Pop());
     auto* rcvr = frame->Pop();
     auto* mthd = static_cast<VMInvokable*>(frame->Pop());

--- a/src/primitives/Primitive.h
+++ b/src/primitives/Primitive.h
@@ -6,6 +6,4 @@
 class _Primitive : public PrimitiveContainer {
 public:
     _Primitive();
-
-    void InvokeOn_With_(VMFrame*);
 };

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -32,6 +32,7 @@
 #include <string>
 
 #include "../compiler/Disassembler.h"
+#include "../interpreter/Interpreter.h"
 #include "../memory/Heap.h"
 #include "../misc/defs.h"
 #include "../vm/Globals.h"
@@ -255,4 +256,9 @@ void VMFrame::CopyArgumentsFrom(VMFrame* frame) {
 
 std::string VMFrame::AsDebugString() const {
     return "VMFrame(" + GetMethod()->AsDebugString() + ")";
+}
+
+void VMFrame::ResetBytecodeIndex() {
+    bytecodeIndex = 0;
+    Interpreter::ResetBytecodeIndex(this);
 }

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -52,8 +52,8 @@ public:
           arguments((gc_oop_t*)&(stack_ptr) + 1),
           locals(arguments + method->GetNumberOfArguments()),
           stack_ptr(locals + method->GetNumberOfLocals() - 1) {
-        // initilize all other fields. Don't need to initalize arguments,
-        // because they iwll be copied in still
+        // initialize all other fields. Don't need to initialize arguments,
+        // because they will be copied in still
         // --> until end of Frame
         auto* end = (gc_oop_t*)SHIFTED_PTR(this, totalObjectSize);
         size_t i = 0;

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -181,6 +181,14 @@ public:
     size_t bytecodeIndex{0};
     size_t totalObjectSize;
 
+    void ResetStackPointer() {
+        VMMethod* meth = GetMethod();
+        // Set the stack pointer to its initial value thereby clearing the stack
+        stack_ptr = locals + meth->GetNumberOfLocals() - 1;
+    }
+
+    void ResetBytecodeIndex();
+
 private:
     GCFrame* previousFrame;
     GCFrame* context{nullptr};


### PR DESCRIPTION
This PR restores the restart primitive on blocks so that `#whileTrue:` and `#whileFalse:` work correctly for blocks that were not inlined.

Issue reported by @sillycross. Thanks.

Needs https://github.com/SOM-st/SOM/pull/125 to be merged to update core-lib to a merged version.