### PR TITLE
Add running of integration tests and fix some issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,16 @@ jobs:
           cd cmake-build
           ./SOM++ -cp ../Smalltalk ../TestSuite/TestHarness.som
 
+      - name: Integration Tests
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          export VM=./cmake-build/SOM++
+          export CLASSPATH=Smalltalk
+          export AWFY=core-lib/Examples/AreWeFastYet/Core
+          export TEST_EXPECTATIONS=./integration-tests.yml
+          pytest core-lib/IntegrationTests
+
       - name: Clang Tidy
         if: matrix.compiler == 'clang'
         run: |

--- a/integration-tests.yml
+++ b/integration-tests.yml
@@ -1,0 +1,164 @@
+known_failures:
+  - Tests/int18.som
+
+
+failing_as_unspecified:
+  - Tests/arbint_double_div_err.som
+  - Tests/arbint_double_div_zero_err.som
+  - Tests/arbint_modulus_err.som
+  - Tests/array_at_idx0_err.som
+  - Tests/array_at_idx2_err.som
+  - Tests/array_at_idx_err.som
+  - Tests/array_at_negative_idx_err.som
+  - Tests/array_at_put_idx0_err.som
+  - Tests/array_at_put_idx2_err.som
+  - Tests/call2.som
+
+  # I think this one is about E vs e, but maybe also double rendering and e+59 or e59
+  - Tests/double2.som
+  - Tests/double_double_div.som
+  - Tests/int_double_div.som
+
+  # printing is not specified
+  # 18446744073709552000
+  # or 1.8446744073709552e19 are both valid options
+  - Tests/integer_asdouble.som
+  - Tests/sin.som
+  - Tests/cos.som
+
+
+  # I think IEEE allows for infinities here, and we probably want that
+  - Tests/double1.som
+  - Tests/double3.som
+  - Tests/double4.som
+  - Tests/double5.som
+  - Tests/double6.som
+  - Tests/double7.som
+  - Tests/double8.som
+  - Tests/double9.som
+  - Tests/double11.som
+  - Tests/double12.som
+  - Tests/double13.som
+
+  # Java seems to do some rounding in the transition, but it's also requiring bigints
+  - Tests/double_asinteger.som
+  
+  
+  # - Tests/fromstring.som
+  - Tests/fromstring_double.som
+
+
+  - Tests/double_double_div_err.som
+  - Tests/double_double_div_zero_err1.som
+  - Tests/double_double_div_zero_err2.som
+  - Tests/double_double_div_zero_err3.som
+  - Tests/double_double_div_zero_err4.som
+  - Tests/double_modulus.som
+  - Tests/double_modulus_err.som
+
+  - Tests/exit_double.som
+  - Tests/exit_int_too_big.som
+  - Tests/exit_string.som
+
+  - Tests/fromstring_double_err.som
+  - Tests/fromstring_err.som
+
+  # - Tests/hashcode2.som
+
+  - Tests/inst_var_at_bad_idx.som
+  - Tests/inst_var_at_put_bad_idx.som
+
+  - Tests/instance_fields_overlap/test.som
+  - Tests/instance_fields_overlap2.som
+  
+  - Tests/ic1.som
+
+  # - Tests/int3.som
+  - Tests/int4.som
+  - Tests/int5.som
+  
+  - Tests/int5.som
+  - Tests/int8.som
+  - Tests/int9.som
+
+  - Tests/int10.som
+  - Tests/int11.som
+  - Tests/int12.som
+  - Tests/int13.som
+  - Tests/int14.som
+  - Tests/int15.som
+  - Tests/int16.som
+  - Tests/int17.som
+  - Tests/int19.som
+
+  # too large shifts would take too much memory to support
+  # need to specify this some how
+  - Tests/int20.som
+  - Tests/int21.som
+  - Tests/int22.som
+  - Tests/int23.som
+  - Tests/int24.som
+  - Tests/int25.som
+  - Tests/int27.som
+  - Tests/int28.som
+  - Tests/int30.som
+  - Tests/int31.som
+  # - Tests/int32.som
+
+  - Tests/int_double_div_err.som
+  - Tests/int_double_div_zero_err.som
+  - Tests/int_modulus.som
+  - Tests/int_modulus_err.som
+
+  - Tests/load_string.som
+
+  - Tests/mutate_methods.som
+  - Tests/mutate_superclass_method/test.som
+
+  - Tests/nested_backtrace1.som
+  - Tests/nested_backtrace2.som
+
+  - Tests/obj2.som
+
+  - Tests/array_literals.som
+  - Tests/perform_string.som
+  - Tests/perform_witharguments_wrong.som
+  - Tests/perform_unknown.som
+
+  - Tests/remainder_zero.som
+  - Tests/round.som
+
+  - Tests/shift_right.som
+  - Tests/shift_right_too_big.som
+  - Tests/shift_right_type_err.som
+
+  - Tests/str_escape_unknown.som
+
+  - Tests/system2.som
+  - Tests/system_global_lookup_string.som
+  - Tests/system_global_put_string.som
+
+  - Tests/test_literals_limit_1.som
+  - Tests/unknown_field_write.som
+
+  # This should be specified so that the "set" of fields cannot be changed reflectively
+  # they obtained array can be changed, but it is expected to have no effect.
+  - Tests/mutate_fields.som
+
+  # specify true, false, nil as literals not globals
+  - Tests/system_global.som
+  
+  # utf8 support required
+  - Tests/string_length.som
+  - Tests/is_letters.som
+  - Tests/substring.som
+
+unsupported:
+  # JS doesn't have a sqrt implementation for BigIntegers
+  - Tests/int26.som
+  - Tests/int29.som
+  
+  # som++ specific
+  - Tests/to32bits.som
+  - Tests/binary_super.som
+  - Tests/test_literals_limit_2.som


### PR DESCRIPTION
This PR adds the support for running the SOM integration tests as introduced with https://github.com/SOM-st/SOM/pull/128 and https://github.com/SOM-st/SOM/pull/129.

SOM++ has various tests not passing, often because SOM does not yet specify what the expected behavior should be.