### PR TITLE
Add per-method bytecode heatmap.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ SOM.xcodeproj/xcuserdata
 build/Debug
 build/Smalltalk
 build/SOM.build
+cmake-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ option(CACHE_INTEGER "Enable caching of boxed integers" FALSE)
 set(INT_CACHE_MIN_VALUE -5  CACHE STRING "Lower bound of cached integers")
 set(INT_CACHE_MAX_VALUE 100 CACHE STRING "Upper bound of cached integers")
 option(GENERATE_INTEGER_HISTOGRAM "Generate histogram of allocated integers" FALSE)
+option(BYTECODE_HEATMAP "Count per-method bytecode hits and show them in the disassembler" FALSE)
 
 option(USE_VECTOR_PRIMITIVES "Use Vector primitives" TRUE)
 
@@ -99,6 +100,9 @@ endif ()
 
 if (GENERATE_INTEGER_HISTOGRAM)
   add_definitions(-DGENERATE_INTEGER_HISTOGRAM)
+endif ()
+if (BYTECODE_HEATMAP)
+  add_definitions(-DBYTECODE_HEATMAP)
 endif ()
 if(USE_VECTOR_PRIMITIVES)
   add_definitions(-DUSE_VECTOR_PRIMITIVES=true)

--- a/src/compiler/Disassembler.cpp
+++ b/src/compiler/Disassembler.cpp
@@ -179,6 +179,12 @@ void Disassembler::dumpMethod(uint8_t* bytecodes, size_t numberOfBytecodes,
         // indent, bytecode index, bytecode mnemonic
         DebugDump("%s%4d:%s  ", indent, bc_idx,
                   Bytecode::GetBytecodeName(bytecode));
+#ifdef BYTECODE_HEATMAP
+        if (method != nullptr) {
+            DebugPrint("[hits: %llu] ",
+                       (unsigned long long)method->heatmap[bc_idx]);
+        }
+#endif
         // parameters (if any)
         if (Bytecode::GetBytecodeLength(bytecode) == 1) {
             DebugPrint("\n");

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -68,11 +68,17 @@ uint8_t* Interpreter::currentBytecodes;
 
 template <bool PrintBytecodes>
 vm_oop_t Interpreter::Start() {
+#ifdef BYTECODE_HEATMAP
+  #define HEATMAP_INC() method->heatmap[bytecodeIndexGlobal]++
+#else
+  #define HEATMAP_INC() ((void)0)
+#endif
 #define PROLOGUE(bcCount)                 \
     {                                     \
         if constexpr (PrintBytecodes) {   \
             disassembleMethod();          \
         }                                 \
+        HEATMAP_INC();                    \
         bytecodeIndexGlobal += (bcCount); \
     }
 

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -417,6 +417,18 @@ void Universe::initialize(int32_t _argc, char** _argv) {
 
     VMArray* argumentsArray = NewArrayFromStrings(argv);
     interpretMethod(systemObject, initialize, argumentsArray);
+
+#ifdef BYTECODE_HEATMAP
+    if (dumpBytecodes != 0) {
+        for (auto& g : globals) {
+            auto* cls =
+                dynamic_cast<VMClass*>((AbstractVMObject*)load_ptr(g.second));
+            if (cls != nullptr) {
+                Disassembler::Dump(cls);
+            }
+        }
+    }
+#endif
 }
 
 Universe::~Universe() {

--- a/src/vmobjects/VMMethod.cpp
+++ b/src/vmobjects/VMMethod.cpp
@@ -74,6 +74,10 @@ VMMethod::VMMethod(VMSymbol* signature, size_t bcCount,
     }
     bytecodes = (uint8_t*)(&indexableFields + 2 + GetNumberOfIndexableFields());
 
+#ifdef BYTECODE_HEATMAP
+    heatmap = new uint64_t[bcCount]();
+#endif
+
     write_barrier(this, signature);
 }
 

--- a/src/vmobjects/VMMethod.h
+++ b/src/vmobjects/VMMethod.h
@@ -221,6 +221,10 @@ private:
 #ifdef UNSAFE_FRAME_OPTIMIZATION
     GCFrame* cachedFrame;
 #endif
+
+#ifdef BYTECODE_HEATMAP
+    uint64_t* heatmap;
+#endif
     gc_oop_t* indexableFields;
     uint8_t* bytecodes;
 };


### PR DESCRIPTION
This is something that I used as part of my work on [yksompp](https://github.com/ykjit/yksompp) to see which bytecodes are frequently executed. I thought it would be worth upstreaming it as a general "where is time being spent" tool :).


## Example
```
cmake-debug/SOM++ -d -cp Smalltalk:Examples/Benchmarks Examples/Benchmarks/BenchmarkHarness.som List 1 10 2>&1 \
  | awk '/hits: [1-9]/{ match($0, /hits: [0-9]+/); h=substr($0,RSTART+6,RLENGTH-6)+0; print "$0 }' \
  | sort -rn | head -20
208590  DUMP:      5:SEND_1            [hits: 208590] (index: 0) signature: isNil
208590  DUMP:      4:PUSH_LOCAL_1      [hits: 208590] 
187520  DUMP:     11:SEND_1            [hits: 187520] (index: 0) signature: isNil
187520  DUMP:     10:PUSH_LOCAL_0      [hits: 187520] 
180500  DUMP:     30:POP               [hits: 180500] 
180500  DUMP:     29:POP_LOCAL_1       [hits: 180500] 
180500  DUMP:     28:DUP               [hits: 180500] 
180500  DUMP:     26:SEND_1            [hits: 180500] (index: 2) signature: next
180500  DUMP:     25:PUSH_LOCAL_1      [hits: 180500] 
180500  DUMP:     24:POP               [hits: 180500] 
180500  DUMP:     23:POP_LOCAL_0       [hits: 180500] 
180500  DUMP:     22:DUP               [hits: 180500] 
180500  DUMP:     20:SEND_1            [hits: 180500] (index: 2) signature: next
180500  DUMP:     19:PUSH_LOCAL_0      [hits: 180500] 
180500  DUMP:     18:POP               [hits: 180500] 
28090   DUMP:      3:SEND              [hits: 28090] (index: 0) signature: isShorter:than:
28090   DUMP:      3:POP_LOCAL_1       [hits: 28090] 
28090   DUMP:      2:PUSH_ARG_2        [hits: 28090] 
28090   DUMP:      2:PUSH_ARG_1        [hits: 28090] 
28090   DUMP:      1:PUSH_ARG_2        [hits: 28090] 
```