### PR TITLE
Update core-lib and add Knapsack and VectorBenchmark to rebench.conf

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -55,6 +55,8 @@ benchmark_suites:
             - WhileLoop:    {extra_args: 100, tags: [yuria ]}
             - Mandelbrot:   {extra_args: 100, tags: [yuria2]}
             - IfNil:        {extra_args: 100, tags: [yuria3]}
+            - Knapsack:     {extra_args: 21, tags: [yuria2]}
+            - VectorBenchmark: {extra_args: 10, tags: [yuria3]}
 
             # - Test:     {invocations: 5, iterations: 1, tags: [yuria2]}
             - TestGC:   {invocations: 5, iterations: 1, extra_args: 100, tags: [yuria2]}


### PR DESCRIPTION
This PR updates the core-lib to the latest version, which includes a few tests and two benchmarks. The benchmarks are added to the benchmarking setup.