### PR TITLE
Yk integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ SOM.xcodeproj/xcuserdata
 build/Debug
 build/Smalltalk
 build/SOM.build
+
+cmake-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,21 +125,14 @@ target_compile_options(SOM++ PRIVATE
 
 target_include_directories(SOM++ PRIVATE ${SRC_DIR})
 
-target_link_libraries(SOM++)
-
 set(YK_BUILD_TYPE "" CACHE STRING "Yk build type (debug or release). Enables Yk JIT when set.")
 
 if(NOT "${YK_BUILD_TYPE}" STREQUAL "")
   execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cppflags
     OUTPUT_VARIABLE YK_CPPFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
-  string(REGEX REPLACE " *-DUSE_YK" "" YK_CPPFLAGS "${YK_CPPFLAGS}")
 
   execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cflags
     OUTPUT_VARIABLE YK_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
-  # Keep -flto: Yk IR passes (--yk-embed-ir, --yk-patch-control-point, etc.)
-  # need LLVM bitcode at link time. Cap LTO at O0 via --lto-O0 to avoid the
-  # YkIRWriter BBCache crash caused by O3 cross-module inlining creating PHI
-  # nodes whose incoming blocks fall outside BBCache.
 
   execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --ldflags
     OUTPUT_VARIABLE YK_LDFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
@@ -154,7 +147,7 @@ if(NOT "${YK_BUILD_TYPE}" STREQUAL "")
 
   target_compile_definitions(SOM++ PRIVATE USE_YK)
   target_compile_options(SOM++ PRIVATE ${YK_CPPFLAGS_LIST} ${YK_CFLAGS_LIST} -fno-exceptions -fno-jump-tables)
-  target_link_options(SOM++ PRIVATE ${YK_LDFLAGS_LIST} -Wl,--lto-O0)
+  target_link_options(SOM++ PRIVATE ${YK_LDFLAGS_LIST})
   target_link_libraries(SOM++ ${YK_LIBS_LIST})
 
   message(STATUS "Yk JIT enabled (${YK_BUILD_TYPE})")
@@ -162,12 +155,8 @@ if(NOT "${YK_BUILD_TYPE}" STREQUAL "")
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  if("${YK_BUILD_TYPE}" STREQUAL "")
-    target_compile_options(SOM++ PRIVATE -O3 -flto)
-    target_link_options(SOM++ PRIVATE -flto)
-  else()
-    target_compile_options(SOM++ PRIVATE -O2)
-  endif()
+  target_compile_options(SOM++ PRIVATE -O3 -flto)
+  target_link_options(SOM++ PRIVATE -flto)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,9 +136,10 @@ if(NOT "${YK_BUILD_TYPE}" STREQUAL "")
 
   execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cflags
     OUTPUT_VARIABLE YK_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
-  # Strip -flto from yk-config cflags: LTO+O3 crashes YkIRWriter (BBCache lookup
-  # fails on PHI nodes created by cross-module inlining). Use O2 without LTO.
-  string(REGEX REPLACE " *-flto" "" YK_CFLAGS "${YK_CFLAGS}")
+  # Keep -flto: Yk IR passes (--yk-embed-ir, --yk-patch-control-point, etc.)
+  # need LLVM bitcode at link time. Cap LTO at O0 via --lto-O0 to avoid the
+  # YkIRWriter BBCache crash caused by O3 cross-module inlining creating PHI
+  # nodes whose incoming blocks fall outside BBCache.
 
   execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --ldflags
     OUTPUT_VARIABLE YK_LDFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
@@ -152,8 +153,8 @@ if(NOT "${YK_BUILD_TYPE}" STREQUAL "")
   separate_arguments(YK_LIBS_LIST UNIX_COMMAND "${YK_LIBS}")
 
   target_compile_definitions(SOM++ PRIVATE USE_YK)
-  target_compile_options(SOM++ PRIVATE ${YK_CPPFLAGS_LIST} ${YK_CFLAGS_LIST} -fno-exceptions)
-  target_link_options(SOM++ PRIVATE ${YK_LDFLAGS_LIST})
+  target_compile_options(SOM++ PRIVATE ${YK_CPPFLAGS_LIST} ${YK_CFLAGS_LIST} -fno-exceptions -fno-jump-tables)
+  target_link_options(SOM++ PRIVATE ${YK_LDFLAGS_LIST} -Wl,--lto-O0)
   target_link_libraries(SOM++ ${YK_LIBS_LIST})
 
   message(STATUS "Yk JIT enabled (${YK_BUILD_TYPE})")
@@ -165,8 +166,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
     target_compile_options(SOM++ PRIVATE -O3 -flto)
     target_link_options(SOM++ PRIVATE -flto)
   else()
-    # LTO with O3 crashes YkIRWriter (PHI incoming blocks outside BBCache after
-    # cross-module inlining). Use O2 without LTO for Yk release builds.
     target_compile_options(SOM++ PRIVATE -O2)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,9 +127,48 @@ target_include_directories(SOM++ PRIVATE ${SRC_DIR})
 
 target_link_libraries(SOM++)
 
+set(YK_BUILD_TYPE "" CACHE STRING "Yk build type (debug or release). Enables Yk JIT when set.")
+
+if(NOT "${YK_BUILD_TYPE}" STREQUAL "")
+  execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cppflags
+    OUTPUT_VARIABLE YK_CPPFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
+  string(REGEX REPLACE " *-DUSE_YK" "" YK_CPPFLAGS "${YK_CPPFLAGS}")
+
+  execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cflags
+    OUTPUT_VARIABLE YK_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
+  # Strip -flto from yk-config cflags: LTO+O3 crashes YkIRWriter (BBCache lookup
+  # fails on PHI nodes created by cross-module inlining). Use O2 without LTO.
+  string(REGEX REPLACE " *-flto" "" YK_CFLAGS "${YK_CFLAGS}")
+
+  execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --ldflags
+    OUTPUT_VARIABLE YK_LDFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
+
+  execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --libs
+    OUTPUT_VARIABLE YK_LIBS OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
+
+  separate_arguments(YK_CPPFLAGS_LIST UNIX_COMMAND "${YK_CPPFLAGS}")
+  separate_arguments(YK_CFLAGS_LIST UNIX_COMMAND "${YK_CFLAGS}")
+  separate_arguments(YK_LDFLAGS_LIST UNIX_COMMAND "${YK_LDFLAGS}")
+  separate_arguments(YK_LIBS_LIST UNIX_COMMAND "${YK_LIBS}")
+
+  target_compile_definitions(SOM++ PRIVATE USE_YK)
+  target_compile_options(SOM++ PRIVATE ${YK_CPPFLAGS_LIST} ${YK_CFLAGS_LIST} -fno-exceptions)
+  target_link_options(SOM++ PRIVATE ${YK_LDFLAGS_LIST})
+  target_link_libraries(SOM++ ${YK_LIBS_LIST})
+
+  message(STATUS "Yk JIT enabled (${YK_BUILD_TYPE})")
+  message(STATUS "  Ensure CMAKE_CXX_COMPILER is set to: yk-config ${YK_BUILD_TYPE} --cc")
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  target_compile_options(SOM++ PRIVATE -O3 -flto)
-  target_link_options(SOM++ PRIVATE -flto)
+  if("${YK_BUILD_TYPE}" STREQUAL "")
+    target_compile_options(SOM++ PRIVATE -O3 -flto)
+    target_link_options(SOM++ PRIVATE -flto)
+  else()
+    # LTO with O3 crashes YkIRWriter (PHI incoming blocks outside BBCache after
+    # cross-module inlining). Use O2 without LTO for Yk release builds.
+    target_compile_options(SOM++ PRIVATE -O2)
+  endif()
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/README.md
+++ b/README.md
@@ -46,6 +46,36 @@ A simple Hello World program is executed with:
 ./SOM++ -cp ../Smalltalk ../Examples/Hello.som
 ```
 
+Yk JIT
+------
+
+SOM++ can be built with the [Yk](https://github.com/ykjit/yk) meta-tracing JIT.
+Yk requires its own modified clang toolchain, supplied via `yk-config`.
+The `yk_config` path at the top of `justfile` must point to it.
+
+```bash
+just build-yk      # Yk debug build  → cmake-yk/SOM++
+just build-yk-release  # Yk release build
+just hello-yk      # run Hello.som under the JIT
+just test-yk       # run full SOM test suite under the JIT
+just awfy          # run Are-We-Fast-Yet benchmarks (plain)
+just awfy-compare  # run AWFY benchmarks, plain vs Yk side-by-side
+```
+
+To inspect JIT activity, set environment variables before running:
+
+```bash
+# lower the hot-loop threshold so tracing fires quickly:
+YK_HOT_THRESHOLD=5 cmake-yk/SOM++ -cp Smalltalk Examples/VeryHeavyLoop.som
+
+# write tracing statistics to a JSON file:
+YKD_LOG_STATS=ykstats.json cmake-yk/SOM++ -cp Smalltalk Examples/VeryHeavyLoop.som
+cat ykstats.json
+# traces_compiled_ok > 0 and trace_executions > 0 confirm the JIT is working.
+```
+
+See `YK_INTEGRATION.md` for a full account of the integration.
+
 Information on previous authors are included in the AUTHORS file. This code is
 distributed under the MIT License. Please see the LICENSE file for details.
 Additional documentation, detailing for instance the object model and how to

--- a/YK_INTEGRATION.md
+++ b/YK_INTEGRATION.md
@@ -1,0 +1,240 @@
+# Integrating a C/C++ Interpreter with Yk
+
+This document records every issue encountered and how it was fixed when integrating
+SOM++ (a C++ Smalltalk VM) with [Yk](https://github.com/ykjit/yk), a meta-tracing
+JIT for bytecode interpreters.  It is written for the next engineer who wants to
+do the same with a different interpreter.
+
+---
+
+## Overview
+
+Yk instruments the interpreter binary with a set of LLVM LTO passes and a Rust
+runtime (`libykrt`).  The interpreter must:
+
+1. Call `yk_mt_control_point(mt, &location[pc])` once per bytecode dispatch.
+2. Have exactly one call site for `yk_mt_control_point` in the binary.
+3. Store one `YkLocation` per bytecode slot, initialized with `yk_location_new()`.
+
+---
+
+## Step-by-step integration guide
+
+### 1  Build system
+
+Install `yk-config` (provided by yk-csom) and use it to obtain the compiler and
+linker flags:
+
+```cmake
+execute_process(COMMAND yk-config debug --cc OUTPUT_VARIABLE YK_CC ...)
+set(CMAKE_CXX_COMPILER "${YK_CC}++")
+```
+
+Pass the Yk link flags at link time (they are LTO passes, not compile-time flags):
+
+```cmake
+execute_process(COMMAND yk-config debug --ldflags OUTPUT_VARIABLE YK_LDFLAGS ...)
+target_link_options(myvm PRIVATE ${YK_LDFLAGS})
+```
+
+The `-yk-patch-control-point` and `-yk-no-vectorize` warnings emitted by clang
+during *compilation* are harmless — those flags are linker-time flags and are
+ignored at compile time.
+
+### 2  Exactly one control point
+
+Yk requires **one** call site for `yk_mt_control_point` in the entire binary.  In a
+dispatch-loop interpreter this usually falls out naturally.  In a computed-goto
+interpreter, every `DISPATCH` macro needs to jump to a single trampoline label
+that contains the one call:
+
+```cpp
+// In interpreter header
+#define DISPATCH() goto YK_DISPATCH_START
+
+// In interpreter Start():
+YK_DISPATCH_START:
+    yk_mt_control_point(global_yk_mt,
+        &static_cast<YkLocation*>(method->yklocs)[bytecodeIndexGlobal]);
+    goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]];
+```
+
+If the interpreter `Start()` function was templated (e.g.
+`template<bool PrintBytecodes>`), **de-templatize it first**.  Each template
+instantiation is a separate function and therefore produces a separate call site,
+triggering the "Unexpected number of control point calls: 2 expected: 1" panic.
+
+Replace `if constexpr` with ordinary `if`, and change callers from
+`Interpreter::Start<flag>()` to `Interpreter::Start(flag)`.
+
+### 3  `YkLocation` array per method
+
+Allocate and initialize one `YkLocation` per bytecode slot when a method object
+is created:
+
+```cpp
+yklocs = malloc(bcCount * sizeof(YkLocation));
+for (size_t i = 0; i < bcCount; i++)
+    static_cast<YkLocation*>(yklocs)[i] = yk_location_new();
+```
+
+Free them in the destructor:
+
+```cpp
+for (size_t i = 0; i < bcLength; i++)
+    if (!yk_location_is_null(static_cast<YkLocation*>(yklocs)[i]))
+        yk_location_drop(static_cast<YkLocation*>(yklocs)[i]);
+free(yklocs);
+```
+
+**Critical layout bug (C++):** If the method object uses an inline-storage trick
+where constants and bytecodes are stored immediately after the struct in the same
+allocation, adding the `yklocs` pointer field shifts the inline data offset.
+
+**Do not** compute the inline-data start by counting trailing pointer fields:
+```cpp
+// WRONG when yklocs is added as a third trailing pointer:
+indexableFields = (gc_oop_t*)(&indexableFields + 2);
+bytecodes       = (uint8_t*)(&indexableFields  + 2 + nConstants);
+```
+
+**Use `this + 1` instead**, which always points one struct past the end of the
+current object regardless of how many pointer-sized fields the struct contains:
+
+```cpp
+indexableFields = reinterpret_cast<gc_oop_t*>(this + 1);
+bytecodes       = reinterpret_cast<uint8_t*>(indexableFields + numberOfConstants);
+```
+
+Apply the same fix to any `CloneForMovingGC` / copy constructor that rebuilds
+these pointers.
+
+### 4  C++ global constructors and the shadow stack
+
+Yk's shadow stack pass runs before the `--yk-outline-untraceable` pass.  Functions
+that are called by C++ global constructors (which run **before `main()`**) will be
+instrumented by the shadow stack pass but will execute before `main()` initialises
+the shadow stack global (`shadowstack_0 = malloc(...)`).  The result is a SIGSEGV
+or memory corruption.
+
+**Fix A — avoid static-storage `std::string` members.**  Every
+`static const std::string` member of a class with static storage duration triggers
+a global constructor that calls into instrumented code.  Replace them with
+`static constexpr const char*`.  This alone eliminates many global constructor
+crashes.
+
+### 5  LTO incompatibility with `yk-config release`
+
+
+`yk-config release --cflags` injects `-flto`, which causes every `.cpp` file to be
+compiled to LLVM bitcode rather than native object files.  The Yk-modified lld then
+runs LTO with `-O3`, applying cross-module inlining before the Yk `YkIRWriter` pass
+serialises the IR.
+
+**The crash:** `std::out_of_range: map::at` in `YkIRWriter::serialiseFunc` at
+`BBCache.at(IB)`.  The root cause is that cross-module inlining can produce PHI
+nodes whose incoming basic blocks come from inlined callee bodies.  Those blocks
+were never registered in `BBCache` (which only tracks blocks following the
+Yk-required `TracingCheck → Record → Serialise` three-block pattern), so the lookup
+throws.
+
+**The fix in `CMakeLists.txt`** (yksompp, no ykllvm changes needed):
+
+```cmake
+# Strip -flto injected by yk-config to avoid the YkIRWriter BBCache crash.
+string(REGEX REPLACE " *-flto" "" YK_CFLAGS "${YK_CFLAGS}")
+```
+
+And for the Release cmake target, skip `-O3 -flto` when a Yk build type is set:
+
+```cmake
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  if("${YK_BUILD_TYPE}" STREQUAL "")
+    target_compile_options(SOM++ PRIVATE -O3 -flto)
+    target_link_options(SOM++ PRIVATE -flto)
+  else()
+    # LTO+O3 crashes YkIRWriter. Use O2 without LTO for Yk release builds.
+    target_compile_options(SOM++ PRIVATE -O2)
+  endif()
+endif()
+```
+
+This produces native `.o` objects that lld links without LTO, avoiding the
+`BBCache` lookup entirely.  The Yk linker passes (`--yk-shadow-stack`,
+`--yk-embed-ir`, etc.) still run at link time through `-mllvm=` flags and are
+unaffected.
+
+**Note:** until the upstream `YkIRWriter` is fixed, a Yk release build uses `-O2`
+rather than `-O3`.  The performance gap is small compared with the JIT speedup once
+traces compile successfully.
+
+### 6  `indirectbr` and computed-goto dispatch
+
+Yk's tracer does not support the LLVM `indirectbr` instruction.  Computed gotos
+(`goto* table[opcode]`) compile to `indirectbr` in LLVM IR, so any interpreter
+dispatch loop that uses them will cause every trace to abort immediately after the
+control point.
+
+**Symptom:** all `YKD_LOG_STATS` counters are zero despite the interpreter running:
+```json
+{ "traces_recorded_ok": 0, "traces_recorded_err": 0, "traces_compiled_ok": 0, ... }
+```
+
+**Root cause:** the control point is reached and tracing begins, but the very next
+instruction is `indirectbr`.  Yk aborts the recording before a single instruction
+is captured, so no trace ever completes.
+
+**Workaround — switch-based dispatch for `USE_YK` builds:**
+
+Replace the computed-goto dispatch with a `switch` statement when `USE_YK` is
+defined:
+
+```cpp
+#ifdef USE_YK
+  switch (currentBytecodes[bytecodeIndexGlobal]) {
+    case BC_PUSH_LOCAL:    goto op_push_local;
+    case BC_PUSH_ARGUMENT: goto op_push_argument;
+    // ...
+  }
+#else
+  goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]];
+#endif
+```
+
+A `switch` compiles to `br` with multiple successors (not `indirectbr`), which Yk
+can trace through.  This is the recommended approach and avoids any changes to the
+ykllvm fork.
+
+**Alternative:** implement `indirectbr` support in Yk's tracer (upstream work).
+
+---
+
+## Diagnostic tips
+
+- **"Unexpected number of control point calls: N expected: 1"** — you have multiple
+  call sites, most likely from template instantiation.  De-templatize.
+- **SIGSEGV in `__cxx_global_var_init`** — a global constructor calls shadow-stack-
+  instrumented code before `main()` initializes the stack.  Check for
+  `static const std::string` members; replace with `constexpr const char*`.
+- **SIGSEGV in constructor (e.g. `PrimitiveLoader`)** — same root cause as above;
+  eliminate remaining `static const std::string` members.
+- **`std::out_of_range: map::at`** in `YkIRWriter` at link time —
+  LTO cross-module inlining broke the Yk IR structure.
+  Strip `-flto` from `yk-config --cflags` in `CMakeLists.txt` (see §5).
+- **YkLocation state corruption (`state == 2`)** — the `yklocs` pointer field is
+  being overwritten by inline-constant storage.  Apply the `this + 1` fix.
+- **All `YKD_LOG_STATS` counters are zero** — tracing is aborting immediately.
+  Most likely cause: computed-goto dispatch.  Switch to `switch`-based dispatch
+  under `#ifdef USE_YK` (see §6).
+
+---
+
+## Runtime verification
+
+```sh
+# Non-Yk build should pass all tests unaffected:
+just test-som
+
+# Yk build should print "Hello, World from SOM":
+just hello-yk
+```

--- a/YK_INTEGRATION.md
+++ b/YK_INTEGRATION.md
@@ -1,9 +1,8 @@
 # Integrating a C/C++ Interpreter with Yk
 
-This document records every issue encountered and how it was fixed when integrating
-SOM++ (a C++ Smalltalk VM) with [Yk](https://github.com/ykjit/yk), a meta-tracing
-JIT for bytecode interpreters.  It is written for the next engineer who wants to
-do the same with a different interpreter.
+This document records what is required to integrate a C/C++ bytecode interpreter
+with [Yk](https://github.com/ykjit/yk), a meta-tracing JIT.  It is written for
+the next engineer who wants to do the same with a different interpreter.
 
 ---
 
@@ -22,50 +21,62 @@ runtime (`libykrt`).  The interpreter must:
 
 ### 1  Build system
 
-Install `yk-config` (provided by yk-csom) and use it to obtain the compiler and
-linker flags:
+`yk-config` (provided by yk-csom) supplies the compiler and linker flags.  Use
+the Yk-modified clang as the C++ compiler and pass all flags through CMake:
 
 ```cmake
-execute_process(COMMAND yk-config debug --cc OUTPUT_VARIABLE YK_CC ...)
+execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cc OUTPUT_VARIABLE YK_CC ...)
 set(CMAKE_CXX_COMPILER "${YK_CC}++")
+
+execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cflags  OUTPUT_VARIABLE YK_CFLAGS ...)
+execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --ldflags OUTPUT_VARIABLE YK_LDFLAGS ...)
+execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --libs    OUTPUT_VARIABLE YK_LIBS ...)
+
+target_compile_options(SOM++ PRIVATE ${YK_CFLAGS_LIST} -fno-exceptions -fno-jump-tables)
+target_link_options(SOM++ PRIVATE ${YK_LDFLAGS_LIST} -Wl,--lto-O0)
+target_link_libraries(SOM++ ${YK_LIBS_LIST})
 ```
 
-Pass the Yk link flags at link time (they are LTO passes, not compile-time flags):
+`yk-config --cflags` injects `-flto`.  Do **not** strip it — the Yk linker passes
+(`--yk-embed-ir`, `--yk-patch-control-point`, etc.) operate on LLVM bitcode produced
+by LTO; without it they silently no-op and tracing never fires.
 
-```cmake
-execute_process(COMMAND yk-config debug --ldflags OUTPUT_VARIABLE YK_LDFLAGS ...)
-target_link_options(myvm PRIVATE ${YK_LDFLAGS})
-```
+Add `-Wl,--lto-O0` to cap LTO optimisation.  The default LTO level (`-O3`) triggers
+a `YkIRWriter` crash via cross-module inlining; `--lto-O0` disables that inlining.
+
+Add `-fno-jump-tables` so the compiler does not lower `switch` statements into
+indirect-jump tables (which produce untraceable `indirectbr` IR — see §4).
 
 The `-yk-patch-control-point` and `-yk-no-vectorize` warnings emitted by clang
-during *compilation* are harmless — those flags are linker-time flags and are
-ignored at compile time.
+during *compilation* are harmless — those are linker-time flags ignored at compile
+time.
 
 ### 2  Exactly one control point
 
 Yk requires **one** call site for `yk_mt_control_point` in the entire binary.  In a
-dispatch-loop interpreter this usually falls out naturally.  In a computed-goto
-interpreter, every `DISPATCH` macro needs to jump to a single trampoline label
-that contains the one call:
+computed-goto interpreter, every `DISPATCH` macro must jump to a single trampoline
+label that contains the one call.  The trampoline then dispatches to the handler via
+a `switch` (not `goto*` — see §4):
 
 ```cpp
-// In interpreter header
-#define DISPATCH() goto YK_DISPATCH_START
+// In interpreter header (USE_YK build)
+#define DISPATCH_NOGC() goto YK_DISPATCH_START
 
 // In interpreter Start():
 YK_DISPATCH_START:
     yk_mt_control_point(global_yk_mt,
         &static_cast<YkLocation*>(method->yklocs)[bytecodeIndexGlobal]);
-    goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]];
+    switch (currentBytecodes[bytecodeIndexGlobal]) {
+        case BC_PUSH_LOCAL: goto LABEL_BC_PUSH_LOCAL;
+        // ... one case per opcode
+    }
 ```
 
-If the interpreter `Start()` function was templated (e.g.
-`template<bool PrintBytecodes>`), **de-templatize it first**.  Each template
-instantiation is a separate function and therefore produces a separate call site,
-triggering the "Unexpected number of control point calls: 2 expected: 1" panic.
-
-Replace `if constexpr` with ordinary `if`, and change callers from
-`Interpreter::Start<flag>()` to `Interpreter::Start(flag)`.
+If the interpreter `Start()` function is templated (e.g.
+`template<bool PrintBytecodes>`), **de-templatize it first** — each instantiation
+is a separate function with its own call site.  Replace `if constexpr` with
+ordinary `if` and change callers from `Interpreter::Start<flag>()` to
+`Interpreter::Start(flag)`.
 
 ### 3  `YkLocation` array per method
 
@@ -87,19 +98,17 @@ for (size_t i = 0; i < bcLength; i++)
 free(yklocs);
 ```
 
-**Critical layout bug (C++):** If the method object uses an inline-storage trick
-where constants and bytecodes are stored immediately after the struct in the same
-allocation, adding the `yklocs` pointer field shifts the inline data offset.
+**Inline-storage layout (C++):** If the method object stores constants and bytecodes
+immediately after the struct in the same allocation, adding the `yklocs` pointer
+field shifts the inline data offset.  Do not count trailing pointer fields manually:
 
-**Do not** compute the inline-data start by counting trailing pointer fields:
 ```cpp
 // WRONG when yklocs is added as a third trailing pointer:
 indexableFields = (gc_oop_t*)(&indexableFields + 2);
 bytecodes       = (uint8_t*)(&indexableFields  + 2 + nConstants);
 ```
 
-**Use `this + 1` instead**, which always points one struct past the end of the
-current object regardless of how many pointer-sized fields the struct contains:
+Use `this + 1` instead, which is always correct regardless of field count:
 
 ```cpp
 indexableFields = reinterpret_cast<gc_oop_t*>(this + 1);
@@ -109,123 +118,131 @@ bytecodes       = reinterpret_cast<uint8_t*>(indexableFields + numberOfConstants
 Apply the same fix to any `CloneForMovingGC` / copy constructor that rebuilds
 these pointers.
 
-### 4  C++ global constructors and the shadow stack
+### 4  Switch-based dispatch (not computed goto)
 
-Yk's shadow stack pass runs before the `--yk-outline-untraceable` pass.  Functions
-that are called by C++ global constructors (which run **before `main()`**) will be
-instrumented by the shadow stack pass but will execute before `main()` initialises
-the shadow stack global (`shadowstack_0 = malloc(...)`).  The result is a SIGSEGV
-or memory corruption.
+Yk's tracer cannot trace LLVM `indirectbr` instructions.  Computed gotos
+(`goto* table[opcode]`) compile to `indirectbr`, so every trace aborts immediately
+after the control point — all `YKD_LOG_STATS` counters will be zero.
 
-**Fix A — avoid static-storage `std::string` members.**  Every
-`static const std::string` member of a class with static storage duration triggers
-a global constructor that calls into instrumented code.  Replace them with
-`static constexpr const char*`.  This alone eliminates many global constructor
-crashes.
-
-### 5  LTO incompatibility with `yk-config release`
-
-
-`yk-config release --cflags` injects `-flto`, which causes every `.cpp` file to be
-compiled to LLVM bitcode rather than native object files.  The Yk-modified lld then
-runs LTO with `-O3`, applying cross-module inlining before the Yk `YkIRWriter` pass
-serialises the IR.
-
-**The crash:** `std::out_of_range: map::at` in `YkIRWriter::serialiseFunc` at
-`BBCache.at(IB)`.  The root cause is that cross-module inlining can produce PHI
-nodes whose incoming basic blocks come from inlined callee bodies.  Those blocks
-were never registered in `BBCache` (which only tracks blocks following the
-Yk-required `TracingCheck → Record → Serialise` three-block pattern), so the lookup
-throws.
-
-**The fix in `CMakeLists.txt`** (yksompp, no ykllvm changes needed):
-
-```cmake
-# Strip -flto injected by yk-config to avoid the YkIRWriter BBCache crash.
-string(REGEX REPLACE " *-flto" "" YK_CFLAGS "${YK_CFLAGS}")
-```
-
-And for the Release cmake target, skip `-O3 -flto` when a Yk build type is set:
-
-```cmake
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  if("${YK_BUILD_TYPE}" STREQUAL "")
-    target_compile_options(SOM++ PRIVATE -O3 -flto)
-    target_link_options(SOM++ PRIVATE -flto)
-  else()
-    # LTO+O3 crashes YkIRWriter. Use O2 without LTO for Yk release builds.
-    target_compile_options(SOM++ PRIVATE -O2)
-  endif()
-endif()
-```
-
-This produces native `.o` objects that lld links without LTO, avoiding the
-`BBCache` lookup entirely.  The Yk linker passes (`--yk-shadow-stack`,
-`--yk-embed-ir`, etc.) still run at link time through `-mllvm=` flags and are
-unaffected.
-
-**Note:** until the upstream `YkIRWriter` is fixed, a Yk release build uses `-O2`
-rather than `-O3`.  The performance gap is small compared with the JIT speedup once
-traces compile successfully.
-
-### 6  `indirectbr` and computed-goto dispatch
-
-Yk's tracer does not support the LLVM `indirectbr` instruction.  Computed gotos
-(`goto* table[opcode]`) compile to `indirectbr` in LLVM IR, so any interpreter
-dispatch loop that uses them will cause every trace to abort immediately after the
-control point.
-
-**Symptom:** all `YKD_LOG_STATS` counters are zero despite the interpreter running:
-```json
-{ "traces_recorded_ok": 0, "traces_recorded_err": 0, "traces_compiled_ok": 0, ... }
-```
-
-**Root cause:** the control point is reached and tracing begins, but the very next
-instruction is `indirectbr`.  Yk aborts the recording before a single instruction
-is captured, so no trace ever completes.
-
-**Workaround — switch-based dispatch for `USE_YK` builds:**
-
-Replace the computed-goto dispatch with a `switch` statement when `USE_YK` is
-defined:
+Replace the computed-goto dispatch with a `switch` under `#ifdef USE_YK`.  A
+`switch` compiles to `br` with multiple successors, which Yk can trace through:
 
 ```cpp
 #ifdef USE_YK
   switch (currentBytecodes[bytecodeIndexGlobal]) {
-    case BC_PUSH_LOCAL:    goto op_push_local;
-    case BC_PUSH_ARGUMENT: goto op_push_argument;
-    // ...
+    case BC_PUSH_LOCAL:    goto LABEL_BC_PUSH_LOCAL;
+    case BC_PUSH_ARGUMENT: goto LABEL_BC_PUSH_ARGUMENT;
+    // ... one case per opcode
+    default: __builtin_unreachable();
   }
 #else
   goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]];
 #endif
 ```
 
-A `switch` compiles to `br` with multiple successors (not `indirectbr`), which Yk
-can trace through.  This is the recommended approach and avoids any changes to the
-ykllvm fork.
+Also add `-fno-jump-tables` to compile options (§1) so the compiler does not lower
+the `switch` back into an indirect-jump table.
 
-**Alternative:** implement `indirectbr` support in Yk's tracer (upstream work).
+### 5  C++ global constructors and the shadow stack
 
----
+Yk's shadow-stack pass instruments every function.  Functions called from C++ global
+constructors run **before `main()`** initialises the shadow stack, which will
+corrupt memory.
 
-## Diagnostic tips
+**Fix A — eliminate static-storage `std::string` members.**  Replace
+`static const std::string` members of classes with static storage duration with
+`static constexpr const char*` to eliminate the ctor.
 
-- **"Unexpected number of control point calls: N expected: 1"** — you have multiple
-  call sites, most likely from template instantiation.  De-templatize.
-- **SIGSEGV in `__cxx_global_var_init`** — a global constructor calls shadow-stack-
-  instrumented code before `main()` initializes the stack.  Check for
-  `static const std::string` members; replace with `constexpr const char*`.
-- **SIGSEGV in constructor (e.g. `PrimitiveLoader`)** — same root cause as above;
-  eliminate remaining `static const std::string` members.
-- **`std::out_of_range: map::at`** in `YkIRWriter` at link time —
-  LTO cross-module inlining broke the Yk IR structure.
-  Strip `-flto` from `yk-config --cflags` in `CMakeLists.txt` (see §5).
-- **YkLocation state corruption (`state == 2`)** — the `yklocs` pointer field is
-  being overwritten by inline-constant storage.  Apply the `this + 1` fix.
-- **All `YKD_LOG_STATS` counters are zero** — tracing is aborting immediately.
-  Most likely cause: computed-goto dispatch.  Switch to `switch`-based dispatch
-  under `#ifdef USE_YK` (see §6).
+**Fix B — lazy singleton for static instances.**  Convert any class with a static
+global instance whose constructor calls instrumented code to a function-local static,
+so construction is deferred until after `main()` runs:
+
+```cpp
+// Replace: static PrimitiveLoader loader;  (eager global ctor)
+// With a lazy accessor:
+static PrimitiveLoader& GetLoader() {
+    static PrimitiveLoader instance;   // initialized on first call
+    return instance;
+}
+// All static methods: loader.foo(x) → GetLoader().foo(x)
+```
+
+### 6  Private-linkage globals (ykrt change)
+
+`--yk-embed-ir` serialises every LLVM global into the binary.  At runtime,
+`GlobalDecl::eval()` in ykrt resolves each global's address via `dlsym()`.
+Private/local-linkage globals — string literals (`.str.N`), `__PRETTY_FUNCTION__`
+constants — are not in the dynamic symbol table, so `dlsym` returns null.
+
+The linker pass also creates `__yk_globalvar_ptrs`: an array indexed by global
+declaration order containing the runtime address of every global including private
+ones.  Update `eval_globaldecls` to use it as a fallback:
+
+```rust
+// ykrt/src/compile/jitc_yk/aot_ir.rs
+
+pub(crate) fn eval_globaldecls(&mut self) {
+    let cn = CString::new("__yk_globalvar_ptrs").unwrap();
+    let gvar_ptrs = unsafe {
+        libc::dlsym(std::ptr::null_mut(), cn.as_c_str().as_ptr())
+    } as *const *const c_void;
+
+    for (idx, g) in self.global_decls.iter_mut().enumerate() {
+        g.eval(idx, gvar_ptrs);
+    }
+}
+
+pub(crate) fn eval(&mut self, idx: usize, gvar_ptrs: *const *const c_void) {
+    let cn = CString::new(&*self.name).unwrap();
+    let ptr = unsafe {
+        libc::dlsym(std::ptr::null_mut(), cn.as_c_str().as_ptr())
+    } as *const c_void;
+    if !ptr.is_null() {
+        self.eval = Some(ConstVal {
+            tyidx: self.tyidx,
+            bytes: Vec::from((ptr as usize).to_ne_bytes()),
+        });
+        return;
+    }
+    // Fall back to __yk_globalvar_ptrs[idx] for private/local-linkage globals.
+    if !gvar_ptrs.is_null() {
+        let fallback = unsafe { *gvar_ptrs.add(idx) };
+        if !fallback.is_null() {
+            self.eval = Some(ConstVal {
+                tyidx: self.tyidx,
+                bytes: Vec::from((fallback as usize).to_ne_bytes()),
+            });
+        }
+    }
+    // TLS globals remain unevaluated — the JIT handles them separately.
+}
+```
+
+### 7  1-bit stores in the x64 JIT backend (ykrt change)
+
+LTO at `-O0` keeps `bool` temporaries as `i1` alloca slots with explicit stores.
+The x64 backend has no 1-bit move instruction; widen `i1` to `i8` (a `bool`'s
+backing allocation is always at least 1 byte):
+
+```rust
+// ykrt/src/compile/j2/x64/x64hir_to_asm.rs
+// register-value store branch:
+match val_bitw {
+    1 | 8 => IcedInst::with2(Code::Mov_rm8_r8, memop, valr.to_reg8()),
+    16    => IcedInst::with2(Code::Mov_rm16_r16, memop, valr.to_reg16()),
+    32    => IcedInst::with2(Code::Mov_rm32_r32, memop, valr.to_reg32()),
+    64    => IcedInst::with2(Code::Mov_rm64_r64, memop, valr.to_reg64()),
+    x     => todo!("{x}"),
+}
+// immediate-value store branch:
+match val_bitw {
+    1 | 8 => IcedInst::with2(Code::Mov_rm8_imm8, memop, imm),
+    16    => IcedInst::with2(Code::Mov_rm16_imm16, memop, imm),
+    32    => IcedInst::with2(Code::Mov_rm32_imm32, memop, imm),
+    64    => IcedInst::with2(Code::Mov_rm64_imm32, memop, imm),
+    x     => todo!("{x}"),
+}
+```
 
 ---
 
@@ -237,4 +254,10 @@ just test-som
 
 # Yk build should print "Hello, World from SOM":
 just hello-yk
+
+# Verify tracing actually fires (all-zero stats means tracing never ran):
+YK_HOT_THRESHOLD=5 YKD_LOG_STATS=ykstats.json \
+  cmake-yk/SOM++ -cp Smalltalk Examples/VeryHeavyLoop.som
+cat ykstats.json
+# Expected: traces_recorded_ok > 0, traces_compiled_ok > 0, trace_executions > 0.
 ```

--- a/YK_INTEGRATION.md
+++ b/YK_INTEGRATION.md
@@ -28,21 +28,22 @@ the Yk-modified clang as the C++ compiler and pass all flags through CMake:
 execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cc OUTPUT_VARIABLE YK_CC ...)
 set(CMAKE_CXX_COMPILER "${YK_CC}++")
 
-execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cflags  OUTPUT_VARIABLE YK_CFLAGS ...)
-execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --ldflags OUTPUT_VARIABLE YK_LDFLAGS ...)
-execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --libs    OUTPUT_VARIABLE YK_LIBS ...)
+execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cppflags OUTPUT_VARIABLE YK_CPPFLAGS ...)
+execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cflags   OUTPUT_VARIABLE YK_CFLAGS ...)
+execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --ldflags  OUTPUT_VARIABLE YK_LDFLAGS ...)
+execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --libs     OUTPUT_VARIABLE YK_LIBS ...)
 
-target_compile_options(SOM++ PRIVATE ${YK_CFLAGS_LIST} -fno-exceptions -fno-jump-tables)
-target_link_options(SOM++ PRIVATE ${YK_LDFLAGS_LIST} -Wl,--lto-O0)
+target_compile_definitions(SOM++ PRIVATE USE_YK)
+target_compile_options(SOM++ PRIVATE ${YK_CPPFLAGS_LIST} ${YK_CFLAGS_LIST} -fno-exceptions -fno-jump-tables)
+target_link_options(SOM++ PRIVATE ${YK_LDFLAGS_LIST})
 target_link_libraries(SOM++ ${YK_LIBS_LIST})
 ```
 
-`yk-config --cflags` injects `-flto`.  Do **not** strip it — the Yk linker passes
-(`--yk-embed-ir`, `--yk-patch-control-point`, etc.) operate on LLVM bitcode produced
-by LTO; without it they silently no-op and tracing never fires.
-
-Add `-Wl,--lto-O0` to cap LTO optimisation.  The default LTO level (`-O3`) triggers
-a `YkIRWriter` crash via cross-module inlining; `--lto-O0` disables that inlining.
+`--cppflags` provides the ykcapi include path.  `--cflags` injects `-flto` — do
+**not** strip it: the Yk linker passes (`--yk-embed-ir`, `--yk-patch-control-point`,
+etc.) operate on LLVM bitcode produced by LTO; without it they silently no-op and
+tracing never fires.  `USE_YK` is added via `target_compile_definitions` rather than
+taken from `--cppflags` so it is scoped to the target.
 
 Add `-fno-jump-tables` so the compiler does not lower `switch` statements into
 indirect-jump tables (which produce untraceable `indirectbr` IR — see §4).
@@ -220,7 +221,7 @@ pub(crate) fn eval(&mut self, idx: usize, gvar_ptrs: *const *const c_void) {
 
 ### 7  1-bit stores in the x64 JIT backend (ykrt change)
 
-LTO at `-O0` keeps `bool` temporaries as `i1` alloca slots with explicit stores.
+LTO keeps `bool` temporaries as `i1` alloca slots with explicit stores.
 The x64 backend has no 1-bit move instruction; widen `i1` to `i8` (a `bool`'s
 backing allocation is always at least 1 byte):
 

--- a/doc/Yk/integration_log.md
+++ b/doc/Yk/integration_log.md
@@ -1,0 +1,257 @@
+# SOM++ × Yk JIT Integration: Changes and Rationale
+
+This document records every change made to integrate SOM++ with the
+[Yk meta-tracing JIT](https://github.com/ykjit/yk), explains why each change
+was needed, and notes any differences from the equivalent CSOM integration.
+
+---
+
+## 1. Yk runtime wiring
+
+### 1.1 `YkMT` initialisation and shutdown — `src/vm/Universe.h`, `src/vm/Universe.cpp`
+
+**What changed.**
+
+`Universe.h` exposes the global Yk meta-tracer handle under `USE_YK`:
+
+```cpp
+#ifdef USE_YK
+#include <yk.h>
+extern YkMT* global_yk_mt;
+#endif
+```
+
+`Universe.cpp` defines it and allocates it at startup inside
+`Universe::initialize()`, and frees it in `Universe::Shutdown()`:
+
+```cpp
+#ifdef USE_YK
+YkMT* global_yk_mt = nullptr;
+#endif
+
+void Universe::initialize(...) {
+    InitializeAllocationLog();
+#ifdef USE_YK
+    {
+        char* yk_err = nullptr;
+        global_yk_mt = yk_mt_new(&yk_err);
+        if (yk_err != nullptr) {
+            fprintf(stderr, "[YK] init failed: %s\n", yk_err);
+            free(yk_err);
+            global_yk_mt = nullptr;
+        }
+    }
+#endif
+    ...
+}
+
+void Universe::Shutdown() {
+    ...
+#ifdef USE_YK
+    if (global_yk_mt != nullptr) {
+        yk_mt_shutdown(global_yk_mt);
+        global_yk_mt = nullptr;
+    }
+#endif
+}
+```
+
+**Why.**
+`YkMT` is Yk's meta-tracer object; every Yk-integrated program creates exactly
+one at startup and destroys it on exit. It must be globally accessible because
+`Universe::initialize` creates it, but the control point in `Interpreter::Start`
+(a separate translation unit) reads it at every bytecode dispatch.
+
+**Difference from CSOM.**
+CSOM initialises in `Universe_start`; SOM++ uses `Universe::initialize` (called
+from `Universe::Start`). Shutdown in CSOM is in `Universe_destruct`; in SOM++ it
+is in `Universe::Shutdown`, which is the natural teardown path.
+
+---
+
+### 1.2 Per-bytecode `YkLocation` array — `src/vmobjects/VMMethod.h`, `src/vmobjects/VMMethod.cpp`
+
+**What changed.**
+
+`VMMethod.h` adds a `yklocs` field to the class:
+
+```cpp
+#ifdef USE_YK
+    void* yklocs{nullptr};  // YkLocation[], one per bytecode
+#endif
+```
+
+The destructor is moved out of the header so that `USE_YK` cleanup can be
+added without pulling `<yk.h>` into every translation unit that includes
+`VMMethod.h`.
+
+`VMMethod.cpp` allocates and initialises the array at construction time, and
+drops the locations in the destructor:
+
+```cpp
+#ifdef USE_YK
+#include <yk.h>
+#endif
+
+VMMethod::VMMethod(...) {
+    ...
+#ifdef USE_YK
+    if (bcCount > 0) {
+        yklocs = malloc(bcCount * sizeof(YkLocation));
+        if (yklocs != nullptr) {
+            for (size_t i = 0; i < bcCount; i++)
+                static_cast<YkLocation*>(yklocs)[i] = yk_location_new();
+        }
+    }
+#endif
+}
+
+VMMethod::~VMMethod() {
+    delete lexicalScope;
+#ifdef USE_YK
+    if (yklocs != nullptr) {
+        for (size_t i = 0; i < bcLength; i++)
+            if (!yk_location_is_null(static_cast<YkLocation*>(yklocs)[i]))
+                yk_location_drop(static_cast<YkLocation*>(yklocs)[i]);
+        free(yklocs);
+    }
+#endif
+}
+```
+
+**Why.**
+Yk's control point takes a `YkLocation*` that identifies the loop being traced.
+Separate location objects are required for each bytecode index in each method so
+the tracer can distinguish different loops. Allocating at method creation time
+keeps the hot dispatch path free of allocation.
+
+**Difference from CSOM.**
+CSOM stores `yklocs` as `void*` on a C struct; SOM++ does the same (using
+`void*` in the header to avoid leaking `<yk.h>` to all includers, then casting
+inside `VMMethod.cpp` where `<yk.h>` is available). CSOM exposes a separate
+`VMMethod_cleanup_yklocs` function; SOM++ integrates cleanup into the
+destructor. `yklocs` is not tracked by the GC — it is a plain
+separately-malloc'd array. When the moving GC copies a `VMMethod` object, the
+`yklocs` pointer is copied as-is; the original becomes unreachable without the
+destructor running, so the array remains valid for the live clone.
+
+---
+
+### 1.3 Control point in the dispatch loop — `src/interpreter/Interpreter.h`, `src/interpreter/Interpreter.cpp`
+
+**What changed.**
+
+`Interpreter.h` adds a `YK_CONTROL_POINT()` helper macro and inserts it into
+both dispatch macros:
+
+```cpp
+#ifdef USE_YK
+#include <yk.h>
+#define YK_CONTROL_POINT()                                              \
+    yk_mt_control_point(global_yk_mt,                                   \
+        &static_cast<YkLocation*>(method->yklocs)[bytecodeIndexGlobal])
+#else
+#define YK_CONTROL_POINT() (void)0
+#endif
+
+#define DISPATCH_NOGC()                                           \
+    {                                                             \
+        YK_CONTROL_POINT();                                       \
+        goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]]; \
+    }
+
+#define DISPATCH_GC()                                             \
+    {                                                             \
+        YK_CONTROL_POINT();                                       \
+        if (GetHeap<HEAP_CLS>()->isCollectionTriggered()) {       \
+            startGC();                                            \
+        }                                                         \
+        goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]]; \
+    }
+```
+
+`Interpreter.cpp` also calls `YK_CONTROL_POINT()` at the initial dispatch
+(before the first `goto*`) so the very first bytecode is covered:
+
+```cpp
+    YK_CONTROL_POINT();
+    goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]];
+```
+
+**Why.**
+`yk_mt_control_point` tells Yk "I am at this point in the hot loop". Yk counts
+how many times each `YkLocation` is reached; once the threshold is exceeded it
+begins tracing.
+
+**Difference from CSOM.**
+CSOM uses a `while(true)` / `switch` loop, so a single control-point call at
+the top of the while body covers every bytecode dispatch. SOM++ uses a computed
+`goto*` dispatch table (threaded code) with no single loop entry point. The
+control point is instead placed in the `DISPATCH_NOGC` and `DISPATCH_GC`
+macros, which are called by every bytecode handler before jumping to the next
+bytecode. The initial dispatch (before any handler runs) also gets the control
+point so the first bytecode is not skipped.
+
+---
+
+## 2. Build system — `CMakeLists.txt`
+
+### 2.1 Yk compiler and linker flags
+
+**What changed.**
+
+A `YK_BUILD_TYPE` CMake cache variable is added. When set to `debug` or
+`release`, the build queries `yk-config` for all necessary flags and applies
+them to the `SOM++` target:
+
+```cmake
+set(YK_BUILD_TYPE "" CACHE STRING
+    "Yk build type (debug or release). Enables Yk JIT when set.")
+
+if(NOT "${YK_BUILD_TYPE}" STREQUAL "")
+  execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cppflags ...)
+  # strip -DUSE_YK from cppflags; added explicitly via target_compile_definitions
+  execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --cflags ...)
+  execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --ldflags ...)
+  execute_process(COMMAND yk-config ${YK_BUILD_TYPE} --libs ...)
+
+  target_compile_definitions(SOM++ PRIVATE USE_YK)
+  target_compile_options(SOM++ PRIVATE ${YK_CPPFLAGS_LIST} ${YK_CFLAGS_LIST})
+  target_link_options(SOM++ PRIVATE ${YK_LDFLAGS_LIST})
+  target_link_libraries(SOM++ ${YK_LIBS_LIST})
+endif()
+```
+
+To build with Yk:
+
+```bash
+cmake -DCMAKE_CXX_COMPILER=$(yk-config debug --cc) \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DYK_BUILD_TYPE=debug \
+      -B cmake-yk .
+cmake --build cmake-yk
+```
+
+**Why.**
+Yk requires a patched clang (`yk-config --cc`) for LTO and its custom LLVM
+passes. The flags mirror those used in CSOM's `build/unix.make` and in other
+Yk-integrated interpreters (yklua, ykmicropython).
+
+**Difference from CSOM.**
+CSOM uses a GNU Make variable block guarded by
+`ifneq ($(strip $(YK_BUILD_TYPE)),)`. The equivalent CMake pattern uses
+`execute_process` to call `yk-config` at configure time and
+`target_compile_definitions` / `target_compile_options` / `target_link_options`
+to apply the results. The compiler override (`YK_CC`) must be passed as
+`-DCMAKE_CXX_COMPILER=...` at configure time since CMake does not support
+changing the compiler after `project()`.
+
+---
+
+## 3. Yk framework changes
+
+The Yk framework changes from the CSOM integration (§4.1 promoting
+internal-linkage globals in `Linkage.cpp`, §4.2 skipping
+`@llvm.experimental.noalias.scope.decl` in `YkIRWriter.cpp`) live in the Yk /
+LLVM tree and are not SOM++-specific. They apply equally here and are assumed
+to be present in the Yk build used.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,76 @@
+yk_config := "/home/pd/yk-csom/bin/yk-config"
+
+build: build-release
+
+build-release:
+    mkdir -p cmake-build
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        "-DCMAKE_CXX_FLAGS=-I$HOME/.local/include" \
+        "-DLIB_CPPUNIT=$HOME/.local/lib/libcppunit.so" \
+        -S . -B cmake-build
+    cmake --build cmake-build --parallel
+
+build-debug:
+    mkdir -p cmake-debug
+    cmake -DCMAKE_BUILD_TYPE=Debug \
+        "-DCMAKE_CXX_FLAGS=-I$HOME/.local/include" \
+        "-DLIB_CPPUNIT=$HOME/.local/lib/libcppunit.so" \
+        -S . -B cmake-debug
+    cmake --build cmake-debug --parallel
+
+build-yk-debug:
+    mkdir -p cmake-yk
+    PATH="$(dirname {{yk_config}}):$PATH" cmake \
+        -DCMAKE_CXX_COMPILER=$({{yk_config}} debug --cc)++ \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DYK_BUILD_TYPE=debug \
+        "-DCMAKE_CXX_FLAGS=-I$HOME/.local/include" \
+        "-DLIB_CPPUNIT=$HOME/.local/lib/libcppunit.so" \
+        -S . -B cmake-yk
+    cmake --build cmake-yk --parallel
+
+build-yk-release:
+    mkdir -p cmake-yk
+    PATH="$(dirname {{yk_config}}):$PATH" cmake \
+        -DCMAKE_CXX_COMPILER=$({{yk_config}} debug --cc)++ \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DYK_BUILD_TYPE=release \
+        -S . -B cmake-yk
+    cmake --build cmake-yk --parallel
+
+build-yk: build-yk-debug
+
+test: test-unit test-som
+
+test-som: build-release
+    cmake-build/SOM++ -cp Smalltalk TestSuite/TestHarness.som
+
+test-unit: build-debug
+    cmake-debug/unittests -cp Smalltalk:TestSuite/BasicInterpreterTests Examples/Hello.som
+
+test-yk: build-yk
+    cmake-yk/SOM++ -cp Smalltalk TestSuite/TestHarness.som
+
+hello: build-release
+    cmake-build/SOM++ -cp Smalltalk Examples/Hello.som
+
+
+hello-yk: build-yk-debug
+    cmake-yk/SOM++ -cp Smalltalk Examples/Hello.som
+
+awfy: build-release
+    #!/usr/bin/env bash
+    for b in Ball Bounce List Mandelbrot Permute Queens Sieve Storage Towers; do
+        cmake-build/SOM++ -cp Smalltalk:Examples/AreWeFastYet Examples/AreWeFastYet/Harness.som $b 200 10 2>/dev/null | grep average
+    done
+
+awfy-compare: build-release build-yk-release
+    #!/usr/bin/env bash
+    for b in Ball Bounce List Mandelbrot Permute Queens Sieve Storage Towers; do
+        echo "=== $b ==="
+        printf "plain: "; cmake-build/SOM++ -cp Smalltalk:Examples/AreWeFastYet Examples/AreWeFastYet/Harness.som $b 200 10 2>/dev/null | grep average
+        printf "yk:    "; cmake-yk/SOM++    -cp Smalltalk:Examples/AreWeFastYet Examples/AreWeFastYet/Harness.som $b 200 10 2>/dev/null | grep average
+    done
+
+clean:
+    rm -rf cmake-build cmake-debug cmake-yk

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -143,7 +143,11 @@ vm_oop_t Interpreter::Start(bool printBytecodes) {
                            &&LABEL_BC_JUMP2_IF_GREATER,
                            &&LABEL_BC_JUMP2_BACKWARD};
 
+#ifdef USE_YK
+    goto YK_DISPATCH_START;
+#else
     goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]];
+#endif
 
     //
     // THIS IS THE former interpretation loop

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -53,10 +53,6 @@
 #include "../vmobjects/VMObject.h"
 #include "../vmobjects/VMSymbol.h"
 
-const std::string Interpreter::unknownGlobal = "unknownGlobal:";
-const std::string Interpreter::doesNotUnderstand =
-    "doesNotUnderstand:arguments:";
-const std::string Interpreter::escapedBlock = "escapedBlock:";
 
 VMFrame* Interpreter::frame = nullptr;
 VMMethod* Interpreter::method = nullptr;
@@ -66,13 +62,12 @@ VMMethod* Interpreter::method = nullptr;
 size_t Interpreter::bytecodeIndexGlobal;
 uint8_t* Interpreter::currentBytecodes;
 
-template <bool PrintBytecodes>
-vm_oop_t Interpreter::Start() {
-#define PROLOGUE(bcCount)                 \
-    {                                     \
-        if constexpr (PrintBytecodes) {   \
-            disassembleMethod();          \
-        }                                 \
+vm_oop_t Interpreter::Start(bool printBytecodes) {
+#define PROLOGUE(bcCount)              \
+    {                                  \
+        if (printBytecodes) {          \
+            disassembleMethod();       \
+        }                              \
         bytecodeIndexGlobal += (bcCount); \
     }
 
@@ -673,10 +668,12 @@ LABEL_BC_JUMP2_BACKWARD: {
     bytecodeIndexGlobal -= offset;
 }
     DISPATCH_NOGC();
+
+    // Single control-point trampoline for Yk. All DISPATCH_NOGC/GC paths jump
+    // here when USE_YK is set, giving Yk exactly one call site.
+    YK_DISPATCH_TRAMPOLINE();
 }
 
-template vm_oop_t Interpreter::Start<true>();
-template vm_oop_t Interpreter::Start<false>();
 
 VMFrame* Interpreter::PushNewFrame(VMMethod* method) {
     SetFrame(Universe::NewFrame(GetFrame(), method));

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -33,11 +33,35 @@
 #include "../vmobjects/VMFrame.h"
 #include "../vmobjects/VMMethod.h"
 
+#ifdef USE_YK
+#include "../vm/Yk.h"
+#endif
+
+// Yk requires exactly one call site for yk_mt_control_point in the binary.
+// DISPATCH_NOGC/GC therefore jump to a trampoline label (YK_DISPATCH_START)
+// where the single control point call lives.  The trampoline is defined in
+// Interpreter::Start() using the YK_DISPATCH_TRAMPOLINE macro below.
+#ifdef USE_YK
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+#define DISPATCH_NOGC() goto YK_DISPATCH_START
+#define DISPATCH_GC()                                       \
+    {                                                       \
+        if (GetHeap<HEAP_CLS>()->isCollectionTriggered()) { \
+            startGC();                                      \
+        }                                                   \
+        goto YK_DISPATCH_START;                             \
+    }
+#define YK_DISPATCH_TRAMPOLINE()                                            \
+    YK_DISPATCH_START:                                                      \
+        yk_mt_control_point(global_yk_mt,                                   \
+            &static_cast<YkLocation*>(method->yklocs)[bytecodeIndexGlobal]);\
+        goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]]
+// NOLINTEND(cppcoreguidelines-macro-usage)
+#else
 #define DISPATCH_NOGC()                                           \
     {                                                             \
         goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]]; \
     }
-
 #define DISPATCH_GC()                                             \
     {                                                             \
         if (GetHeap<HEAP_CLS>()->isCollectionTriggered()) {       \
@@ -45,11 +69,12 @@
         }                                                         \
         goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]]; \
     }
+#define YK_DISPATCH_TRAMPOLINE() (void)0
+#endif
 
 class Interpreter {
 public:
-    template <bool PrintBytecodes>
-    static vm_oop_t Start();
+    static vm_oop_t Start(bool printBytecodes = false);
 
     static VMFrame* PushNewFrame(VMMethod* method);
     static void SetFrame(VMFrame* frm);
@@ -81,9 +106,9 @@ private:
     static size_t bytecodeIndexGlobal;
     static uint8_t* currentBytecodes;
 
-    static const std::string unknownGlobal;
-    static const std::string doesNotUnderstand;
-    static const std::string escapedBlock;
+    static constexpr const char* unknownGlobal = "unknownGlobal:";
+    static constexpr const char* doesNotUnderstand = "doesNotUnderstand:arguments:";
+    static constexpr const char* escapedBlock = "escapedBlock:";
 
     static void startGC();
     static void disassembleMethod();

--- a/src/interpreter/Interpreter.h
+++ b/src/interpreter/Interpreter.h
@@ -51,11 +51,83 @@
         }                                                   \
         goto YK_DISPATCH_START;                             \
     }
-#define YK_DISPATCH_TRAMPOLINE()                                            \
-    YK_DISPATCH_START:                                                      \
-        yk_mt_control_point(global_yk_mt,                                   \
-            &static_cast<YkLocation*>(method->yklocs)[bytecodeIndexGlobal]);\
-        goto* loopTargets[currentBytecodes[bytecodeIndexGlobal]]
+// Switch-based dispatch for USE_YK: computed gotos (goto*) compile to LLVM
+// indirectbr which Yk's tracer cannot trace through. A switch compiles to a
+// regular br with multiple successors and is fully traceable.
+#define YK_DISPATCH_TRAMPOLINE()                                             \
+    YK_DISPATCH_START:                                                       \
+        yk_mt_control_point(global_yk_mt,                                    \
+            &static_cast<YkLocation*>(method->yklocs)[bytecodeIndexGlobal]); \
+        switch (currentBytecodes[bytecodeIndexGlobal]) {                     \
+            case BC_HALT:                  goto LABEL_BC_HALT;               \
+            case BC_DUP:                   goto LABEL_BC_DUP;                \
+            case BC_DUP_SECOND:            goto LABEL_BC_DUP_SECOND;         \
+            case BC_PUSH_LOCAL:            goto LABEL_BC_PUSH_LOCAL;         \
+            case BC_PUSH_LOCAL_0:          goto LABEL_BC_PUSH_LOCAL_0;       \
+            case BC_PUSH_LOCAL_1:          goto LABEL_BC_PUSH_LOCAL_1;       \
+            case BC_PUSH_LOCAL_2:          goto LABEL_BC_PUSH_LOCAL_2;       \
+            case BC_PUSH_ARGUMENT:         goto LABEL_BC_PUSH_ARGUMENT;      \
+            case BC_PUSH_SELF:             goto LABEL_BC_PUSH_SELF;          \
+            case BC_PUSH_ARG_1:            goto LABEL_BC_PUSH_ARG_1;         \
+            case BC_PUSH_ARG_2:            goto LABEL_BC_PUSH_ARG_2;         \
+            case BC_PUSH_FIELD:            goto LABEL_BC_PUSH_FIELD;         \
+            case BC_PUSH_FIELD_0:          goto LABEL_BC_PUSH_FIELD_0;       \
+            case BC_PUSH_FIELD_1:          goto LABEL_BC_PUSH_FIELD_1;       \
+            case BC_PUSH_BLOCK:            goto LABEL_BC_PUSH_BLOCK;         \
+            case BC_PUSH_CONSTANT:         goto LABEL_BC_PUSH_CONSTANT;      \
+            case BC_PUSH_CONSTANT_0:       goto LABEL_BC_PUSH_CONSTANT_0;    \
+            case BC_PUSH_CONSTANT_1:       goto LABEL_BC_PUSH_CONSTANT_1;    \
+            case BC_PUSH_CONSTANT_2:       goto LABEL_BC_PUSH_CONSTANT_2;    \
+            case BC_PUSH_0:                goto LABEL_BC_PUSH_0;             \
+            case BC_PUSH_1:                goto LABEL_BC_PUSH_1;             \
+            case BC_PUSH_NIL:              goto LABEL_BC_PUSH_NIL;           \
+            case BC_PUSH_GLOBAL:           goto LABEL_BC_PUSH_GLOBAL;        \
+            case BC_POP:                   goto LABEL_BC_POP;                \
+            case BC_POP_LOCAL:             goto LABEL_BC_POP_LOCAL;          \
+            case BC_POP_LOCAL_0:           goto LABEL_BC_POP_LOCAL_0;        \
+            case BC_POP_LOCAL_1:           goto LABEL_BC_POP_LOCAL_1;        \
+            case BC_POP_LOCAL_2:           goto LABEL_BC_POP_LOCAL_2;        \
+            case BC_POP_ARGUMENT:          goto LABEL_BC_POP_ARGUMENT;       \
+            case BC_POP_FIELD:             goto LABEL_BC_POP_FIELD;          \
+            case BC_POP_FIELD_0:           goto LABEL_BC_POP_FIELD_0;        \
+            case BC_POP_FIELD_1:           goto LABEL_BC_POP_FIELD_1;        \
+            case BC_SEND:                  goto LABEL_BC_SEND;               \
+            case BC_SEND_1:                goto LABEL_BC_SEND_1;             \
+            case BC_SUPER_SEND:            goto LABEL_BC_SUPER_SEND;         \
+            case BC_RETURN_LOCAL:          goto LABEL_BC_RETURN_LOCAL;       \
+            case BC_RETURN_NON_LOCAL:      goto LABEL_BC_RETURN_NON_LOCAL;   \
+            case BC_RETURN_SELF:           goto LABEL_BC_RETURN_SELF;        \
+            case BC_RETURN_FIELD_0:        goto LABEL_BC_RETURN_FIELD_0;     \
+            case BC_RETURN_FIELD_1:        goto LABEL_BC_RETURN_FIELD_1;     \
+            case BC_RETURN_FIELD_2:        goto LABEL_BC_RETURN_FIELD_2;     \
+            case BC_INC:                   goto LABEL_BC_INC;                \
+            case BC_DEC:                   goto LABEL_BC_DEC;                \
+            case BC_INC_FIELD:             goto LABEL_BC_INC_FIELD;          \
+            case BC_INC_FIELD_PUSH:        goto LABEL_BC_INC_FIELD_PUSH;     \
+            case BC_JUMP:                  goto LABEL_BC_JUMP;               \
+            case BC_JUMP_ON_FALSE_POP:     goto LABEL_BC_JUMP_ON_FALSE_POP;  \
+            case BC_JUMP_ON_TRUE_POP:      goto LABEL_BC_JUMP_ON_TRUE_POP;   \
+            case BC_JUMP_ON_FALSE_TOP_NIL: goto LABEL_BC_JUMP_ON_FALSE_TOP_NIL; \
+            case BC_JUMP_ON_TRUE_TOP_NIL:  goto LABEL_BC_JUMP_ON_TRUE_TOP_NIL;  \
+            case BC_JUMP_ON_NOT_NIL_POP:   goto LABEL_BC_JUMP_ON_NOT_NIL_POP;   \
+            case BC_JUMP_ON_NIL_POP:       goto LABEL_BC_JUMP_ON_NIL_POP;       \
+            case BC_JUMP_ON_NOT_NIL_TOP_TOP: goto LABEL_BC_JUMP_ON_NOT_NIL_TOP_TOP; \
+            case BC_JUMP_ON_NIL_TOP_TOP:   goto LABEL_BC_JUMP_ON_NIL_TOP_TOP;   \
+            case BC_JUMP_IF_GREATER:       goto LABEL_BC_JUMP_IF_GREATER;    \
+            case BC_JUMP_BACKWARD:         goto LABEL_BC_JUMP_BACKWARD;      \
+            case BC_JUMP2:                 goto LABEL_BC_JUMP2;              \
+            case BC_JUMP2_ON_FALSE_POP:    goto LABEL_BC_JUMP2_ON_FALSE_POP; \
+            case BC_JUMP2_ON_TRUE_POP:     goto LABEL_BC_JUMP2_ON_TRUE_POP;  \
+            case BC_JUMP2_ON_FALSE_TOP_NIL: goto LABEL_BC_JUMP2_ON_FALSE_TOP_NIL; \
+            case BC_JUMP2_ON_TRUE_TOP_NIL:  goto LABEL_BC_JUMP2_ON_TRUE_TOP_NIL;  \
+            case BC_JUMP2_ON_NOT_NIL_POP:   goto LABEL_BC_JUMP2_ON_NOT_NIL_POP;   \
+            case BC_JUMP2_ON_NIL_POP:       goto LABEL_BC_JUMP2_ON_NIL_POP;       \
+            case BC_JUMP2_ON_NOT_NIL_TOP_TOP: goto LABEL_BC_JUMP2_ON_NOT_NIL_TOP_TOP; \
+            case BC_JUMP2_ON_NIL_TOP_TOP:   goto LABEL_BC_JUMP2_ON_NIL_TOP_TOP;   \
+            case BC_JUMP2_IF_GREATER:      goto LABEL_BC_JUMP2_IF_GREATER;   \
+            case BC_JUMP2_BACKWARD:        goto LABEL_BC_JUMP2_BACKWARD;     \
+            default: __builtin_unreachable();                                 \
+        }
 // NOLINTEND(cppcoreguidelines-macro-usage)
 #else
 #define DISPATCH_NOGC()                                           \

--- a/src/primitivesCore/PrimitiveLoader.cpp
+++ b/src/primitivesCore/PrimitiveLoader.cpp
@@ -43,7 +43,13 @@
 #include "../vmobjects/ObjectFormats.h"
 #include "PrimitiveContainer.h"
 
-PrimitiveLoader PrimitiveLoader::loader;
+// Lazy singleton: defer construction until first use so global ctors (which
+// run before main()) never call shadow-stack-instrumented code before the
+// shadow stack is initialized by main().
+PrimitiveLoader& PrimitiveLoader::GetLoader() {
+    static PrimitiveLoader instance;
+    return instance;
+}
 
 PrimitiveLoader::PrimitiveLoader() {
     AddPrimitiveObject("Array", new _Array());
@@ -75,13 +81,13 @@ bool PrimitiveLoader::supportsClass(const std::string& name) {
 }
 
 bool PrimitiveLoader::SupportsClass(const std::string& name) {
-    return loader.supportsClass(name);
+    return GetLoader().supportsClass(name);
 }
 
 void PrimitiveLoader::InstallPrimitives(const std::string& cname,
                                         VMClass* clazz,
                                         bool classSide) {
-    loader.installPrimitives(cname, clazz, classSide);
+    GetLoader().installPrimitives(cname, clazz, classSide);
 }
 
 void PrimitiveLoader::installPrimitives(const std::string& cname,

--- a/src/primitivesCore/PrimitiveLoader.h
+++ b/src/primitivesCore/PrimitiveLoader.h
@@ -62,5 +62,5 @@ private:
 
     std::map<std::string, PrimitiveContainer*> primitiveObjects;
 
-    static PrimitiveLoader loader;
+    static PrimitiveLoader& GetLoader();
 };

--- a/src/vm/Shell.cpp
+++ b/src/vm/Shell.cpp
@@ -128,11 +128,7 @@ void Shell::Start() {
 
         // Start the Interpreter
 
-        if (dumpBytecodes > 1) {
-            Interpreter::Start<true>();
-        } else {
-            Interpreter::Start<false>();
-        }
+        Interpreter::Start(dumpBytecodes > 1);
 
         // Save the result of the run method
         it = currentFrame->Pop();

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -26,6 +26,10 @@
 
 #include "Universe.h"
 
+#ifdef USE_YK
+YkMT* global_yk_mt = nullptr;
+#endif
+
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
@@ -110,6 +114,13 @@ void Universe::Shutdown() {
          it != integerHist.end();
          it++) {
         hist_csv << it->first << ", " << it->second << endl;
+    }
+#endif
+
+#ifdef USE_YK
+    if (global_yk_mt != nullptr) {
+        yk_mt_shutdown(global_yk_mt);
+        global_yk_mt = nullptr;
     }
 #endif
 
@@ -353,14 +364,23 @@ vm_oop_t Universe::interpretMethod(VMObject* receiver, VMInvokable* initialize,
         dumpBytecodes = 2 - trace;
     }
 
-    if (dumpBytecodes > 1) {
-        return Interpreter::Start<true>();
-    }
-    return Interpreter::Start<false>();
+    return Interpreter::Start(dumpBytecodes > 1);
 }
 
 void Universe::initialize(int32_t _argc, char** _argv) {
     InitializeAllocationLog();
+
+#ifdef USE_YK
+    {
+        char* yk_err = nullptr;
+        global_yk_mt = yk_mt_new(&yk_err);
+        if (yk_err != nullptr) {
+            fprintf(stderr, "[YK] init failed: %s\n", yk_err);
+            free(yk_err);
+            global_yk_mt = nullptr;
+        }
+    }
+#endif
 
     heapSize = 1ULL * 1024 * 1024;
 

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -37,6 +37,11 @@
 #include "../vmobjects/ObjectFormats.h"
 #include "Print.h"
 
+#ifdef USE_YK
+#include "Yk.h"
+extern YkMT* global_yk_mt;
+#endif
+
 class SourcecodeCompiler;
 
 // for runtime debug

--- a/src/vm/Yk.h
+++ b/src/vm/Yk.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// yk.h is a C header with two C++-incompatibilities:
+//   1. Uses `restrict`, which is C99 but not C++. Clang supports `__restrict`.
+//   2. Missing `extern "C"` guards — without them C++ mangles the function
+//      names and they won't link against the C ykcapi library.
+#ifdef __cplusplus
+#define restrict __restrict
+extern "C" {
+#endif
+#include <yk.h>
+#ifdef __cplusplus
+#undef restrict
+}
+#endif

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -26,6 +26,10 @@
 
 #include "VMMethod.h"
 
+#ifdef USE_YK
+#include "../vm/Yk.h"
+#endif
+
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
@@ -67,13 +71,38 @@ VMMethod::VMMethod(VMSymbol* signature, size_t bcCount,
     cachedFrame = nullptr;
 #endif
 
-    indexableFields = (gc_oop_t*)(&indexableFields + 2);
+    indexableFields = reinterpret_cast<gc_oop_t*>(this + 1);
     for (size_t i = 0; i < numberOfConstants; ++i) {
         indexableFields[i] = nilObject;
     }
-    bytecodes = (uint8_t*)(&indexableFields + 2 + GetNumberOfIndexableFields());
+    bytecodes = reinterpret_cast<uint8_t*>(indexableFields + numberOfConstants);
+
+#ifdef USE_YK
+    if (bcCount > 0) {
+        yklocs = malloc(bcCount * sizeof(YkLocation));
+        if (yklocs != nullptr) {
+            for (size_t i = 0; i < bcCount; i++) {
+                static_cast<YkLocation*>(yklocs)[i] = yk_location_new();
+            }
+        }
+    }
+#endif
 
     write_barrier(this, signature);
+}
+
+VMMethod::~VMMethod() {
+    delete lexicalScope;
+#ifdef USE_YK
+    if (yklocs != nullptr) {
+        for (size_t i = 0; i < bcLength; i++) {
+            if (!yk_location_is_null(static_cast<YkLocation*>(yklocs)[i])) {
+                yk_location_drop(static_cast<YkLocation*>(yklocs)[i]);
+            }
+        }
+        free(yklocs);
+    }
+#endif
 }
 
 VMMethod* VMMethod::CloneForMovingGC() const {
@@ -83,11 +112,10 @@ VMMethod* VMMethod::CloneForMovingGC() const {
     memcpy(SHIFTED_PTR(clone, sizeof(VMObject)),
            SHIFTED_PTR(this, sizeof(VMObject)),
            GetObjectSize() - sizeof(VMObject));
-    clone->indexableFields = (gc_oop_t*)(&(clone->indexableFields) + 2);
-
     size_t const numIndexableFields = GetNumberOfIndexableFields();
+    clone->indexableFields = reinterpret_cast<gc_oop_t*>(clone + 1);
     clone->bytecodes =
-        (uint8_t*)(&(clone->indexableFields) + 2 + numIndexableFields);
+        reinterpret_cast<uint8_t*>(clone->indexableFields + numIndexableFields);
 
     // Use of GetNumberOfIndexableFields() is problematic here, because it may
     // be invalid object while cloning/moving within GC

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -96,7 +96,7 @@ public:
              size_t numLocals, size_t maxStackDepth, LexicalScope* lexicalScope,
              BackJump* inlinedLoops);
 
-    ~VMMethod() override { delete lexicalScope; }
+    ~VMMethod() override;
 
     [[nodiscard]] inline size_t GetNumberOfLocals() const {
         return numberOfLocals;
@@ -220,4 +220,7 @@ private:
 #endif
     gc_oop_t* indexableFields;
     uint8_t* bytecodes;
+#ifdef USE_YK
+    void* yklocs{nullptr};  // YkLocation[], one per bytecode
+#endif
 };

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -221,6 +221,6 @@ private:
     gc_oop_t* indexableFields;
     uint8_t* bytecodes;
 #ifdef USE_YK
-    void* yklocs{nullptr};  // YkLocation[], one per bytecode
+    void* yklocs{nullptr};  // YkLocation[], one per bytecode; malloc'd (not GC-managed)
 #endif
 };


### PR DESCRIPTION
I am not sure this is optimal, but it kind of works.

On ykifying SOM++

SOM++ uses computed-goto dispatch where at the end of each bytecode handler, the interpreter reads the next bytecode and jumps to it directly.
These gotos compile down to indirectbr LLVM instruction and yk can't follow it because the target is not statically known in the IR.

I replaced computed-goto dispatch for Yk builds with a switch statement (test suite is passing for yk integraiton)

Fist time compare for long loop
```
# sompp
$ time cmake-build/SOM++ -cp Smalltalk Examples/VeryHeavyLoop.som

real    0m0.070s
user    0m0.069s
sys     0m0.001s

# yksompp
$ time cmake-yk/SOM++ -cp Smalltalk Examples/VeryHeavyLoop.som

real    0m0.770s
user    0m1.611s
sys     0m0.021s
```

## Traces:
```
YKD_LOG=2 cmake-yk/SOM++ -cp Smalltalk Examples/VeryHeavyLoop.som 
...
yk-warning: stop-tracing-aborted: Trace too long
yk-warning: stop-tracing-aborted: Trace too long
yk-warning: stop-tracing-aborted: Trace too long
yk-warning: stop-tracing-aborted: Trace too long
yk-warning: stop-tracing-aborted: Trace too long
yk-warning: stop-tracing-aborted: Trace too long
yk-warning: stop-tracing-aborted: Trace too long
yk-warning: stop-tracing-aborted: Trace too long
yk-warning: stop-tracing-aborted: Trace too long
yk-warning: stop-tracing-aborted: Trace too long
sum = 499999500000

$ cat ykstats.json
{
    "duration_compiling": 0.846,
    "duration_deopting": 0.000,
    "duration_jit_executing": 0.386,
    "duration_outside_yk": 0.293,
    "duration_tracing": 0.076,
    "trace_executions": 51,
    "traces_compiled_err": 0,
    "traces_compiled_ok": 14,
    "traces_recorded_err": 10,
    "traces_recorded_ok": 14
}
```