### PR TITLE
Update README to include submodule init instructions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout SOM Repository
         uses: actions/checkout@v6
-        with:
-          submodules: true
 
       - name: Install Apt Packages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout SOM Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,22 @@ project(SOMpp LANGUAGES CXX)
 set(CMAKE_PROJECT_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_CXX_STANDARD 17)
 
+# Make sure we have the SOM core-lib
+find_package(Git QUIET)
+if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/core-lib/README.md")
+    message(STATUS "Initializing git submodule core-lib.")
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      RESULT_VARIABLE GIT_SUBMOD_RESULT
+    )
+    if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+      message(FATAL_ERROR "git submodule update --init --recursive failed with ${GIT_SUBMOD_RESULT}, please checkout submodules manually.")
+    endif()
+  endif()
+endif()
+
 set(ROOT_DIR         "${CMAKE_CURRENT_SOURCE_DIR}")
 set(SRC_DIR          "${ROOT_DIR}/src")
 set(COMPILER_DIR     "${SRC_DIR}/compiler")

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ the SOM standard library and a number of examples are included as a git submodul
 Please see the [main project page][SOMst] for links to other VM implementations.
 
 
+Prerequisites
+-------------
+
+The SOM standard library and examples are located in the `core-lib` git submodule.
+Before building, initialize and fetch the submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+
+Building
+--------
+
 SOM++ uses CMake and an optimized release build can be built like this:
 
 ```bash


### PR DESCRIPTION
It happened to me multiple times when I was building sompp from fresh fork while forgetting to init submodules.
Error I get with uninitialised submodules:
```
SOM++ -cp ../Smalltalk ../TestSuite/TestHarness.som
This is SOM++
Can't load system class: Object
```