### PR TITLE
Fix Generational GC bug, add GC stress-test mode, add DEBUG_COPYING to CI

### DIFF
--- a/.github/build-and-test.sh
+++ b/.github/build-and-test.sh
@@ -54,8 +54,8 @@ make_and_test_debug_build() {
   cd debug || exit 1
   cmake .. $CMAKE_FLAGS -DGC_TYPE=$GC -DCMAKE_BUILD_TYPE=Debug
   make -j
-  ./SOM++ -cfg -cp ../Smalltalk ../TestSuite/TestHarness.som
-  ./unittests -cfg -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
+  ./SOM++ -gc-stress -cfg -cp ../Smalltalk ../TestSuite/TestHarness.som
+  ./unittests -gc-stress -cfg -cp ../Smalltalk:../TestSuite/BasicInterpreterTests ../Examples/Hello.som
   ./SOM++ -prim-hash-check -cp ../Smalltalk ../Examples/Benchmarks/BenchmarkHarness.som VectorBenchmark 1 1
   cd ..
 }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,14 @@ build_and_test:
         CMAKE_FLAGS:
           - "-DUSE_TAGGING=true"
           - "-DUSE_TAGGING=false -DCACHE_INTEGER=false -DUSE_VECTOR_PRIMITIVES=false"
-      
+
+      - MACHINE: [yuria4]
+        MACHINE_LOCATION: [kent]
+        GC: [DEBUG_COPYING]
+        COMPILER: [clang]
+        CMAKE_FLAGS:
+          - "-DUSE_TAGGING=true"
+
       - MACHINE: [cassius]
         MACHINE_LOCATION: [ssw]
         COMPILER: [clang, gcc]

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -447,7 +447,7 @@ LABEL_BC_JUMP_ON_FALSE_TOP_NIL: {
     if (val == load_ptr(falseObject)) {
         uint8_t const offset = currentBytecodes[bytecodeIndexGlobal + 1];
         bytecodeIndexGlobal += offset;
-        GetFrame()->SetTop(nilObject);
+        GetFrame()->SetTop(load_ptr(nilObject));
     } else {
         GetFrame()->PopVoid();
         bytecodeIndexGlobal += 3;
@@ -460,7 +460,7 @@ LABEL_BC_JUMP_ON_TRUE_TOP_NIL: {
     if (val == load_ptr(trueObject)) {
         uint8_t const offset = currentBytecodes[bytecodeIndexGlobal + 1];
         bytecodeIndexGlobal += offset;
-        GetFrame()->SetTop(nilObject);
+        GetFrame()->SetTop(load_ptr(nilObject));
     } else {
         GetFrame()->PopVoid();
         bytecodeIndexGlobal += 3;
@@ -578,7 +578,7 @@ LABEL_BC_JUMP2_ON_FALSE_TOP_NIL: {
             ComputeOffset(currentBytecodes[bytecodeIndexGlobal + 1],
                           currentBytecodes[bytecodeIndexGlobal + 2]);
         bytecodeIndexGlobal += offset;
-        GetFrame()->SetTop(nilObject);
+        GetFrame()->SetTop(load_ptr(nilObject));
     } else {
         GetFrame()->PopVoid();
         bytecodeIndexGlobal += 3;
@@ -593,7 +593,7 @@ LABEL_BC_JUMP2_ON_TRUE_TOP_NIL: {
             ComputeOffset(currentBytecodes[bytecodeIndexGlobal + 1],
                           currentBytecodes[bytecodeIndexGlobal + 2]);
         bytecodeIndexGlobal += offset;
-        GetFrame()->SetTop(nilObject);
+        GetFrame()->SetTop(load_ptr(nilObject));
     } else {
         GetFrame()->PopVoid();
         bytecodeIndexGlobal += 3;
@@ -1094,7 +1094,7 @@ void Interpreter::doInc() {
         ErrorExit("unsupported");
     }
 
-    GetFrame()->SetTop(store_root(val));
+    GetFrame()->SetTop(val);
 }
 
 void Interpreter::doDec() {
@@ -1110,7 +1110,7 @@ void Interpreter::doDec() {
         ErrorExit("unsupported");
     }
 
-    GetFrame()->SetTop(store_root(val));
+    GetFrame()->SetTop(val);
 }
 
 void Interpreter::doIncField(uint8_t fieldIndex) {

--- a/src/memory/CopyingHeap.cpp
+++ b/src/memory/CopyingHeap.cpp
@@ -102,7 +102,7 @@ AbstractVMObject* CopyingHeap::AllocateObject(size_t size) {
     }
 
     // let's see if we have to trigger the GC
-    if (nextFreePosition > collectionLimit) {
+    if (nextFreePosition > collectionLimit || gcStressMode) {
         requestGC();
     }
 

--- a/src/memory/DebugCopyingHeap.cpp
+++ b/src/memory/DebugCopyingHeap.cpp
@@ -8,6 +8,7 @@
 
 #include "../vm/Print.h"
 #include "../vmobjects/AbstractObject.h"
+#include "Heap.h"
 
 void DebugCopyingHeap::switchBuffers(bool increaseMemory) {
     assert(
@@ -60,7 +61,7 @@ AbstractVMObject* DebugCopyingHeap::AllocateObject(size_t size) {
     }
 
     // let's see if we have to trigger the GC
-    if (currentHeapUsage > collectionLimit) {
+    if (currentHeapUsage > collectionLimit || gcStressMode) {
         requestGC();
     }
 

--- a/src/memory/GenerationalHeap.cpp
+++ b/src/memory/GenerationalHeap.cpp
@@ -36,7 +36,7 @@ AbstractVMObject* GenerationalHeap::AllocateNurseryObject(size_t size) {
         Quit(-1);
     }
     // let's see if we have to trigger the GC
-    if (nextFreePosition > collectionLimit) {
+    if (nextFreePosition > collectionLimit || gcStressMode) {
         requestGC();
     }
     return newObject;
@@ -50,6 +50,9 @@ AbstractVMObject* GenerationalHeap::AllocateMatureObject(size_t size) {
     }
     allocatedObjects.push_back(newObject);
     matureObjectsSize += size;
+    if (gcStressMode) {
+        requestGC();
+    }
     return newObject;
 }
 

--- a/src/memory/Heap.cpp
+++ b/src/memory/Heap.cpp
@@ -35,6 +35,8 @@
 #include "GenerationalHeap.h"  // NOLINT(misc-include-cleaner)
 #include "MarkSweepHeap.h"     // NOLINT(misc-include-cleaner)
 
+bool gcStressMode = false;
+
 template <class HEAP_T>
 void Heap<HEAP_T>::InitializeHeap(size_t objectSpaceSize) {
     if (theHeap) {

--- a/src/memory/Heap.cpp
+++ b/src/memory/Heap.cpp
@@ -35,7 +35,11 @@
 #include "GenerationalHeap.h"  // NOLINT(misc-include-cleaner)
 #include "MarkSweepHeap.h"     // NOLINT(misc-include-cleaner)
 
+#if DEBUG
 bool gcStressMode = false;
+#else
+// it's defined as false
+#endif
 
 template <class HEAP_T>
 void Heap<HEAP_T>::InitializeHeap(size_t objectSpaceSize) {

--- a/src/memory/Heap.h
+++ b/src/memory/Heap.h
@@ -44,6 +44,11 @@
 
 using namespace std;
 
+/*
+ * If true, request a GC after every single allocation.
+ */
+extern bool gcStressMode;
+
 template <class HEAP_T>
 class Heap {
     friend class GarbageCollector<HEAP_T>;

--- a/src/memory/Heap.h
+++ b/src/memory/Heap.h
@@ -47,7 +47,11 @@ using namespace std;
 /*
  * If true, request a GC after every single allocation.
  */
+#if DEBUG
 extern bool gcStressMode;
+#else
+  #define gcStressMode false
+#endif
 
 template <class HEAP_T>
 class Heap {

--- a/src/memory/MarkSweepHeap.cpp
+++ b/src/memory/MarkSweepHeap.cpp
@@ -28,7 +28,7 @@ AbstractVMObject* MarkSweepHeap::AllocateObject(size_t size) {
     // VMObject's new operator
     allocatedObjects->push_back(newObject);
     // let's see if we have to trigger the GC
-    if (spcAlloc >= collectionLimit) {
+    if (spcAlloc >= collectionLimit || gcStressMode) {
         requestGC();
     }
     return newObject;

--- a/src/unitTests/BasicInterpreterTests.h
+++ b/src/unitTests/BasicInterpreterTests.h
@@ -3,6 +3,7 @@
 #include <cppunit/extensions/HelperMacros.h>
 #include <utility>
 
+#include "../memory/Heap.h"
 #include "../vmobjects/VMClass.h"
 #include "../vmobjects/VMDouble.h"
 #include "../vmobjects/VMSymbol.h"
@@ -198,9 +199,19 @@ private:
 
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     void testBasic(TestData data) {
+        bool const oldGcStressMode = gcStressMode;
+        if (data.className == "ObjectCreation") {
+            gcStressMode = false;  // it's too slow...
+        }
+
         // The Unit Test harness will initialize Universe for a standard run.
         // This is different from other SOMs.
         vm_oop_t result = Universe::interpret(data.className, data.methodName);
+
+        if (data.className == "ObjectCreation") {
+            gcStressMode = oldGcStressMode;
+        }
+
         CPPUNIT_ASSERT(result != nullptr);
         assertEqualsSOMValue(result, data);
     }

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -203,7 +203,12 @@ vector<std::string> Universe::handleArguments(int32_t argc, char** argv) {
         } else if (!sawOtherArgs && strncmp(argv[i], "-cfg", 4) == 0) {
             printVmConfig();
         } else if (!sawOtherArgs && strncmp(argv[i], "-gc-stress", 10) == 0) {
+#if DEBUG
             gcStressMode = true;
+#else
+            ErrorPrint(
+                "gc-stress mode is only available in debug builds of SOM++");
+#endif
         } else if (!sawOtherArgs && strncmp(argv[i], "-g", 2) == 0) {
             ++gcVerbosity;
         } else if (!sawOtherArgs && strncmp(argv[i], "-H", 2) == 0) {

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -202,6 +202,8 @@ vector<std::string> Universe::handleArguments(int32_t argc, char** argv) {
             ++dumpBytecodes;
         } else if (!sawOtherArgs && strncmp(argv[i], "-cfg", 4) == 0) {
             printVmConfig();
+        } else if (!sawOtherArgs && strncmp(argv[i], "-gc-stress", 10) == 0) {
+            gcStressMode = true;
         } else if (!sawOtherArgs && strncmp(argv[i], "-g", 2) == 0) {
             ++gcVerbosity;
         } else if (!sawOtherArgs && strncmp(argv[i], "-H", 2) == 0) {
@@ -304,6 +306,8 @@ void Universe::printUsageAndExit(char* executable) {
         << "         2x - print statistics upon each collection\n"
         << "         3x - print statistics and dump heap upon each collection\n"
         << "\n";
+    cout << "    -gc-stress trigger a garbage collection after every "
+            "allocation\n";
     cout << "    -HxMB set the heap size to x MB (default: 1 MB)\n";
     cout << "    -HxKB set the heap size to x KB (default: 1 MB)\n";
     cout << "    -h|--help show this help\n";

--- a/src/vmobjects/VMFrame.h
+++ b/src/vmobjects/VMFrame.h
@@ -110,7 +110,7 @@ public:
         return result;
     }
 
-    inline void SetTop(gc_oop_t val) { *stack_ptr = val; }
+    inline void SetTop(vm_oop_t val) { store_ptr(*stack_ptr, val); }
 
     inline void Push(vm_oop_t obj) {
         assert(RemainingStackSize() > 0);


### PR DESCRIPTION
The main issue fixed here is that storing into top of frame didn't have a write barrier.
This means for tenured/old frames, we would not add the probably new objects stored into top to the remembered set, which means they could be collected unintentionally.

This is likely the issue that #91 caused on the generational GC. Though, I have not looked at the PR again with these changes applied. Frame caching caused crashes for me with the generational GC.

I found this after adding a GC stress test mode. The idea here is to request a collect immediately after every allocation., which was of course very helpful to diagnose this bug. Since it popped up pretty much immediately.

Not sure what the performance impact is. It could be pretty bad for microbenchmarks. But otherwise seems fine. 