### PR TITLE
Fix parser issues and ensure primitive holder is set

### DIFF
--- a/src/compiler/BytecodeGenerator.cpp
+++ b/src/compiler/BytecodeGenerator.cpp
@@ -30,6 +30,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <string>
 
 #include "../interpreter/bytecodes.h"
 #include "../vm/Globals.h"
@@ -141,7 +142,15 @@ void EmitPUSHARGUMENT(MethodGenerationContext& mgenc, const Parser& parser,
 void EmitPUSHFIELD(MethodGenerationContext& mgenc, const Parser& parser,
                    VMSymbol* field) {
     const int64_t idx = mgenc.GetFieldIndex(field);
-    if (idx < 0 || idx > std::numeric_limits<uint8_t>::max()) {
+    if (idx < 0) {
+        std::string const msg(
+            "The method tries to access the field " + field->GetStdString() +
+            ", which was not found in the class " +
+            mgenc.GetHolder()->GetName()->GetStdString() + ".");
+        parser.ParseError(msg.c_str());
+    }
+
+    if (idx > std::numeric_limits<uint8_t>::max()) {
         parser.ParseError(
             "The method tries to access a field that cannot be represented in "
             "the SOM++ bytecodes. Make sure this class and its superclasses "
@@ -283,7 +292,15 @@ void EmitPOPARGUMENT(MethodGenerationContext& mgenc, const Parser& parser,
 void EmitPOPFIELD(MethodGenerationContext& mgenc, const Parser& parser,
                   VMSymbol* field) {
     const int64_t idx = mgenc.GetFieldIndex(field);
-    if (idx < 0 || idx > std::numeric_limits<uint8_t>::max()) {
+    if (idx < 0) {
+        std::string const msg(
+            "The method tries to access the field " + field->GetStdString() +
+            ", which was not found in the class " +
+            mgenc.GetHolder()->GetName()->GetStdString() + ".");
+        parser.ParseError(msg.c_str());
+    }
+
+    if (idx > std::numeric_limits<uint8_t>::max()) {
         parser.ParseError(
             "The method tries to access a field that cannot be represented in "
             "the SOM++ bytecodes. Make sure this class and its superclasses "

--- a/src/compiler/Disassembler.cpp
+++ b/src/compiler/Disassembler.cpp
@@ -45,6 +45,7 @@
 #include "../vmobjects/VMInvokable.h"
 #include "../vmobjects/VMMethod.h"
 #include "../vmobjects/VMObject.h"
+#include "../vmobjects/VMPrimitive.h"
 #include "../vmobjects/VMString.h"
 #include "../vmobjects/VMSymbol.h"
 
@@ -81,6 +82,18 @@ void Disassembler::dispatch(vm_oop_t o) {
         } else if (c == load_ptr(symbolClass)) {
             DebugPrint("#%s",
                        static_cast<VMSymbol*>(o)->GetStdString().c_str());
+        } else if (c == load_ptr(methodClass)) {
+            DebugPrint("#%s",
+                       static_cast<VMMethod*>(o)
+                           ->GetSignature()
+                           ->GetStdString()
+                           .c_str());
+        } else if (c == load_ptr(primitiveClass)) {
+            DebugPrint("#%s",
+                       static_cast<VMPrimitive*>(o)
+                           ->GetSignature()
+                           ->GetStdString()
+                           .c_str());
         } else {
             DebugPrint("address: %p", (void*)o);
         }
@@ -452,7 +465,7 @@ void Disassembler::DumpBytecode(VMFrame* frame, VMMethod* method,
         case BC_PUSH_0:
         case BC_PUSH_1:
         case BC_PUSH_NIL: {
-            // no more details to be printed
+            DebugPrint("\n");
             break;
         }
         case BC_HALT: {
@@ -667,6 +680,7 @@ void Disassembler::DumpBytecode(VMFrame* frame, VMMethod* method,
             }
             break;
         }
+        case BC_RETURN_SELF:
         case BC_RETURN_LOCAL:
         case BC_RETURN_NON_LOCAL: {
             DebugPrint(")\n");

--- a/src/compiler/MethodGenerationContext.cpp
+++ b/src/compiler/MethodGenerationContext.cpp
@@ -297,7 +297,6 @@ int8_t MethodGenerationContext::FindLiteralIndex(vm_oop_t lit) {
 
 int64_t MethodGenerationContext::GetFieldIndex(VMSymbol* field) {
     int64_t const idx = holderGenc.GetFieldIndex(field);
-    assert(idx >= 0);
     return idx;
 }
 

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -959,7 +959,7 @@ __attribute__((noreturn)) void Parser::parseError(const char* msg,
 
 __attribute__((noreturn)) void Parser::ParseError(const char* msg) const {
     std::string msgWithMeta =
-        "%(file)s:%(line)d:%(column)d: error: " + std::string(msg);
+        "%(file)s:%(line)d:%(column)d: error: " + std::string(msg) + "\n";
 
     ReplacePattern(msgWithMeta, "%(file)s", fname);
 

--- a/src/compiler/Parser.cpp
+++ b/src/compiler/Parser.cpp
@@ -192,7 +192,7 @@ static Symbol binaryOpSyms[] = {Or,   Comma, Minus, Equal, Not,  And,
                                 Or,   Star,  Div,   Mod,   Plus, Equal,
                                 More, Less,  Comma, At,    Per,  NONE};
 
-static Symbol keywordSelectorSyms[] = {Keyword, KeywordSequence};
+static Symbol keywordSelectorSyms[] = {Keyword, KeywordSequence, NONE};
 
 void Parser::Classdef(ClassGenerationContext& cgenc) {
     cgenc.SetName(SymbolFor(text));

--- a/src/primitives/Primitive.cpp
+++ b/src/primitives/Primitive.cpp
@@ -1,5 +1,6 @@
 #include "Primitive.h"
 
+#include <cassert>
 #include <cstddef>
 
 #include "../vmobjects/ObjectFormats.h"
@@ -9,7 +10,9 @@
 
 static vm_oop_t pHolder(vm_oop_t rcvr) {
     auto* self = static_cast<VMInvokable*>(rcvr);
-    return self->GetHolder();
+    vm_oop_t holder = self->GetHolder();
+    assert(holder != nullptr);
+    return holder;
 }
 
 static vm_oop_t pSignature(vm_oop_t rcvr) {

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -92,6 +92,11 @@ bool VMClass::AddInstanceInvokable(VMInvokable* invokable) {
     store_ptr(instanceInvokables,
               instInvokables->CopyAndExtendWith((vm_oop_t)invokable));
 
+    // set holder, since we don't call SetInstanceInvokable, which does it
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+    if (invokable != reinterpret_cast<VMInvokable*>(load_ptr(nilObject))) {
+        invokable->SetHolder(this);
+    }
     return true;
 }
 


### PR DESCRIPTION
This resolves #65.

It does the following:

 - ensure that `keywordSelectorSyms` is terminated with `NONE`
 - removes a broken assert and improve the already existing parse error to trigger when writing to a non-existing variable
 - ensures that primitives have a holder when they are added to a class, instead of replacing an existing invokable
 
Thanks @sillycross for the report!