### PR TITLE
Add parser errors to make sure we do not generate wrong bytecodes

### DIFF
--- a/src/compiler/BytecodeGenerator.h
+++ b/src/compiler/BytecodeGenerator.h
@@ -34,31 +34,43 @@
 
 void Emit1(MethodGenerationContext& mgenc, uint8_t bytecode,
            int64_t stackEffect);
-void Emit2(MethodGenerationContext& mgenc, uint8_t bytecode, size_t idx,
+void Emit2(MethodGenerationContext& mgenc, uint8_t bytecode, uint8_t idx,
            int64_t stackEffect);
-void Emit3(MethodGenerationContext& mgenc, uint8_t bytecode, size_t idx,
+void Emit3(MethodGenerationContext& mgenc, uint8_t bytecode, uint8_t idx,
            size_t ctx, int64_t stackEffect);
 
 void EmitHALT(MethodGenerationContext& mgenc);
 void EmitDUP(MethodGenerationContext& mgenc);
-void EmitPUSHLOCAL(MethodGenerationContext& mgenc, size_t idx, size_t ctx);
-void EmitPUSHARGUMENT(MethodGenerationContext& mgenc, size_t idx, size_t ctx);
-void EmitPUSHFIELD(MethodGenerationContext& mgenc, VMSymbol* field);
-void EmitPUSHBLOCK(MethodGenerationContext& mgenc, VMInvokable* block);
-void EmitPUSHCONSTANT(MethodGenerationContext& mgenc, vm_oop_t cst);
+void EmitPUSHLOCAL(MethodGenerationContext& mgenc, const Parser& parser,
+                   size_t index, size_t context);
+void EmitPUSHARGUMENT(MethodGenerationContext& mgenc, const Parser& parser,
+                      size_t index, size_t context);
+void EmitPUSHFIELD(MethodGenerationContext& mgenc, const Parser& parser,
+                   VMSymbol* field);
+void EmitPUSHBLOCK(MethodGenerationContext& mgenc, const Parser& parser,
+                   VMInvokable* block);
+void EmitPUSHCONSTANT(MethodGenerationContext& mgenc, const Parser& parser,
+                      vm_oop_t cst);
 void EmitPUSHCONSTANT(MethodGenerationContext& mgenc, uint8_t literalIndex);
 void EmitPUSHCONSTANTString(MethodGenerationContext& mgenc, VMString* str);
-void EmitPUSHGLOBAL(MethodGenerationContext& mgenc, VMSymbol* global);
+void EmitPUSHGLOBAL(MethodGenerationContext& mgenc, const Parser& parser,
+                    VMSymbol* global);
 void EmitPOP(MethodGenerationContext& mgenc);
-void EmitPOPLOCAL(MethodGenerationContext& mgenc, size_t idx, size_t ctx);
-void EmitPOPARGUMENT(MethodGenerationContext& mgenc, size_t idx, size_t ctx);
-void EmitPOPFIELD(MethodGenerationContext& mgenc, VMSymbol* field);
-void EmitSEND(MethodGenerationContext& mgenc, VMSymbol* msg);
-void EmitSUPERSEND(MethodGenerationContext& mgenc, VMSymbol* msg);
+void EmitPOPLOCAL(MethodGenerationContext& mgenc, const Parser& parser,
+                  size_t index, size_t context);
+void EmitPOPARGUMENT(MethodGenerationContext& mgenc, const Parser& parser,
+                     size_t idx, size_t ctx);
+void EmitPOPFIELD(MethodGenerationContext& mgenc, const Parser& parser,
+                  VMSymbol* field);
+void EmitSEND(MethodGenerationContext& mgenc, const Parser& parser,
+              VMSymbol* msg);
+void EmitSUPERSEND(MethodGenerationContext& mgenc, const Parser& parser,
+                   VMSymbol* msg);
 void EmitRETURNSELF(MethodGenerationContext& mgenc);
-void EmitRETURNLOCAL(MethodGenerationContext& mgenc);
+void EmitRETURNLOCAL(MethodGenerationContext& mgenc, const Parser& parser);
 void EmitRETURNNONLOCAL(MethodGenerationContext& mgenc);
-void EmitRETURNFIELD(MethodGenerationContext& mgenc, size_t index);
+void EmitRETURNFIELD(MethodGenerationContext& mgenc, const Parser& parser,
+                     size_t index);
 
 void EmitINC(MethodGenerationContext& mgenc);
 void EmitDEC(MethodGenerationContext& mgenc);

--- a/src/compiler/MethodGenerationContext.h
+++ b/src/compiler/MethodGenerationContext.h
@@ -67,8 +67,8 @@ public:
 
     void SetPrimitive(bool prim = true);
 
-    uint8_t AddLiteral(vm_oop_t lit);
-    uint8_t AddLiteralIfAbsent(vm_oop_t lit);
+    uint8_t AddLiteral(vm_oop_t lit, const Parser& parser);
+    uint8_t AddLiteralIfAbsent(vm_oop_t lit, const Parser& parser);
     void UpdateLiteral(vm_oop_t oldValue, uint8_t index, vm_oop_t newValue);
 
     void MarkFinished();
@@ -96,18 +96,18 @@ public:
 
     uint8_t GetNumberOfArguments();
     void AddBytecode(uint8_t bc, int64_t stackEffect);
-    void AddBytecodeArgument(uint8_t bc);
-    size_t AddBytecodeArgumentAndGetIndex(uint8_t bc);
+    void AddBytecodeArgument(uint8_t arg);
+    size_t AddBytecodeArgumentAndGetIndex(size_t bc);
 
     bool HasBytecodes();
 
     std::vector<uint8_t> GetBytecodes() { return bytecode; }
 
-    bool InlineWhile(Parser& parser, bool isWhileTrue);
-    bool InlineThenElseBranches(JumpCondition condition);
-    bool InlineThenBranch(JumpCondition condition);
-    bool InlineAndOr(bool isOr);
-    bool InlineToDo();
+    bool InlineWhile(const Parser& parser, bool isWhileTrue);
+    bool InlineThenElseBranches(const Parser& parser, JumpCondition condition);
+    bool InlineThenBranch(const Parser& parser, JumpCondition condition);
+    bool InlineAndOr(const Parser& parser, bool isOr);
+    bool InlineToDo(const Parser& parser);
 
     inline size_t OffsetOfNextInstruction() { return bytecode.size(); }
 
@@ -123,7 +123,7 @@ public:
 
     bool OptimizeDupPopPopSequence();
     bool OptimizeIncField(uint8_t fieldIdx);
-    bool OptimizeReturnField();
+    bool OptimizeReturnField(const Parser& parser);
 
     bool LastBytecodeIs(size_t indexFromEnd, uint8_t bytecode);
 
@@ -155,7 +155,8 @@ private:
 
     VMInvokable* getLastBlockMethodAndFreeLiteral(uint8_t blockLiteralIdx);
 
-    void completeJumpsAndEmitReturningNil(Parser& parser, size_t loopBeginIdx,
+    void completeJumpsAndEmitReturningNil(const Parser& parser,
+                                          size_t loopBeginIdx,
                                           size_t jumpOffsetIdxToSkipLoopBody);
 
     static void checkJumpOffset(size_t jumpOffset, uint8_t bytecode);

--- a/src/compiler/Parser.h
+++ b/src/compiler/Parser.h
@@ -45,6 +45,8 @@ public:
     void method(MethodGenerationContext& mgenc);
     void nestedBlock(MethodGenerationContext& mgenc);
 
+    __attribute__((noreturn)) void ParseError(const char* msg) const;
+
 private:
     __attribute__((noreturn)) void parseError(const char* msg, Symbol expected);
     __attribute__((noreturn)) void parseError(const char* msg,
@@ -118,10 +120,10 @@ private:
     std::string _string();
     void blockPattern(MethodGenerationContext& mgenc);
     void blockArguments(MethodGenerationContext& mgenc);
-    static void genPushVariable(MethodGenerationContext& /*mgenc*/,
-                                std::string& /*var*/);
-    static void genPopVariable(MethodGenerationContext& /*mgenc*/,
-                               std::string& /*var*/);
+    void genPushVariable(MethodGenerationContext& /*mgenc*/,
+                         std::string& /*var*/) const;
+    void genPopVariable(MethodGenerationContext& /*mgenc*/,
+                        std::string& /*var*/) const;
 
     Lexer lexer;
     std::string& fname;

--- a/src/vmobjects/VMEvaluationPrimitive.cpp
+++ b/src/vmobjects/VMEvaluationPrimitive.cpp
@@ -135,6 +135,7 @@ bool VMEvaluationPrimitive::IsMarkedInvalid() const {
 }
 
 void VMEvaluationPrimitive::InlineInto(MethodGenerationContext& /*mgenc*/,
+                                       const Parser& /*parser*/,
                                        bool /*mergeScope*/) {
     ErrorExit(
         "VMEvaluationPrimitive::InlineInto is not supported, and should not be "

--- a/src/vmobjects/VMEvaluationPrimitive.h
+++ b/src/vmobjects/VMEvaluationPrimitive.h
@@ -51,7 +51,7 @@ public:
 
     VMFrame* Invoke(VMFrame* frm) override;
     VMFrame* Invoke1(VMFrame* frm) override;
-    void InlineInto(MethodGenerationContext& mgenc,
+    void InlineInto(MethodGenerationContext& mgenc, const Parser& parser,
                     bool mergeScope = true) final;
 
     [[nodiscard]] inline uint8_t GetNumberOfArguments() const final {

--- a/src/vmobjects/VMInvokable.h
+++ b/src/vmobjects/VMInvokable.h
@@ -33,6 +33,7 @@
 class MethodGenerationContext;
 class Variable;
 class VMFrame;
+class Parser;
 
 class VMInvokable : public AbstractVMObject {
 public:
@@ -46,7 +47,7 @@ public:
     virtual VMFrame* Invoke(VMFrame*) = 0;
     virtual VMFrame* Invoke1(VMFrame*) = 0;
     virtual void InlineInto(MethodGenerationContext& mgenc,
-                            bool mergeScope = true) = 0;
+                            const Parser& parser, bool mergeScope = true) = 0;
     virtual void MergeScopeInto(
         MethodGenerationContext& /*unused*/) { /* NOOP for everything but
                                                   VMMethods */

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -37,6 +37,7 @@
 
 class MethodGenerationContext;
 class Interpreter;
+class Parser;
 
 class Jump {
 public:
@@ -169,7 +170,7 @@ public:
 
     [[nodiscard]] std::string AsDebugString() const override;
 
-    void InlineInto(MethodGenerationContext& mgenc,
+    void InlineInto(MethodGenerationContext& mgenc, const Parser& parser,
                     bool mergeScope = true) final;
 
     void AdaptAfterOuterInlined(
@@ -184,7 +185,7 @@ public:
     void Dump(const char* indent, bool printObjects) override;
 
 private:
-    void inlineInto(MethodGenerationContext& mgenc);
+    void inlineInto(MethodGenerationContext& mgenc, const Parser& parser);
     std::priority_queue<BackJump> createBackJumpHeap();
 
     static void prepareBackJumpToCurrentAddress(

--- a/src/vmobjects/VMPrimitive.cpp
+++ b/src/vmobjects/VMPrimitive.cpp
@@ -65,7 +65,7 @@ bool VMPrimitive::IsEmpty() const {
 }
 
 void VMPrimitive::InlineInto(MethodGenerationContext& /*mgenc*/,
-                             bool /*mergeScope*/) {
+                             const Parser& /*parser*/, bool /*mergeScope*/) {
     ErrorExit(
         "VMPrimitive::InlineInto is not supported, and should not be reached");
 }

--- a/src/vmobjects/VMPrimitive.h
+++ b/src/vmobjects/VMPrimitive.h
@@ -66,7 +66,7 @@ public:
         return nullptr;
     };
 
-    void InlineInto(MethodGenerationContext& mgenc,
+    void InlineInto(MethodGenerationContext& mgenc, const Parser& parser,
                     bool mergeScope = true) final;
 
     [[nodiscard]] bool IsPrimitive() const override { return true; };

--- a/src/vmobjects/VMSafePrimitive.cpp
+++ b/src/vmobjects/VMSafePrimitive.cpp
@@ -94,6 +94,7 @@ AbstractVMObject* VMSafeTernaryPrimitive::CloneForMovingGC() const {
 }
 
 void VMSafePrimitive::InlineInto(MethodGenerationContext& /*mgenc*/,
+                                 const Parser& /*parser*/,
                                  bool /*mergeScope*/) {
     ErrorExit(
         "VMPrimitive::InlineInto is not supported, and should not be reached");

--- a/src/vmobjects/VMSafePrimitive.h
+++ b/src/vmobjects/VMSafePrimitive.h
@@ -16,7 +16,7 @@ public:
 
     [[nodiscard]] bool IsPrimitive() const final { return true; };
 
-    void InlineInto(MethodGenerationContext& mgenc,
+    void InlineInto(MethodGenerationContext& mgenc, const Parser& parser,
                     bool mergeScope = true) final;
 
     static VMSafePrimitive* GetSafeUnary(VMSymbol* sig, UnaryPrim prim);

--- a/src/vmobjects/VMTrivialMethod.cpp
+++ b/src/vmobjects/VMTrivialMethod.cpp
@@ -83,8 +83,8 @@ void VMLiteralReturn::WalkObjects(walk_heap_fn walk) {
 }
 
 void VMLiteralReturn::InlineInto(MethodGenerationContext& mgenc,
-                                 bool /*mergeScope*/) {
-    EmitPUSHCONSTANT(mgenc, load_ptr(literal));
+                                 const Parser& parser, bool /*mergeScope*/) {
+    EmitPUSHCONSTANT(mgenc, parser, load_ptr(literal));
 }
 
 VMFrame* VMGlobalReturn::Invoke(VMFrame* frame) {
@@ -117,8 +117,8 @@ VMFrame* VMGlobalReturn::Invoke1(VMFrame* frame) {
 }
 
 void VMGlobalReturn::InlineInto(MethodGenerationContext& mgenc,
-                                bool /*mergeScope*/) {
-    EmitPUSHGLOBAL(mgenc, load_ptr(globalName));
+                                const Parser& parser, bool /*mergeScope*/) {
+    EmitPUSHGLOBAL(mgenc, parser, load_ptr(globalName));
 }
 
 void VMGlobalReturn::WalkObjects(walk_heap_fn walk) {
@@ -177,7 +177,8 @@ VMFrame* VMGetter::Invoke1(VMFrame* frame) {
     return nullptr;
 }
 
-void VMGetter::InlineInto(MethodGenerationContext& mgenc, bool /*mergeScope*/) {
+void VMGetter::InlineInto(MethodGenerationContext& mgenc,
+                          const Parser& /*parser*/, bool /*mergeScope*/) {
     EmitPushFieldWithIndex(mgenc, fieldIndex);
 }
 
@@ -224,7 +225,7 @@ VMFrame* VMSetter::Invoke1(VMFrame* /*unused*/) {
 }
 
 void VMSetter::InlineInto(MethodGenerationContext& /*mgenc*/,
-                          bool /*mergeScope*/) {
+                          const Parser& /*parser*/, bool /*mergeScope*/) {
     ErrorExit("We don't currently support blocks for trivial setters");
 }
 

--- a/src/vmobjects/VMTrivialMethod.h
+++ b/src/vmobjects/VMTrivialMethod.h
@@ -73,7 +73,7 @@ public:
     VMFrame* Invoke(VMFrame* /*frame*/) override;
     VMFrame* Invoke1(VMFrame* /*frame*/) override;
 
-    void InlineInto(MethodGenerationContext& mgenc,
+    void InlineInto(MethodGenerationContext& mgenc, const Parser& parser,
                     bool mergeScope = true) final;
 
     [[nodiscard]] AbstractVMObject* CloneForMovingGC() const final;
@@ -116,7 +116,7 @@ public:
     VMFrame* Invoke(VMFrame* /*frame*/) override;
     VMFrame* Invoke1(VMFrame* /*frame*/) override;
 
-    void InlineInto(MethodGenerationContext& mgenc,
+    void InlineInto(MethodGenerationContext& mgenc, const Parser& parser,
                     bool mergeScope = true) final;
 
     [[nodiscard]] AbstractVMObject* CloneForMovingGC() const final;
@@ -156,7 +156,7 @@ public:
     VMFrame* Invoke(VMFrame* /*frame*/) override;
     VMFrame* Invoke1(VMFrame* /*frame*/) override;
 
-    void InlineInto(MethodGenerationContext& mgenc,
+    void InlineInto(MethodGenerationContext& mgenc, const Parser& parser,
                     bool mergeScope = true) final;
 
     [[nodiscard]] AbstractVMObject* CloneForMovingGC() const final;
@@ -195,7 +195,7 @@ public:
     VMFrame* Invoke(VMFrame* /*frame*/) override;
     VMFrame* Invoke1(VMFrame* /*unused*/) override;
 
-    void InlineInto(MethodGenerationContext& mgenc,
+    void InlineInto(MethodGenerationContext& mgenc, const Parser& parser,
                     bool mergeScope = true) final;
 
     [[nodiscard]] AbstractVMObject* CloneForMovingGC() const final;


### PR DESCRIPTION
This PR introduces `ParserError()` calls to report when code goes over certain limits.
For instance, we can currently only support 256 literal values, because the literal index is encoded as an 8bit number. The same restriction applies for field indexes etc.