### PR TITLE
Minor improvements and preparation for primitives for Vector class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Clang Tidy
         if: matrix.compiler == 'clang'
         run: |
-          clang-tidy-20 --config-file=.clang-tidy src/**/*.cpp -- -fdiagnostics-absolute-paths -DGC_TYPE=${{ matrix.gc}} ${{ matrix.integers }} -DUNITTESTS
+          clang-tidy-20 --config-file=.clang-tidy src/*.cpp src/**/*.cpp -- -fdiagnostics-absolute-paths -DGC_TYPE=${{ matrix.gc}} ${{ matrix.integers }} -DUNITTESTS
 
       - name: Clang Format
         if: matrix.compiler == 'clang' && matrix.gc == 'GENERATIONAL'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test_soms:
+    name: Run (Compiler=${{matrix.compiler}} GC=${{matrix.gc}} ${{matrix.cmake_flags}}
     runs-on: ubuntu-24.04
     # continue-on-error: true
     strategy:
@@ -11,7 +12,7 @@ jobs:
       matrix:
         compiler: [clang, gcc]
         gc: [GENERATIONAL, MARK_SWEEP, COPYING]
-        integers:
+        cmake_flags:
           - "-DUSE_TAGGING=true"
           - "-DUSE_TAGGING=false -DCACHE_INTEGER=true"
           - "-DUSE_TAGGING=false -DCACHE_INTEGER=false"
@@ -50,10 +51,10 @@ jobs:
             export CXX=g++
           fi
           echo $CC $CXX
-          echo cmake . -DGC_TYPE=${{ matrix.gc}} ${{ matrix.integers }}
+          echo cmake . -DGC_TYPE=${{ matrix.gc}} ${{ matrix.cmake_flags }}
           mkdir cmake-build
           cd cmake-build
-          cmake .. -DGC_TYPE=${{ matrix.gc}} ${{ matrix.integers }} -DCMAKE_BUILD_TYPE=Debug
+          cmake .. -DGC_TYPE=${{ matrix.gc}} ${{ matrix.cmake_flags }} -DCMAKE_BUILD_TYPE=Debug
           make -j5
 
       - name: Run Unit Tests
@@ -79,7 +80,7 @@ jobs:
       - name: Clang Tidy
         if: matrix.compiler == 'clang'
         run: |
-          clang-tidy-20 --config-file=.clang-tidy src/*.cpp src/**/*.cpp -- -fdiagnostics-absolute-paths -DGC_TYPE=${{ matrix.gc}} ${{ matrix.integers }} -DUNITTESTS
+          clang-tidy-20 --config-file=.clang-tidy src/*.cpp src/**/*.cpp -- -fdiagnostics-absolute-paths -DGC_TYPE=${{ matrix.gc}} ${{ matrix.cmake_flags }} -DUNITTESTS
 
       - name: Clang Format
         if: matrix.compiler == 'clang' && matrix.gc == 'GENERATIONAL'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,8 +83,15 @@ build_and_test:
     - cd debug
     - cmake .. $CMAKE_FLAGS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Debug
     - make -j
-    - ./SOM++ -cp ../Smalltalk ../TestSuite/TestHarness.som
-    - ./unittests -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
+    - ./SOM++ -cfg -cp ../Smalltalk ../TestSuite/TestHarness.som
+    - ./unittests -cfg -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
+    - cd ..
+
+    - cd release
+    - cmake .. $CMAKE_FLAGS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Release
+    - make -j
+    - ./SOM++ -cfg -cp ../Smalltalk ../TestSuite/TestHarness.som
+    - mv SOM++ ../$NAME
     - cd ..
 
     - |+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,30 +23,32 @@ build_and_test:
           - yuria3
         COMPILER: [clang]
         GC: [COPYING]
-        INTEGERS:
+        CMAKE_FLAGS:
           - "-DUSE_TAGGING=true"
           - "-DUSE_TAGGING=false -DCACHE_INTEGER=true"
           - "-DUSE_TAGGING=false -DCACHE_INTEGER=false"
+          - "-DUSE_TAGGING=false -DCACHE_INTEGER=false -DUSE_VECTOR_PRIMITIVES=false"
 
       # Track GCC only for one configuration
       - MACHINE: [yuria, yuria2, yuria3]
         COMPILER: [gcc]
         GC: [COPYING]
-        INTEGERS: ["-DUSE_TAGGING=true"]
+        CMAKE_FLAGS: ["-DUSE_TAGGING=true"]
 
       - MACHINE: [zullie1]
         COMPILER: [clang]
         GC: [GENERATIONAL]
-        INTEGERS:
+        CMAKE_FLAGS:
           - "-DUSE_TAGGING=true"
           - "-DUSE_TAGGING=false -DCACHE_INTEGER=true"
           - "-DUSE_TAGGING=false -DCACHE_INTEGER=false"
+          - "-DUSE_TAGGING=false -DCACHE_INTEGER=false -DUSE_VECTOR_PRIMITIVES=false"
 
       # Mark-Sweep working, but not super exciting
       - MACHINE: [yuria, yuria2, yuria3]
         COMPILER: [gcc]
         GC: [MARK_SWEEP]
-        INTEGERS: ["-DUSE_TAGGING=true"]
+        CMAKE_FLAGS: ["-DUSE_TAGGING=true"]
 
   tags: [$MACHINE]
   script:
@@ -59,24 +61,27 @@ build_and_test:
     # compose a name for this configuration
     - |+
       export NAME="som-$COMPILER-$GC"
-      if [[ $INTEGERS =~ "USE_TAGGING=true" ]]; then
+      if [[ $CMAKE_FLAGS =~ "USE_TAGGING=true" ]]; then
         NAME="$NAME-inttag"
       else
         NAME="$NAME-intbox"
       fi
-      if [[ $INTEGERS =~ "CACHE_INTEGER=true" ]]; then
+      if [[ $CMAKE_FLAGS =~ "CACHE_INTEGER=true" ]]; then
         NAME="$NAME-intcache"
+      fi
+      if [[ $CMAKE_FLAGS =~ "DUSE_VECTOR_PRIMITIVES=false" ]]; then
+        NAME="$NAME-somvec"
       fi
       NAME=`echo "$NAME" | tr '[:upper:]' '[:lower:]'`
 
     - cd release
-    - cmake .. $INTEGERS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Release
+    - cmake .. $CMAKE_FLAGS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Release
     - make -j
     - mv SOM++ ../$NAME
     - cd ..
 
     - cd debug
-    - cmake .. $INTEGERS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Debug
+    - cmake .. $CMAKE_FLAGS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Debug
     - make -j
     - ./SOM++ -cp ../Smalltalk ../TestSuite/TestHarness.som
     - ./unittests -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
@@ -87,7 +92,7 @@ build_and_test:
       if [ "$COMPILER" = "clang" ]; then
         # this is to load balance the SomSom testing
         # only when compiling with Clang, and only on one machine for each integer configuration
-        if [ "$MACHINE $INTEGERS" = "zullie1 -DUSE_TAGGING=true" ] || [ "$MACHINE $INTEGERS" = "yuria2 -DUSE_TAGGING=false -DCACHE_INTEGER=true" ] || [ "$MACHINE $INTEGERS" = "yuria3 -DUSE_TAGGING=false -DCACHE_INTEGER=false" ]; then
+        if [ "$MACHINE $CMAKE_FLAGS" = "zullie1 -DUSE_TAGGING=true" ] || [ "$MACHINE $CMAKE_FLAGS" = "yuria2 -DUSE_TAGGING=false -DCACHE_INTEGER=true" ] || [ "$MACHINE $CMAKE_FLAGS" = "yuria3 -DUSE_TAGGING=false -DCACHE_INTEGER=false" ]; then
           ./$NAME -cp Smalltalk:TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects core-lib/SomSom/tests/SomSomTests.som
         fi
       fi

--- a/SOM.xcodeproj/project.pbxproj
+++ b/SOM.xcodeproj/project.pbxproj
@@ -313,7 +313,6 @@
 		3F5203320FA6624C00E75857 /* Universe.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Universe.cpp; sourceTree = "<group>"; };
 		3F5203330FA6624C00E75857 /* Universe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Universe.h; sourceTree = "<group>"; };
 		3F5203350FA6624C00E75857 /* ObjectFormats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectFormats.h; sourceTree = "<group>"; };
-		3F5203360FA6624C00E75857 /* PrimitiveRoutine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrimitiveRoutine.h; sourceTree = "<group>"; };
 		3F5203370FA6624C00E75857 /* Signature.cpp */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Signature.cpp; sourceTree = "<group>"; tabWidth = 4; };
 		3F5203380FA6624C00E75857 /* Signature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Signature.h; sourceTree = "<group>"; };
 		3F52033B0FA6624C00E75857 /* VMArray.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VMArray.cpp; sourceTree = "<group>"; };
@@ -447,13 +446,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		0A1886C71832BBC900A2CBCA /* SOM++ */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = "SOM++";
-			sourceTree = "<group>";
-		};
 		0A67EA7A19ACD44000830E3B /* unittests */ = {
 			isa = PBXGroup;
 			children = (
@@ -499,7 +491,6 @@
 				E18AE29C0FB1C45E00EE6540 /* Examples */,
 				E18AE27F0FB1C44700EE6540 /* Smalltalk */,
 				3F5202EF0FA6624C00E75857 /* src */,
-				0A1886C71832BBC900A2CBCA /* SOM++ */,
 				0A1886C61832BBC900A2CBCA /* Products */,
 			);
 			sourceTree = "<group>";
@@ -554,7 +545,6 @@
 				3F5203020FA6624C00E75857 /* bytecodes.h */,
 				3F5203030FA6624C00E75857 /* Interpreter.cpp */,
 				3F5203040FA6624C00E75857 /* Interpreter.h */,
-				0AB80ADA2C39AC27006B6419 /* InterpreterLoop.h */,
 			);
 			path = interpreter;
 			sourceTree = "<group>";
@@ -670,7 +660,6 @@
 				0A1887091832C0E400A2CBCA /* AbstractObject.cpp */,
 				0A18870A1832C0E400A2CBCA /* AbstractObject.h */,
 				3F5203350FA6624C00E75857 /* ObjectFormats.h */,
-				3F5203360FA6624C00E75857 /* PrimitiveRoutine.h */,
 				0A32B7FC199D6143002825DF /* IntegerBox.cpp */,
 				0A32B7FD199D6143002825DF /* IntegerBox.h */,
 				3F5203370FA6624C00E75857 /* Signature.cpp */,

--- a/rebench.conf
+++ b/rebench.conf
@@ -128,12 +128,14 @@ executors:
     som-clang-generational-inttag:          {path: ., executable: som-clang-generational-inttag         }
     som-clang-generational-intbox:          {path: ., executable: som-clang-generational-intbox         }
     som-clang-generational-intbox-intcache: {path: ., executable: som-clang-generational-intbox-intcache}
+    som-clang-generational-intbox-somvec:   {path: ., executable: som-clang-generational-intbox-somvec  }
     som-clang-mark_sweep-inttag:            {path: ., executable: som-clang-mark_sweep-inttag           }
     som-clang-mark_sweep-intbox:            {path: ., executable: som-clang-mark_sweep-intbox           }
     som-clang-mark_sweep-intbox-intcache:   {path: ., executable: som-clang-mark_sweep-intbox-intcache  }
     som-clang-copying-inttag:               {path: ., executable: som-clang-copying-inttag              }
     som-clang-copying-intbox:               {path: ., executable: som-clang-copying-intbox              }
     som-clang-copying-intbox-intcache:      {path: ., executable: som-clang-copying-intbox-intcache     }
+    som-clang-copying-intbox-somvec:        {path: ., executable: som-clang-copying-intbox-somvec       }
 
 # define the benchmarks to be executed for a re-executable benchmark run
 experiments:
@@ -160,9 +162,11 @@ experiments:
             - som-clang-generational-inttag
             - som-clang-generational-intbox
             - som-clang-generational-intbox-intcache
+            - som-clang-generational-intbox-somvec
             - som-clang-mark_sweep-inttag
             - som-clang-mark_sweep-intbox
             - som-clang-mark_sweep-intbox-intcache
             - som-clang-copying-inttag
             - som-clang-copying-intbox
             - som-clang-copying-intbox-intcache
+            - som-clang-copying-intbox-somvec

--- a/src/primitivesCore/PrimitiveContainer.cpp
+++ b/src/primitivesCore/PrimitiveContainer.cpp
@@ -65,7 +65,9 @@ void PrimitiveContainer::Add(const char* name,
     ternaryPrims[std::string(name)] = {routine, classSide};
 }
 
-void PrimitiveContainer::InstallPrimitives(VMClass* clazz, bool classSide) {
+void PrimitiveContainer::InstallPrimitives(VMClass* clazz,
+                                           bool classSide,
+                                           bool showWarning) {
     for (auto const& p : unaryPrims) {
         assert(p.second.IsValid());
         if (classSide != p.second.isClassSide) {
@@ -74,7 +76,8 @@ void PrimitiveContainer::InstallPrimitives(VMClass* clazz, bool classSide) {
 
         VMSymbol* sig = SymbolFor(p.first);
         if (clazz->AddInstanceInvokable(
-                VMSafePrimitive::GetSafeUnary(sig, p.second))) {
+                VMSafePrimitive::GetSafeUnary(sig, p.second)) &&
+            showWarning) {
             cout << "Warn: Primitive " << p.first
                  << " is not in class definition for class "
                  << clazz->GetName()->GetStdString() << '\n';
@@ -89,7 +92,8 @@ void PrimitiveContainer::InstallPrimitives(VMClass* clazz, bool classSide) {
 
         VMSymbol* sig = SymbolFor(p.first);
         if (clazz->AddInstanceInvokable(
-                VMSafePrimitive::GetSafeBinary(sig, p.second))) {
+                VMSafePrimitive::GetSafeBinary(sig, p.second)) &&
+            showWarning) {
             cout << "Warn: Primitive " << p.first
                  << " is not in class definition for class "
                  << clazz->GetName()->GetStdString() << '\n';
@@ -104,7 +108,8 @@ void PrimitiveContainer::InstallPrimitives(VMClass* clazz, bool classSide) {
 
         VMSymbol* sig = SymbolFor(p.first);
         if (clazz->AddInstanceInvokable(
-                VMSafePrimitive::GetSafeTernary(sig, p.second))) {
+                VMSafePrimitive::GetSafeTernary(sig, p.second)) &&
+            showWarning) {
             cout << "Warn: Primitive " << p.first
                  << " is not in class definition for class "
                  << clazz->GetName()->GetStdString() << '\n';
@@ -119,7 +124,8 @@ void PrimitiveContainer::InstallPrimitives(VMClass* clazz, bool classSide) {
 
         VMSymbol* sig = SymbolFor(p.first);
         if (clazz->AddInstanceInvokable(
-                VMPrimitive::GetFramePrim(sig, p.second))) {
+                VMPrimitive::GetFramePrim(sig, p.second)) &&
+            showWarning) {
             cout << "Warn: Primitive " << p.first
                  << " is not in class definition for class "
                  << clazz->GetName()->GetStdString() << '\n';

--- a/src/primitivesCore/PrimitiveContainer.h
+++ b/src/primitivesCore/PrimitiveContainer.h
@@ -40,7 +40,7 @@ public:
     PrimitiveContainer() = default;
     virtual ~PrimitiveContainer() = default;
 
-    void InstallPrimitives(VMClass* clazz, bool classSide);
+    void InstallPrimitives(VMClass* clazz, bool classSide, bool showWarning);
 
     void Add(const char* name, FramePrimitiveRoutine /*routine*/,
              bool classSide);

--- a/src/primitivesCore/PrimitiveLoader.cpp
+++ b/src/primitivesCore/PrimitiveLoader.cpp
@@ -80,16 +80,18 @@ bool PrimitiveLoader::SupportsClass(const std::string& name) {
 
 void PrimitiveLoader::InstallPrimitives(const std::string& cname,
                                         VMClass* clazz,
-                                        bool classSide) {
-    loader.installPrimitives(cname, clazz, classSide);
+                                        bool classSide,
+                                        bool showWarning) {
+    loader.installPrimitives(cname, clazz, classSide, showWarning);
 }
 
 void PrimitiveLoader::installPrimitives(const std::string& cname,
                                         VMClass* clazz,
-                                        bool classSide) {
+                                        bool classSide,
+                                        bool showWarning) {
     if (primitiveObjects.find(cname) == primitiveObjects.end()) {
         return;
     }
 
-    primitiveObjects[cname]->InstallPrimitives(clazz, classSide);
+    primitiveObjects[cname]->InstallPrimitives(clazz, classSide, showWarning);
 }

--- a/src/primitivesCore/PrimitiveLoader.h
+++ b/src/primitivesCore/PrimitiveLoader.h
@@ -51,12 +51,14 @@ public:
 
     static void InstallPrimitives(const std::string& cname,
                                   VMClass* clazz,
-                                  bool classSide);
+                                  bool classSide,
+                                  bool showWarning);
 
 private:
     void installPrimitives(const std::string& cname,
                            VMClass* clazz,
-                           bool classSide);
+                           bool classSide,
+                           bool showWarning);
 
     bool supportsClass(const std::string& name);
 

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -585,7 +585,7 @@ VMClass* Universe::LoadClass(VMSymbol* name) {
     }
 
     if (result->HasPrimitives() || result->GetClass()->HasPrimitives()) {
-        result->LoadPrimitives();
+        result->LoadPrimitives(true);
     }
 
     SetGlobal(name, result);
@@ -628,7 +628,7 @@ void Universe::LoadSystemClass(VMClass* systemClass) {
     }
 
     if (result->HasPrimitives() || result->GetClass()->HasPrimitives()) {
-        result->LoadPrimitives();
+        result->LoadPrimitives(false);
     }
 }
 

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -198,12 +198,13 @@ bool VMClass::HasPrimitives() const {
     return false;
 }
 
-void VMClass::LoadPrimitives() {
+void VMClass::LoadPrimitives(bool showWarning) {
     std::string const cname = load_ptr(name)->GetStdString();
 
     if (hasPrimitivesFor(cname)) {
-        PrimitiveLoader::InstallPrimitives(cname, this, false);
-        PrimitiveLoader::InstallPrimitives(cname, GetClass(), true);
+        PrimitiveLoader::InstallPrimitives(cname, this, false, showWarning);
+        PrimitiveLoader::InstallPrimitives(
+            cname, GetClass(), true, showWarning);
     }
 }
 

--- a/src/vmobjects/VMClass.h
+++ b/src/vmobjects/VMClass.h
@@ -66,7 +66,7 @@ public:
     [[nodiscard]] VMSymbol* GetInstanceFieldName(size_t index) const;
     [[nodiscard]] size_t GetNumberOfInstanceFields() const;
     [[nodiscard]] bool HasPrimitives() const;
-    void LoadPrimitives();
+    void LoadPrimitives(bool showWarning);
     [[nodiscard]] VMClass* CloneForMovingGC() const override;
 
     [[nodiscard]] std::string AsDebugString() const override;


### PR DESCRIPTION
- refactor CI config a bit, and have a dummy version to benchmark upcoming vector primitives
- suppress primitive warnings for systems classes, may partially address https://github.com/SOM-st/SOMpp/issues/78
- remove unused entries from Xcode project
- core-lib update is just going to the last merge commit, instead of the head of the previous branch, so, no code changes