### PR TITLE
Move code from GitLab CI config to script and setup benchmarking on SSW machines

### DIFF
--- a/.github/build-and-test.sh
+++ b/.github/build-and-test.sh
@@ -61,8 +61,16 @@ test_somsom() {
 }
 
 set_m() {
-  if [ "$MACHINE" = "zullie1" ]; then
+  if [ "$MACHINE" = "zullie1" ] || [ "$MACHINE" = "cassius" ]; then
     export M=''
+  # for benchmarking we treat these machines like the yuria ones, just to
+  # have some load balancing
+  elif [ "$MACHINE" = "brutus" ]; then
+    export M="t:yuria"
+  elif [ "$MACHINE" = "laertes" ]; then
+    export M="t:yuria2"
+  elif [ "$MACHINE" = "ophelia" ]; then
+    export M="t:yuria3"
   else
     export M="t:$MACHINE"
   fi

--- a/.github/build-and-test.sh
+++ b/.github/build-and-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+init_submodule_and_path() {
+  git submodule update --init
+  if [ "$MACHINE" = "zullie1" ]; then
+    export PATH=/opt/local/bin:/Users/gitlab-runner/Library/Python/3.12/bin:$PATH
+    export MP='-mp'
+  fi
+  export PATH=$HOME/.local/bin:$PATH
+}
+
+prepare_build_folders() {
+  rm -rf release && mkdir release
+  rm -rf debug && mkdir debug
+}
+
+set_compiler() {
+  if [ "$COMPILER" = "gcc" ];   then export CC=gcc-13;   export CXX=g++-13; fi
+  if [ "$COMPILER" = "clang" ]; then export CC=clang$MP-18; export CXX=clang++$MP-18; fi
+}
+
+determine_name() {
+  export NAME="som-$COMPILER-$GC"
+  if [[ $CMAKE_FLAGS =~ "USE_TAGGING=true" ]]; then
+    NAME="$NAME-inttag"
+  else
+    NAME="$NAME-intbox"
+  fi
+  
+  if [[ $CMAKE_FLAGS =~ "CACHE_INTEGER=true" ]]; then
+    NAME="$NAME-intcache"
+  fi
+  if [[ $CMAKE_FLAGS =~ "DUSE_VECTOR_PRIMITIVES=false" ]]; then
+    NAME="$NAME-somvec"
+  fi
+  
+  NAME=$( echo "$NAME" | tr '[:upper:]' '[:lower:]' )
+}
+
+make_and_test_debug_build() {
+  cd debug || exit 1
+  cmake .. $CMAKE_FLAGS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Debug
+  make -j
+  ./SOM++ -cfg -cp ../Smalltalk ../TestSuite/TestHarness.som
+  ./unittests -cfg -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
+  ./SOM++ -prim-hash-check -cp ../Smalltalk ../Examples/Benchmarks/BenchmarkHarness.som VectorBenchmark 1 1
+  cd ..
+}
+
+make_and_test_release_build() {
+  cd release || exit 1
+  cmake .. $CMAKE_FLAGS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Release
+  make -j
+  ./SOM++ -cfg -cp ../Smalltalk ../TestSuite/TestHarness.som
+  mv SOM++ ../$NAME
+  cd ..
+}
+
+test_somsom() {
+  ./$NAME -cp Smalltalk:TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects core-lib/SomSom/tests/SomSomTests.som
+}
+
+set_m() {
+  if [ "$MACHINE" = "zullie1" ]; then
+    export M=''
+  else
+    export M="t:$MACHINE"
+  fi
+}

--- a/.github/build-and-test.sh
+++ b/.github/build-and-test.sh
@@ -15,8 +15,21 @@ prepare_build_folders() {
 }
 
 set_compiler() {
-  if [ "$COMPILER" = "gcc" ];   then export CC=gcc-13;   export CXX=g++-13; fi
+  echo "set_compiler: COMPILER: $COMPILER, MACHINE_LOCATION: $MACHINE_LOCATION"
+  if [ "$COMPILER" = "gcc" ];   then
+    if [ "$MACHINE_LOCATION" = "ssw" ]; then
+      # Debian Trixie's standard compiler is GCC 14, and we use libstdc++
+      # from it, even for older GCCs. Probably something that could be fixed in CMake...
+      export CC=gcc-14;
+      export CXX=g++-14;
+    else
+      export CC=gcc-13;
+      export CXX=g++-13;
+    fi
+  fi
   if [ "$COMPILER" = "clang" ]; then export CC=clang$MP-18; export CXX=clang++$MP-18; fi
+
+  echo "set_compiler: CC: $CC, CXX: $CXX"
 }
 
 determine_name() {
@@ -60,7 +73,7 @@ test_somsom() {
   ./$NAME -cp Smalltalk:TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects core-lib/SomSom/tests/SomSomTests.som
 }
 
-set_m() {
+set_machine_tag_and_experiment() {
   if [ "$MACHINE" = "zullie1" ] || [ "$MACHINE" = "cassius" ]; then
     export M=''
   # for benchmarking we treat these machines like the yuria ones, just to
@@ -73,5 +86,17 @@ set_m() {
     export M="t:yuria3"
   else
     export M="t:$MACHINE"
+  fi
+  echo "set_machine_tag_and_experiment: MACHINE: $MACHINE, M: $M"
+
+  if [ "$MACHINE_LOCATION" = "ssw" ]; then
+    if [ "$MACHINE" = "cassius" ]; then
+      # cassius is comparably slow, so, use the old settings
+      export EXPERIMENT="SOM++"
+    else
+      export EXPERIMENT="SOM++-ssw"
+    fi
+  else
+    export EXPERIMENT="SOM++"
   fi
 }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,8 +86,9 @@ build_and_test:
       fi
 
     - |+
-      set m
-      rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf all "e:${NAME}" $M
+      set -o xtrace
+      set_machine_tag_and_experiment
+      rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf ${EXPERIMENT} "e:${NAME}" $M
 
 complete_benchmarking:
   stage: benchmark-completion

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,13 +6,9 @@ variables:
   PYTHONUNBUFFERED: "true"
 
 before_script:
-  - |+
-    git submodule update --init
-    if [ "$MACHINE" = "zullie1" ]; then
-      export PATH=/opt/local/bin:/Users/gitlab-runner/Library/Python/3.12/bin:$PATH
-      export MP='-mp'
-    fi
-    export PATH=$HOME/.local/bin:$PATH
+  - |
+    source .github/build-and-test.sh
+    init_submodule_and_path
 
 build_and_test:
   stage: build-and-test
@@ -53,48 +49,11 @@ build_and_test:
 
   tags: [kent-$MACHINE]
   script:
-    - rm -rf release && mkdir release
-    - rm -rf debug && mkdir debug
-
-    - if [ "$COMPILER" = "gcc" ];   then export CC=gcc-13;   export CXX=g++-13; fi
-    - if [ "$COMPILER" = "clang" ]; then export CC=clang$MP-18; export CXX=clang++$MP-18; fi
-
-    # compose a name for this configuration
-    - |+
-      export NAME="som-$COMPILER-$GC"
-      if [[ $CMAKE_FLAGS =~ "USE_TAGGING=true" ]]; then
-        NAME="$NAME-inttag"
-      else
-        NAME="$NAME-intbox"
-      fi
-      if [[ $CMAKE_FLAGS =~ "CACHE_INTEGER=true" ]]; then
-        NAME="$NAME-intcache"
-      fi
-      if [[ $CMAKE_FLAGS =~ "DUSE_VECTOR_PRIMITIVES=false" ]]; then
-        NAME="$NAME-somvec"
-      fi
-      NAME=`echo "$NAME" | tr '[:upper:]' '[:lower:]'`
-
-    - cd release
-    - cmake .. $CMAKE_FLAGS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Release
-    - make -j
-    - mv SOM++ ../$NAME
-    - cd ..
-
-    - cd debug
-    - cmake .. $CMAKE_FLAGS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Debug
-    - make -j
-    - ./SOM++ -cfg -cp ../Smalltalk ../TestSuite/TestHarness.som
-    - ./unittests -cfg -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
-    - ./SOM++ -prim-hash-check -cp ../Smalltalk ../Examples/Benchmarks/BenchmarkHarness.som VectorBenchmark 1 1
-    - cd ..
-
-    - cd release
-    - cmake .. $CMAKE_FLAGS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Release
-    - make -j
-    - ./SOM++ -cfg -cp ../Smalltalk ../TestSuite/TestHarness.som
-    - mv SOM++ ../$NAME
-    - cd ..
+    - prepare_build_folders
+    - set_compiler
+    - determine_name
+    - make_and_test_debug_build
+    - make_and_test_release_build
 
     - |+
       # Test SomSom
@@ -102,17 +61,12 @@ build_and_test:
         # this is to load balance the SomSom testing
         # only when compiling with Clang, and only on one machine for each integer configuration
         if [ "$MACHINE $CMAKE_FLAGS" = "zullie1 -DUSE_TAGGING=true" ] || [ "$MACHINE $CMAKE_FLAGS" = "yuria2 -DUSE_TAGGING=false -DCACHE_INTEGER=true" ] || [ "$MACHINE $CMAKE_FLAGS" = "yuria3 -DUSE_TAGGING=false -DCACHE_INTEGER=false" ]; then
-          ./$NAME -cp Smalltalk:TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects core-lib/SomSom/tests/SomSomTests.som
+          test_somsom
         fi
       fi
 
-    # run the benchmarks
     - |+
-      if [ "$MACHINE" = "zullie1" ]; then
-        M=''
-      else
-        M="t:$MACHINE"
-      fi
+      set m
       rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf all "e:${NAME}" $M
 
 complete_benchmarking:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ build_and_test:
           - yuria
           - yuria2
           - yuria3
+        MACHINE_LOCATION: [kent]
         COMPILER: [clang]
         GC: [COPYING]
         CMAKE_FLAGS:
@@ -28,11 +29,13 @@ build_and_test:
 
       # Track GCC only for one configuration
       - MACHINE: [yuria, yuria2, yuria3]
+        MACHINE_LOCATION: [kent]
         COMPILER: [gcc]
         GC: [COPYING]
         CMAKE_FLAGS: ["-DUSE_TAGGING=true"]
 
       - MACHINE: [zullie1]
+        MACHINE_LOCATION: [kent]
         COMPILER: [clang]
         GC: [GENERATIONAL]
         CMAKE_FLAGS:
@@ -43,11 +46,28 @@ build_and_test:
 
       # Mark-Sweep working, but not super exciting
       - MACHINE: [yuria, yuria2, yuria3]
+        MACHINE_LOCATION: [kent]
         COMPILER: [gcc]
         GC: [MARK_SWEEP]
         CMAKE_FLAGS: ["-DUSE_TAGGING=true"]
+      
+      - MACHINE: [laertes, ophelia, brutus]
+        MACHINE_LOCATION: [ssw]
+        GC: [GENERATIONAL]
+        COMPILER: [clang, gcc]
+        CMAKE_FLAGS:
+          - "-DUSE_TAGGING=true"
+          - "-DUSE_TAGGING=false -DCACHE_INTEGER=false -DUSE_VECTOR_PRIMITIVES=false"
+      
+      - MACHINE: [cassius]
+        MACHINE_LOCATION: [ssw]
+        COMPILER: [clang, gcc]
+        GC: [GENERATIONAL]
+        CMAKE_FLAGS:
+          - "-DUSE_TAGGING=true"
+      
 
-  tags: [kent-$MACHINE]
+  tags: [$MACHINE_LOCATION-$MACHINE]
   script:
     - prepare_build_folders
     - set_compiler
@@ -60,7 +80,7 @@ build_and_test:
       if [ "$COMPILER" = "clang" ]; then
         # this is to load balance the SomSom testing
         # only when compiling with Clang, and only on one machine for each integer configuration
-        if [ "$MACHINE $CMAKE_FLAGS" = "zullie1 -DUSE_TAGGING=true" ] || [ "$MACHINE $CMAKE_FLAGS" = "yuria2 -DUSE_TAGGING=false -DCACHE_INTEGER=true" ] || [ "$MACHINE $CMAKE_FLAGS" = "yuria3 -DUSE_TAGGING=false -DCACHE_INTEGER=false" ]; then
+        if [ "$MACHINE $CMAKE_FLAGS" = "zullie1 -DUSE_TAGGING=true" ] || [ "$MACHINE $CMAKE_FLAGS" = "yuria2 -DUSE_TAGGING=false -DCACHE_INTEGER=true" ] || [ "$MACHINE $CMAKE_FLAGS" = "yuria3 -DUSE_TAGGING=false -DCACHE_INTEGER=false" ] || [ "$MACHINE $CMAKE_FLAGS" = "brutus -DUSE_TAGGING=true" ]; then
           test_somsom
         fi
       fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,6 @@ target_sources(SOM++ PRIVATE
   ${PRIMITIVESCORE_SRC})
 
 target_compile_options(SOM++ PRIVATE
-  -m64
   -Wno-endif-labels)
 
 target_include_directories(SOM++ PRIVATE ${SRC_DIR})

--- a/rebench.conf
+++ b/rebench.conf
@@ -29,6 +29,18 @@ benchmark_suites:
             - GraphSearch:  {extra_args:   7, tags: [yuria2]}
             - PageRank:     {extra_args: 150, tags: [yuria3]}
 
+    macro-ssw:
+        gauge_adapter: RebenchLog
+        command: "-H16MB -cp Smalltalk:Examples/Benchmarks/Richards:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/NBody:Examples/Benchmarks/Json:Examples/Benchmarks/GraphSearch Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
+        iterations: 10
+        benchmarks:
+            - Richards:     {iterations: 5, extra_args:   3, tags: [yuria3]}
+            - DeltaBlue:    {extra_args: 3500, tags: [yuria2]}
+            - NBody:        {extra_args: 15000, tags: [yuria3]}
+            - JsonSmall:    {extra_args:  50, tags: [yuria ]}
+            - GraphSearch:  {extra_args:  12, tags: [yuria2]}
+            - PageRank:     {extra_args: 250, tags: [yuria3]}
+
     micro:
         gauge_adapter: RebenchLog
         command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures:Examples/Benchmarks/TestSuite Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
@@ -61,6 +73,38 @@ benchmark_suites:
             # - Test:     {invocations: 5, iterations: 1, tags: [yuria2]}
             - TestGC:   {invocations: 5, iterations: 1, extra_args: 100, tags: [yuria2]}
 
+    micro-ssw:
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures:Examples/Benchmarks/TestSuite Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
+        iterations: 10
+        benchmarks:
+            - Fannkuch:     {extra_args:   8, tags: [yuria ]}
+            - Fibonacci:    {extra_args:   6, tags: [yuria2]}
+            - Dispatch:     {extra_args: 150, tags: [yuria3]}
+            - Bounce:       {extra_args:  40, tags: [yuria ]}
+            - Loop:         {extra_args: 400, tags: [yuria2]}
+            - Permute:      {extra_args:  70, tags: [yuria3]}
+            - Queens:       {extra_args:  20, tags: [yuria ]}
+            - List:         {extra_args:  50, tags: [yuria2]}
+            - Recurse:      {extra_args: 200, tags: [yuria3]}
+            - Storage:      {extra_args:  40, tags: [yuria ]}
+            - Sieve:        {extra_args:  80, tags: [yuria2]}
+            - BubbleSort:   {extra_args: 150, tags: [yuria3]}
+            - QuickSort:    {extra_args:  12, tags: [yuria ]}
+            - Sum:          {extra_args: 300, tags: [yuria2]}
+            - Towers:       {extra_args: 100, tags: [yuria3]}
+            - TreeSort:     {extra_args:  30, tags: [yuria ]}
+            - IntegerLoop:  {extra_args:  60, tags: [yuria2]}
+            - FieldLoop:    {extra_args:  50, tags: [yuria3]}
+            - WhileLoop:    {extra_args: 150, tags: [yuria ]}
+            - Mandelbrot:   {extra_args: 300, tags: [yuria2]}
+            - IfNil:        {extra_args:  80, tags: [yuria3]}
+            - Knapsack:     {extra_args:  21, tags: [yuria2]}
+            - VectorBenchmark: {extra_args: 800, tags: [yuria3]}
+
+            # - Test:     {invocations: 5, iterations: 1, tags: [yuria2]}
+            - TestGC:   {invocations: 5, iterations: 1, extra_args: 1000, tags: [yuria2]}
+
     awfy:
         gauge_adapter: RebenchLog
         command: "-cp Examples/AreWeFastYet/CD:Examples/AreWeFastYet/Havlak:Examples/AreWeFastYet/Core:Smalltalk Examples/AreWeFastYet/Harness.som --gc %(benchmark)s %(iterations)s "
@@ -68,6 +112,15 @@ benchmark_suites:
         invocations: 5
         benchmarks:
             - CD:     {extra_args: 10, tags: [yuria2]}
+            # - Havlak: {extra_args:  1, tags: [yuria3]}
+
+    awfy-ssw:
+        gauge_adapter: RebenchLog
+        command: "-cp Examples/AreWeFastYet/CD:Examples/AreWeFastYet/Havlak:Examples/AreWeFastYet/Core:Smalltalk Examples/AreWeFastYet/Harness.som --gc %(benchmark)s %(iterations)s "
+        iterations: 1
+        invocations: 5
+        benchmarks:
+            - CD:     {extra_args: 100, tags: [yuria2]}
             # - Havlak: {extra_args:  1, tags: [yuria3]}
 
     micro-somsom:
@@ -82,6 +135,18 @@ benchmark_suites:
             - Recurse:      {extra_args: 10, tags: [yuria3]}
             - Mandelbrot:   {extra_args: 50, tags: [yuria3]}
 
+    micro-somsom-ssw:
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
+        iterations: 1
+        invocations: 5
+        benchmarks:
+            - Loop:         {extra_args: 200, tags: [yuria3]}
+            - Queens:       {extra_args:  50, tags: [yuria2]}
+            - List:         {extra_args: 100, tags: [yuria2]}
+            - Recurse:      {extra_args: 150, tags: [yuria3]}
+            - Mandelbrot:   {extra_args: 400, tags: [yuria3]}
+
     som-parse:
         gauge_adapter: RebenchLog
         command: "-cp Smalltalk:Examples:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/GraphSearch:Examples/Benchmarks/Json:Examples/Benchmarks/NBody:TestSuite:core-lib/SomSom/tests:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/primitives:core-lib/SomSom/src/compiler  Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
@@ -90,6 +155,15 @@ benchmark_suites:
         benchmarks:
             - SomParse: {extra_args: 1, tags: [yuria2]}
             - SomInit:  {extra_args: 10000, tags: [yuria2]}
+
+    som-parse-ssw:
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples:Examples/Benchmarks/DeltaBlue:Examples/Benchmarks/GraphSearch:Examples/Benchmarks/Json:Examples/Benchmarks/NBody:TestSuite:core-lib/SomSom/tests:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/primitives:core-lib/SomSom/src/compiler  Examples/Benchmarks/BenchmarkHarness.som --gc %(benchmark)s %(iterations)s "
+        iterations: 1!
+        invocations: 5
+        benchmarks:
+            - SomParse: {invocations: 50, extra_args: 1, tags: [yuria2]}
+            - SomInit:  {extra_args: 120000, tags: [yuria2]}
 
     interpreter:
         description: Basic interpreter benchmarks for comparing performance of most basic concepts.
@@ -114,6 +188,30 @@ benchmark_suites:
             - SelfSend0:                         {extra_args: 2, tags: [yuria3]}
             - SelfSend0BlockConstNonLocalReturn: {extra_args: 1, tags: [yuria3]}
 
+    interpreter-ssw:
+        description: Basic interpreter benchmarks for comparing performance of most basic concepts.
+        gauge_adapter: RebenchLog
+        invocations: 5
+        command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s "
+        benchmarks:
+            - ArgRead:                           {extra_args: 90, tags: [yuria2]}
+            - ArrayReadConst:                    {extra_args: 15, tags: [yuria2]}
+            - ArrayWriteConstConst:              {extra_args: 15, tags: [yuria2]}
+            - BlockSend0ConstReturn:             {extra_args:  8, tags: [yuria2]}
+            - Const:                             {extra_args: 60, tags: [yuria2]}
+            - FieldConstWrite:                   {extra_args: 35, tags: [yuria2]}
+            - FieldRead:                         {extra_args: 70, tags: [yuria2]}
+            - FieldReadIncWrite:                 {extra_args: 25, tags: [yuria2]}
+            - FieldReadWrite:                    {extra_args: 30, tags: [yuria3]}
+            - GlobalRead:                        {extra_args: 30, tags: [yuria3]}
+            - LocalConstWrite:                   {extra_args: 40, tags: [yuria3]}
+            - LocalRead:                         {extra_args: 50, tags: [yuria3]}
+            - LocalReadIncWrite:                 {extra_args: 30, tags: [yuria3]}
+            - LocalReadWrite:                    {extra_args: 45, tags: [yuria3]}
+            - SelfSend0:                         {extra_args: 20, tags: [yuria3]}
+            - SelfSend0BlockConstNonLocalReturn: {extra_args:  5, tags: [yuria3]}
+
+
 executors:
     som-gcc-generational-inttag:            {path: ., executable: som-gcc-generational-inttag           }
     som-gcc-generational-intbox:            {path: ., executable: som-gcc-generational-intbox           }
@@ -124,6 +222,7 @@ executors:
     som-gcc-copying-inttag:                 {path: ., executable: som-gcc-copying-inttag                }
     som-gcc-copying-intbox:                 {path: ., executable: som-gcc-copying-intbox                }
     som-gcc-copying-intbox-intcache:        {path: ., executable: som-gcc-copying-intbox-intcache       }
+    som-gcc-generational-intbox-somvec:     {path: ., executable: som-gcc-generational-intbox-somvec    }
 
     som-clang-generational-inttag:          {path: ., executable: som-clang-generational-inttag         }
     som-clang-generational-intbox:          {path: ., executable: som-clang-generational-intbox         }
@@ -158,6 +257,40 @@ experiments:
             - som-gcc-copying-inttag
             - som-gcc-copying-intbox
             - som-gcc-copying-intbox-intcache
+            - som-gcc-generational-intbox-somvec
+
+            - som-clang-generational-inttag
+            - som-clang-generational-intbox
+            - som-clang-generational-intbox-intcache
+            - som-clang-generational-intbox-somvec
+            - som-clang-mark_sweep-inttag
+            - som-clang-mark_sweep-intbox
+            - som-clang-mark_sweep-intbox-intcache
+            - som-clang-copying-inttag
+            - som-clang-copying-intbox
+            - som-clang-copying-intbox-intcache
+            - som-clang-copying-intbox-somvec
+
+    SOM++-ssw:
+        description: All benchmarks on CSOM
+        suites:
+            - micro-ssw
+            - macro-ssw
+            - awfy-ssw
+            - micro-somsom-ssw
+            - som-parse-ssw
+            - interpreter-ssw
+        executions:
+            - som-gcc-generational-inttag
+            - som-gcc-generational-intbox
+            - som-gcc-generational-intbox-intcache
+            - som-gcc-mark_sweep-inttag
+            - som-gcc-mark_sweep-intbox
+            - som-gcc-mark_sweep-intbox-intcache
+            - som-gcc-copying-inttag
+            - som-gcc-copying-intbox
+            - som-gcc-copying-intbox-intcache
+            - som-gcc-generational-intbox-somvec
 
             - som-clang-generational-inttag
             - som-clang-generational-intbox


### PR DESCRIPTION
This moves the CI code to a shell script.
Furthermore, it adds the SSW machines into the benchmarking setup.

As part of the new setup, `-m64` needs to be removed from the build flags. It's not supported on Aarch64, and not needed on the other systems.