### PR TITLE
The build instructions should do a release build, not debug build

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2007 Michael Haupt, Tobias Pape, Arne Bergmann
+Software Architecture Group, Hasso Plattner Institute, Potsdam, Germany
+http://www.hpi.uni-potsdam.de/swa/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ SOM is a minimal Smalltalk dialect used to teach VM construction at the [Hasso
 Plattner Institute][SOM]. It was originally built at the University of Århus
 (Denmark) where it was also used for teaching.
 
-Currently, implementations exist for Java (SOM), C (CSOM), C++ (SOM++), Python
-(PySOM), RPython (RPySOM), the Truffle framework (TruffleSOM), and
-Squeak/Pharo Smalltalk (AweSOM).
+Implementations exist for instance for Java (SOM), C (CSOM), C++ (SOM++), Python & RPython
+(PySOM), the Truffle framework (TruffleSOM), and Squeak/Pharo Smalltalk (AweSOM).
 
 A simple SOM Hello World looks like:
 
@@ -22,33 +21,36 @@ Hello = (
 )
 ```
 
-This repository contains the C++ implementation of SOM, including an
-implementation of the SOM standard library and a number of examples. Please see
-the [main project page][SOMst] for links to the VM implementations.
+This repository contains the C++ implementation of SOM. The implementation of
+the SOM standard library and a number of examples are included as a git submodule.
+Please see the [main project page][SOMst] for links to other VM implementations.
 
 
-SOM++ uses CMake for building:
+SOM++ uses CMake and an optimized release build can be built like this:
 
-    $ mkdir cmake-build && cd cmake-build
-    $ cmake -DCMAKE_BUILD_TYPE=Release ..
-    $ make
+```bash
+mkdir cmake-build && cd cmake-build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make
+```
 
 Afterwards, the tests can be executed with:
 
-    $ ./SOM++ -cp ../Smalltalk ../TestSuite/TestHarness.som
-   
+```bash
+./SOM++ -cp ../Smalltalk ../TestSuite/TestHarness.som
+```
+
 A simple Hello World program is executed with:
 
-    $ ./SOM++ -cp ../Smalltalk ../Examples/Hello.som
-
-**Note**: On Linux, the library search path needs to be adapted:
-
-    $ export LD_LIBRARY_PATH=.
+```bash
+./SOM++ -cp ../Smalltalk ../Examples/Hello.som
+```
 
 Information on previous authors are included in the AUTHORS file. This code is
 distributed under the MIT License. Please see the LICENSE file for details.
 Additional documentation, detailing for instance the object model and how to
 implement primitives, is available in the `doc` folder.
+
 
 Advanced Compilation Settings
 -----------------------------
@@ -71,12 +73,43 @@ Integer caching:
     example: cmake .. -DCACHE_INTEGER=true
 
 
+Development Build and Testing
+-----------------------------
+
+A build with assertions for development and debugging can be built with:
+
+```bash
+mkdir cmake-debug && cd cmake-debug
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+make -j
+```
+
+This build also creates a `unittests` binary, which uses cppunit for
+implementation-level unit tests, to run the basic interpreter tests
+in `TestSuite/BasicInterpreterTests`, as well as the SOM test suite.
+
+The unit tests need the SOM classpath set as follows:
+
+```bash
+./unittests -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
+```
+
+Code Style and Linting
+----------------------
+
+To have a somewhat consistent code style and catch some basic bugs, the CI
+setup runs `clang-format` and `clang-tidy`
+
+```bash
+clang-tidy --config-file=.clang-tidy src/**/*.cpp -- -fdiagnostics-absolute-paths
+clang-format --dry-run --style=file --Werror src/*.cpp  src/**/*.cpp src/**/*.h
+```
+
 Build Status
 ------------
 
-Thanks to GitHub Actions, all commits of this repository are tested.
+Thanks to GitHub Actions, this repository is automatically tested.
 The current build status is: [![Build Status](https://github.com/SOM-st/SOMpp/actions/workflows/ci.yml/badge.svg)](https://github.com/SOM-st/SOMpp/actions/workflows/ci.yml)
 
  [SOM]: http://www.hpi.uni-potsdam.de/hirschfeld/projects/som/
  [SOMst]: https://som-st.github.io
-

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the [main project page][SOMst] for links to the VM implementations.
 SOM++ uses CMake for building:
 
     $ mkdir cmake-build && cd cmake-build
-    $ cmake ..
+    $ cmake -DCMAKE_BUILD_TYPE=Release ..
     $ make
 
 Afterwards, the tests can be executed with:
@@ -44,10 +44,6 @@ A simple Hello World program is executed with:
 **Note**: On Linux, the library search path needs to be adapted:
 
     $ export LD_LIBRARY_PATH=.
-
-The debug version of CSOM can be built using the `debug` target:
-
-    $ make debug
 
 Information on previous authors are included in the AUTHORS file. This code is
 distributed under the MIT License. Please see the LICENSE file for details.


### PR DESCRIPTION
Currently the build instruction will generate a debug build, instead of the release build. This can easily mislead readers who wants to use or benchmark SOM++. This diff changed the build instructions to do a release build instead. Also removed the obsoleted description about CSOM "make debug" (this won't work for SOM++: the build flavor must be passed to CMake instead).